### PR TITLE
fix: add proper Zod schemas for purchase tools

### DIFF
--- a/src/tools/create-purchase.tool.ts
+++ b/src/tools/create-purchase.tool.ts
@@ -2,20 +2,69 @@ import { createQuickbooksPurchase } from "../handlers/create-quickbooks-purchase
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
-// Define the tool metadata
 const toolName = "create_purchase";
-const toolDescription = "Create a purchase in QuickBooks Online.";
+const toolDescription = "Create a purchase (expense/check) in QuickBooks Online. Requires AccountRef (bank account), PaymentType ('Cash', 'Check', or 'CreditCard'), and at least one Line item.";
 
-// Define the expected input schema for creating a purchase
-const toolSchema = z.object({
-  purchase: z.any(),
+// Schema for AccountBasedExpenseLineDetail (the most common line type for purchases)
+const purchaseLineSchema = z.object({
+  Amount: z.number(),
+  Description: z.string().optional(),
+  DetailType: z.literal("AccountBasedExpenseLineDetail"),
+  AccountBasedExpenseLineDetail: z.object({
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    ClassRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    CustomerRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    BillableStatus: z.string().optional(),
+    TaxCodeRef: z.object({
+      value: z.string(),
+    }).optional(),
+  }),
 });
 
-type ToolParams = z.infer<typeof toolSchema>;
+const toolSchema = z.object({
+  purchase: z.object({
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    PaymentType: z.enum(["Cash", "Check", "CreditCard"]),
+    Line: z.array(purchaseLineSchema),
+    EntityRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+      type: z.string().optional(),
+    }).optional(),
+    TxnDate: z.string().optional(),
+    DepartmentRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    PrivateNote: z.string().optional(),
+  }),
+});
 
-// Define the tool handler
-const toolHandler = async (args: any) => {
-  const response = await createQuickbooksPurchase(args.params.purchase);
+const toolHandler = async (args: { [x: string]: any }) => {
+  // Handle different argument structures from MCP SDK
+  const purchase = args.purchase || args.params?.purchase || args;
+
+  if (!purchase || !purchase.AccountRef) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error: Invalid args structure. Received keys: ${Object.keys(args).join(', ')}. Args: ${JSON.stringify(args).slice(0, 500)}` },
+      ],
+    };
+  }
+
+  const response = await createQuickbooksPurchase(purchase);
 
   if (response.isError) {
     return {
@@ -27,8 +76,7 @@ const toolHandler = async (args: any) => {
 
   return {
     content: [
-      { type: "text" as const, text: `Purchase created:` },
-      { type: "text" as const, text: JSON.stringify(response.result) },
+      { type: "text" as const, text: `Purchase created: ${JSON.stringify(response.result)}` },
     ],
   };
 };
@@ -38,4 +86,4 @@ export const CreatePurchaseTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: toolHandler,
-}; 
+};

--- a/src/tools/update-purchase.tool.ts
+++ b/src/tools/update-purchase.tool.ts
@@ -2,20 +2,73 @@ import { updateQuickbooksPurchase } from "../handlers/update-quickbooks-purchase
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
-// Define the tool metadata
 const toolName = "update_purchase";
-const toolDescription = "Update a purchase in QuickBooks Online.";
+const toolDescription = "Update a purchase (expense/check) in QuickBooks Online. Requires Id, SyncToken, PaymentType ('Cash', 'Check', or 'CreditCard'), and AccountRef (bank account) from the existing purchase.";
 
-// Define the expected input schema for updating a purchase
-const toolSchema = z.object({
-  purchase: z.any(),
+// Schema for AccountBasedExpenseLineDetail (the most common line type for purchases)
+const purchaseLineSchema = z.object({
+  Id: z.string().optional(),
+  Amount: z.number(),
+  Description: z.string().optional(),
+  DetailType: z.literal("AccountBasedExpenseLineDetail"),
+  AccountBasedExpenseLineDetail: z.object({
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    ClassRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    CustomerRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    BillableStatus: z.string().optional(),
+    TaxCodeRef: z.object({
+      value: z.string(),
+    }).optional(),
+  }),
 });
 
-type ToolParams = z.infer<typeof toolSchema>;
+const toolSchema = z.object({
+  purchase: z.object({
+    Id: z.string(),
+    SyncToken: z.string(),
+    Line: z.array(purchaseLineSchema),
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    PaymentType: z.enum(["Cash", "Check", "CreditCard"]),
+    EntityRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+      type: z.string().optional(),
+    }).optional(),
+    TxnDate: z.string().optional(),
+    DepartmentRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    PrivateNote: z.string().optional(),
+    TotalAmt: z.number().optional(),
+  }),
+});
 
-// Define the tool handler
-const toolHandler = async (args: any) => {
-  const response = await updateQuickbooksPurchase(args.params.purchase);
+const toolHandler = async (args: { [x: string]: any }) => {
+  // Handle different argument structures from MCP SDK
+  const purchase = args.purchase || args.params?.purchase || args;
+
+  if (!purchase || !purchase.Id) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error: Invalid args structure. Received keys: ${Object.keys(args).join(', ')}. Args: ${JSON.stringify(args).slice(0, 500)}` },
+      ],
+    };
+  }
+
+  const response = await updateQuickbooksPurchase(purchase);
 
   if (response.isError) {
     return {
@@ -27,8 +80,7 @@ const toolHandler = async (args: any) => {
 
   return {
     content: [
-      { type: "text" as const, text: `Purchase updated:` },
-      { type: "text" as const, text: JSON.stringify(response.result) },
+      { type: "text" as const, text: `Purchase updated: ${JSON.stringify(response.result)}` },
     ],
   };
 };
@@ -38,4 +90,4 @@ export const UpdatePurchaseTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: toolHandler,
-}; 
+};


### PR DESCRIPTION
## Summary

The `create_purchase` and `update_purchase` tools were using `z.any()` for the purchase schema, which caused several issues:

1. **No input validation** - Any malformed input would pass schema validation
2. **Inconsistent argument handling** - The handler received args in an unpredictable structure
3. **Missing required fields** - QuickBooks API requires `PaymentType` and `AccountRef`, but the tools didn't enforce this

## Changes

- Add proper Zod schemas with typed fields for purchases and line items
- Make `PaymentType` required with enum validation (`"Cash"`, `"Check"`, `"CreditCard"`)
- Make `AccountRef` required (bank account reference)
- Add fallback argument handling to work with different MCP SDK argument structures
- Add validation with helpful error messages for debugging
- Update tool descriptions to clarify required fields

## Testing

Tested with Claude Code MCP integration:
- `update_purchase` now correctly updates purchases with line items
- Previously failed with "Cannot read properties of undefined (reading 'Id')" error
- Now works reliably with proper schema validation

## Files Changed

- `src/tools/create-purchase.tool.ts`
- `src/tools/update-purchase.tool.ts`

---

🤖 Generated with [Claude Code](https://claude.ai/code)