### PR TITLE
fix: Zod schema fixes and attachable tools

### DIFF
--- a/docs/qb-auth-bootstrap.md
+++ b/docs/qb-auth-bootstrap.md
@@ -1,0 +1,75 @@
+# QuickBooks Auth Bootstrap (Normalized)
+
+## Objective
+Use a **single source of truth** for QuickBooks OAuth credentials/tokens so both MCP servers (`quickbooks`, `quickbooks-reports`) stay in sync.
+
+## Canonical env file
+
+Use one file only:
+
+- `~/mcp-servers/quickbooks/.env`
+
+Optional explicit override:
+
+- `QUICKBOOKS_ENV_FILE=/absolute/path/to/.env`
+
+Both servers now resolve env using the same path order:
+1. `QUICKBOOKS_ENV_FILE` (if set)
+2. `~/mcp-servers/quickbooks/.env`
+3. `~/.quickbooks/.env`
+4. `./.env` (last resort)
+
+## Required variables (startup validation)
+
+- `QUICKBOOKS_CLIENT_ID`
+- `QUICKBOOKS_CLIENT_SECRET`
+- `QUICKBOOKS_REFRESH_TOKEN`
+- `QUICKBOOKS_REALM_ID`
+
+If any are missing, startup hard-fails with diagnostics:
+- loaded env path
+- missing vars
+- search paths checked
+
+## Rolling refresh token behavior
+
+QuickBooks rotates refresh tokens. Both servers must persist refreshed token back to the same env file.
+
+Normalized behavior:
+- `quickbooks` now persists rotated refresh tokens
+- `quickbooks-reports` already persisted rotated refresh tokens
+
+## One-time re-auth (if refresh token is invalid)
+
+If you hit `invalid_grant`, run:
+
+```bash
+cd ~/mcp-servers/quickbooks
+QUICKBOOKS_ENV_FILE=~/mcp-servers/quickbooks/.env \
+  node scripts/bootstrap-qb-oauth.mjs
+```
+
+This opens Intuit auth and writes new `QUICKBOOKS_REFRESH_TOKEN` + `QUICKBOOKS_REALM_ID` to the shared env file.
+
+## Health-check routine (Audra context)
+
+```bash
+mcporter --config ~/.claude/agents/audra/config/mcporter.json list quickbooks
+mcporter --config ~/.claude/agents/audra/config/mcporter.json list quickbooks-reports
+
+mcporter --config ~/.claude/agents/audra/config/mcporter.json \
+  call quickbooks.search_accounts params='{"criteria":{},"limit":1}'
+
+mcporter --config ~/.claude/agents/audra/config/mcporter.json \
+  call quickbooks-reports.get_profit_and_loss params='{"start_date":"2026-01-01","end_date":"2026-01-31"}'
+```
+
+## Rollback
+
+If bootstrap changes cause issues:
+1. Revert `src/clients/env-bootstrap.ts` and `src/clients/quickbooks-client.ts`
+2. Rebuild: `npm run build`
+3. Remove `QUICKBOOKS_ENV_FILE` from agent configs (if added)
+4. Restart mcporter daemon for affected agents
+
+> Note: rollback restores old behavior but also restores split-brain token risk.

--- a/scripts/bootstrap-qb-oauth.mjs
+++ b/scripts/bootstrap-qb-oauth.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+import https from 'https';
+import os from 'os';
+import { URLSearchParams } from 'url';
+import open from 'open';
+import dotenv from 'dotenv';
+
+// ── env resolution ────────────────────────────────────────────────────────────
+const home = os.homedir() || process.env.HOME || '';
+const candidates = [
+  process.env.QUICKBOOKS_ENV_FILE,
+  home ? path.join(home, 'mcp-servers/quickbooks/.env') : undefined,
+  home ? path.join(home, '.quickbooks/.env') : undefined,
+  path.join(process.cwd(), '.env'),
+].filter(Boolean);
+const envFile = candidates.find((p) => fs.existsSync(p));
+if (envFile) dotenv.config({ path: envFile });
+else dotenv.config();
+
+const clientId     = process.env.QUICKBOOKS_CLIENT_ID;
+const clientSecret = process.env.QUICKBOOKS_CLIENT_SECRET;
+const environment  = process.env.QUICKBOOKS_ENVIRONMENT || 'sandbox';
+
+// registeredUri = what Intuit has in the developer portal (used in exchange)
+// localPort     = where this script listens (site may proxy/redirect there)
+const registeredUri = process.env.QUICKBOOKS_REDIRECTURI || 'http://localhost:8000/callback';
+const parsedUri     = new URL(registeredUri);
+const parsedHostname = parsedUri.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+const isLocalRedirect = ['localhost', '127.0.0.1', '::1'].includes(parsedHostname);
+const localPort     = Number(
+  process.env.QUICKBOOKS_LOCAL_PORT ||
+  (isLocalRedirect ? parsedUri.port || 80 : 8081)
+);
+
+if (!clientId || !clientSecret) {
+  console.error('❌  Missing QUICKBOOKS_CLIENT_ID or QUICKBOOKS_CLIENT_SECRET in', envFile);
+  process.exit(1);
+}
+
+// ── env writer ────────────────────────────────────────────────────────────────
+function updateEnv(updates) {
+  const target = envFile || candidates[0] || path.join(process.cwd(), '.env');
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const current = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : '';
+  const map = new Map(
+    current.split('\n').filter(Boolean).map((l) => {
+      const i = l.indexOf('=');
+      return i === -1 ? [l, ''] : [l.slice(0, i), l.slice(i + 1)];
+    })
+  );
+  for (const [k, v] of Object.entries(updates)) map.set(k, String(v));
+  fs.writeFileSync(target, Array.from(map.entries()).map(([k, v]) => `${k}=${v}`).join('\n') + '\n');
+  console.log('✅  Tokens written to', target);
+}
+
+// ── token exchange (raw HTTPS — avoids redirect_uri mismatch in library) ─────
+function exchangeCode(code, realmId) {
+  return new Promise((resolve, reject) => {
+    const body = new URLSearchParams({
+      grant_type:   'authorization_code',
+      code,
+      redirect_uri: registeredUri,          // must match Intuit registration exactly
+    }).toString();
+
+    const auth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    const options = {
+      hostname: 'oauth.platform.intuit.com',
+      path:     '/oauth2/v1/tokens/bearer',
+      method:   'POST',
+      headers:  {
+        Authorization:   `Basic ${auth}`,
+        'Content-Type':  'application/x-www-form-urlencoded',
+        Accept:          'application/json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (d) => (data += d));
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          if (res.statusCode !== 200) reject(new Error(`${res.statusCode}: ${JSON.stringify(json)}`));
+          else resolve({ ...json, realmId });
+        } catch (e) { reject(new Error('Parse error: ' + data)); }
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+// ── success HTML ──────────────────────────────────────────────────────────────
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>QuickBooks Connected</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      background: #f5f5f7;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    .card {
+      background: #fff;
+      border-radius: 18px;
+      box-shadow: 0 4px 32px rgba(0,0,0,.10);
+      padding: 52px 56px;
+      max-width: 440px;
+      width: 100%;
+      text-align: center;
+    }
+    .icon {
+      width: 72px;
+      height: 72px;
+      background: #e8f9ee;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 24px;
+      font-size: 36px;
+    }
+    h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: #1d1d1f;
+      margin-bottom: 10px;
+    }
+    p {
+      font-size: 15px;
+      color: #6e6e73;
+      line-height: 1.5;
+      margin-bottom: 32px;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: #f5f5f7;
+      border-radius: 100px;
+      padding: 8px 18px;
+      font-size: 13px;
+      font-weight: 500;
+      color: #1d1d1f;
+    }
+    .dot {
+      width: 8px; height: 8px;
+      background: #34c759;
+      border-radius: 50%;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">&#x2705;</div>
+    <h1>QuickBooks Connected</h1>
+    <p>Your refresh token has been written to the shared env file. You can close this tab.</p>
+    <div class="badge"><div class="dot"></div> Auth complete</div>
+  </div>
+</body>
+</html>`;
+
+// ── callback server ───────────────────────────────────────────────────────────
+const server = http.createServer(async (req, res) => {
+  const reqUrl = new URL(req.url, `http://localhost:${localPort}`);
+  const code    = reqUrl.searchParams.get('code');
+  const realmId = reqUrl.searchParams.get('realmId');
+
+  if (!code) { res.writeHead(200); res.end('Waiting for auth callback...'); return; }
+
+  console.log(`Got code — exchanging (redirect_uri: ${registeredUri})`);
+  try {
+    const token = await exchangeCode(code, realmId);
+    updateEnv({
+      QUICKBOOKS_REFRESH_TOKEN: token.refresh_token,
+      QUICKBOOKS_REALM_ID: realmId || token.realmId || process.env.QUICKBOOKS_REALM_ID,
+    });
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(SUCCESS_HTML);
+    console.log('OAuth bootstrap complete.');
+    setTimeout(() => server.close(() => process.exit(0)), 800);
+  } catch (e) {
+    console.error('Exchange failed:', e.message);
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('OAuth error: ' + e.message);
+  }
+});
+
+// ── launch ────────────────────────────────────────────────────────────────────
+const authUri = `https://appcenter.intuit.com/connect/oauth2` +
+  `?client_id=${encodeURIComponent(clientId)}` +
+  `&redirect_uri=${encodeURIComponent(registeredUri)}` +
+  `&response_type=code` +
+  `&scope=com.intuit.quickbooks.accounting` +
+  `&state=qb-bootstrap`;
+
+server.listen(localPort, () => {
+  console.log(`Listening on port ${localPort}`);
+  console.log(`Registered redirect URI: ${registeredUri}`);
+  console.log('Opening browser for Intuit auth...');
+  open(authUri);
+});

--- a/src/clients/env-bootstrap.ts
+++ b/src/clients/env-bootstrap.ts
@@ -1,0 +1,78 @@
+import dotenv from "dotenv";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+export type QBCreds = {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  realmId: string;
+  environment: string;
+  redirectUri: string;
+  envFilePath: string;
+};
+
+const REQUIRED_VARS = [
+  "QUICKBOOKS_CLIENT_ID",
+  "QUICKBOOKS_CLIENT_SECRET",
+  "QUICKBOOKS_REFRESH_TOKEN",
+  "QUICKBOOKS_REALM_ID",
+] as const;
+
+function candidateEnvPaths(): string[] {
+  const fromEnv = process.env.QUICKBOOKS_ENV_FILE;
+  const home = os.homedir() || process.env.HOME || "";
+  const homeCandidates = home
+    ? [
+        path.join(home, "mcp-servers/quickbooks/.env"),
+        path.join(home, ".quickbooks/.env"),
+      ]
+    : [];
+  return [
+    fromEnv,
+    ...homeCandidates,
+    path.join(process.cwd(), ".env"),
+  ].filter((p): p is string => !!p);
+}
+
+function firstExisting(paths: string[]): string | null {
+  for (const p of paths) {
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+export function bootstrapQuickBooksEnv(): QBCreds {
+  const candidates = candidateEnvPaths();
+  const envFilePath = firstExisting(candidates);
+
+  if (envFilePath) {
+    dotenv.config({ path: envFilePath, override: false });
+  } else {
+    dotenv.config();
+  }
+
+  const missing = REQUIRED_VARS.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    const where = envFilePath ?? "(no .env file found)";
+    const details = [
+      "QuickBooks MCP startup validation failed.",
+      `Loaded env file: ${where}`,
+      `Missing required vars: ${missing.join(", ")}`,
+      `Search paths: ${candidates.join(" | ")}`,
+      "Set QUICKBOOKS_ENV_FILE to your single source-of-truth .env (recommended: ~/mcp-servers/quickbooks/.env).",
+    ].join("\n");
+    throw new Error(details);
+  }
+
+  return {
+    clientId: process.env.QUICKBOOKS_CLIENT_ID!,
+    clientSecret: process.env.QUICKBOOKS_CLIENT_SECRET!,
+    refreshToken: process.env.QUICKBOOKS_REFRESH_TOKEN!,
+    realmId: process.env.QUICKBOOKS_REALM_ID!,
+    environment: process.env.QUICKBOOKS_ENVIRONMENT || "sandbox",
+    redirectUri: process.env.QUICKBOOKS_REDIRECTURI || "http://localhost:8000/callback",
+    envFilePath: envFilePath || candidates[0] || path.join(process.cwd(), ".env"),
+  };
+}

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -1,25 +1,66 @@
-import dotenv from "dotenv";
 import QuickBooks from "node-quickbooks";
 import OAuthClient from "intuit-oauth";
 import http from 'http';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import open from 'open';
+import { bootstrapQuickBooksEnv } from "./env-bootstrap.js";
+import { persistQuickBooksRefreshTokenToWarehouse } from "./warehouse-token-sync.js";
 
-dotenv.config();
+const qb = bootstrapQuickBooksEnv();
+const client_id = qb.clientId;
+const client_secret = qb.clientSecret;
+const refresh_token = qb.refreshToken;
+const realm_id = qb.realmId;
+const environment = qb.environment;
+const redirect_uri = qb.redirectUri;
+const env_file_path = qb.envFilePath;
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const client_id = process.env.QUICKBOOKS_CLIENT_ID;
-const client_secret = process.env.QUICKBOOKS_CLIENT_SECRET;
-const refresh_token = process.env.QUICKBOOKS_REFRESH_TOKEN;
-const realm_id = process.env.QUICKBOOKS_REALM_ID;
-const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'sandbox';
-const redirect_uri = 'http://localhost:8000/callback';
+type QuickBooksTokenPayload = {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  realmId?: string;
+};
 
-// Only throw error if client_id or client_secret is missing
-if (!client_id || !client_secret || !redirect_uri) {
-  throw Error("Client ID, Client Secret and Redirect URI must be set in environment variables");
+type OAuthCallbackConfig = {
+  origin: string;
+  path: string;
+  port: number;
+};
+
+function quickBooksTokenPayload(response: any): QuickBooksTokenPayload {
+  const token = response?.token;
+  if (typeof token?.getToken === 'function') {
+    return token.getToken();
+  }
+  if (typeof response?.getToken === 'function') {
+    return response.getToken();
+  }
+  return token ?? response ?? {};
+}
+
+function oauthCallbackConfig(redirectUri: string): OAuthCallbackConfig {
+  const callbackUrl = new URL(redirectUri);
+  const hostname = callbackUrl.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  const localHostnames = new Set(['localhost', '127.0.0.1', '::1']);
+
+  if (callbackUrl.protocol !== 'http:' || !localHostnames.has(hostname)) {
+    throw new Error(
+      'QUICKBOOKS_REDIRECTURI must be an http://localhost callback URL for the local OAuth flow',
+    );
+  }
+
+  const port = Number(callbackUrl.port || '80');
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`QUICKBOOKS_REDIRECTURI has an invalid callback port: ${redirectUri}`);
+  }
+
+  return {
+    origin: `${callbackUrl.protocol}//${callbackUrl.host}`,
+    path: callbackUrl.pathname || '/',
+    port,
+  };
 }
 
 class QuickbooksClient {
@@ -62,76 +103,84 @@ class QuickbooksClient {
       return;
     }
 
+    const callback = oauthCallbackConfig(this.redirectUri);
     this.isAuthenticating = true;
-    const port = 8000;
 
     return new Promise((resolve, reject) => {
       // Create temporary server for OAuth callback
       const server = http.createServer(async (req, res) => {
-        if (req.url?.startsWith('/callback')) {
-          try {
-            const response = await this.oauthClient.createToken(req.url);
-            const tokens = response.token;
-            
-            // Save tokens
-            this.refreshToken = tokens.refresh_token;
-            this.realmId = tokens.realmId;
-            this.saveTokensToEnv();
-            
-            // Send success response
-            res.writeHead(200, { 'Content-Type': 'text/html' });
-            res.end(`
-              <html>
-                <body style="
-                  display: flex;
-                  flex-direction: column;
-                  justify-content: center;
-                  align-items: center;
-                  height: 100vh;
-                  margin: 0;
-                  font-family: Arial, sans-serif;
-                  background-color: #f5f5f5;
-                ">
-                  <h2 style="color: #2E8B57;">✓ Successfully connected to QuickBooks!</h2>
-                  <p>You can close this window now.</p>
-                </body>
-              </html>
-            `);
-            
-            // Close server after a short delay
-            setTimeout(() => {
-              server.close();
-              this.isAuthenticating = false;
-              resolve();
-            }, 1000);
-          } catch (error) {
-            console.error('Error during token creation:', error);
-            res.writeHead(500, { 'Content-Type': 'text/html' });
-            res.end(`
-              <html>
-                <body style="
-                  display: flex;
-                  flex-direction: column;
-                  justify-content: center;
-                  align-items: center;
-                  height: 100vh;
-                  margin: 0;
-                  font-family: Arial, sans-serif;
-                  background-color: #fff0f0;
-                ">
-                  <h2 style="color: #d32f2f;">Error connecting to QuickBooks</h2>
-                  <p>Please check the console for more details.</p>
-                </body>
-              </html>
-            `);
-            this.isAuthenticating = false;
-            reject(error);
+        const requestUrl = new URL(req.url ?? '/', callback.origin);
+        if (requestUrl.pathname !== callback.path) {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end('Not found');
+          return;
+        }
+
+        try {
+          const response = await this.oauthClient.createToken(requestUrl.toString());
+          const tokens = quickBooksTokenPayload(response);
+          if (!tokens.refresh_token) {
+            throw new Error('QuickBooks OAuth response omitted refresh_token');
           }
+          
+          // Save tokens
+          this.refreshToken = tokens.refresh_token;
+          this.realmId = tokens.realmId;
+          await this.persistTokensAfterQuickBooksAuth();
+          
+          // Send success response
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end(`
+            <html>
+              <body style="
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+                margin: 0;
+                font-family: Arial, sans-serif;
+                background-color: #f5f5f5;
+              ">
+                <h2 style="color: #2E8B57;">✓ Successfully connected to QuickBooks!</h2>
+                <p>You can close this window now.</p>
+              </body>
+            </html>
+          `);
+          
+          // Close server after a short delay
+          setTimeout(() => {
+            server.close();
+            this.isAuthenticating = false;
+            resolve();
+          }, 1000);
+        } catch (error) {
+          console.error('Error during token creation:', error);
+          res.writeHead(500, { 'Content-Type': 'text/html' });
+          res.end(`
+            <html>
+              <body style="
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+                margin: 0;
+                font-family: Arial, sans-serif;
+                background-color: #fff0f0;
+              ">
+                <h2 style="color: #d32f2f;">Error connecting to QuickBooks</h2>
+                <p>Please check the console for more details.</p>
+              </body>
+            </html>
+          `);
+          this.isAuthenticating = false;
+          reject(error);
         }
       });
 
       // Start server
-      server.listen(port, async () => {
+      server.listen(callback.port, async () => {
         
         // Generate authorization URL with proper type assertion
         const authUri = this.oauthClient.authorizeUri({
@@ -153,9 +202,10 @@ class QuickbooksClient {
   }
 
   private saveTokensToEnv(): void {
-    const tokenPath = path.join(__dirname, '..', '..', '.env');
-    const envContent = fs.readFileSync(tokenPath, 'utf-8');
-    const envLines = envContent.split('\n');
+    const tokenPath = env_file_path;
+    fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+    const envContent = fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath, 'utf-8') : '';
+    const envLines = envContent ? envContent.replace(/\n$/, '').split('\n') : [];
     
     const updateEnvVar = (name: string, value: string) => {
       const index = envLines.findIndex(line => line.startsWith(`${name}=`));
@@ -169,7 +219,28 @@ class QuickbooksClient {
     if (this.refreshToken) updateEnvVar('QUICKBOOKS_REFRESH_TOKEN', this.refreshToken);
     if (this.realmId) updateEnvVar('QUICKBOOKS_REALM_ID', this.realmId);
 
-    fs.writeFileSync(tokenPath, envLines.join('\n'));
+    fs.writeFileSync(tokenPath, envLines.join('\n').replace(/\n*$/, '\n'));
+  }
+
+  private async persistTokensAfterQuickBooksAuth(): Promise<void> {
+    this.saveTokensToEnv();
+    await this.persistRefreshTokenToWarehouse();
+  }
+
+  private async persistRefreshTokenToWarehouse(): Promise<void> {
+    if (!this.refreshToken) return;
+
+    try {
+      const result = await persistQuickBooksRefreshTokenToWarehouse(this.refreshToken);
+      if (result.synced) {
+        console.warn(`[QuickBooks MCP] Refresh token synced to Warehouse secrets for ${result.warehouseId}`);
+      } else {
+        console.warn(`[QuickBooks MCP] Warehouse refresh token sync skipped: ${result.skippedReason}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[QuickBooks MCP] Warehouse refresh token sync failed; continuing: ${message}`);
+    }
   }
 
   async refreshAccessToken() {
@@ -185,11 +256,32 @@ class QuickbooksClient {
     try {
       // At this point we know refreshToken is not undefined
       const authResponse = await this.oauthClient.refreshUsingToken(this.refreshToken);
-      
-      this.accessToken = authResponse.token.access_token;
+      const tokens = quickBooksTokenPayload(authResponse);
+
+      if (!tokens.access_token) {
+        throw new Error('QuickBooks refresh response omitted access_token');
+      }
+      if (!tokens.refresh_token) {
+        throw new Error('QuickBooks refresh response omitted refresh_token');
+      }
+
+      this.accessToken = tokens.access_token;
+
+      // QuickBooks uses rolling refresh tokens. Push every successful refresh
+      // through Warehouse too, so cloud secrets heal even if Intuit returns the
+      // same refresh token value this time.
+      const nextRefreshToken = tokens.refresh_token;
+      const refreshTokenChanged = Boolean(nextRefreshToken && nextRefreshToken !== this.refreshToken);
+      if (nextRefreshToken) {
+        this.refreshToken = nextRefreshToken;
+      }
+      if (refreshTokenChanged) {
+        this.saveTokensToEnv();
+      }
+      await this.persistRefreshTokenToWarehouse();
       
       // Calculate expiry time
-      const expiresIn = authResponse.token.expires_in || 3600; // Default to 1 hour
+      const expiresIn = tokens.expires_in || 3600; // Default to 1 hour
       this.accessTokenExpiry = new Date(Date.now() + expiresIn * 1000);
       
       return {

--- a/src/clients/warehouse-token-sync.ts
+++ b/src/clients/warehouse-token-sync.ts
@@ -1,0 +1,247 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+type Env = Record<string, string | undefined>;
+
+export type WarehouseQuickBooksSyncConfig = {
+  controlPlaneUrl: string;
+  anonKey: string;
+  workerToken: string;
+  warehouseId: string;
+};
+
+export type WarehouseQuickBooksSyncConfigResult =
+  | { ok: true; config: WarehouseQuickBooksSyncConfig }
+  | { ok: false; missing: string[] };
+
+export type PersistQuickBooksRefreshTokenResult =
+  | { synced: true; warehouseId: string }
+  | { synced: false; skippedReason: string };
+
+export type WarehouseTokenSyncOptions = {
+  env?: Env;
+  fallbackEnv?: Env;
+  fetchImpl?: typeof fetch;
+  launchAgentsDir?: string;
+  timeoutMs?: number;
+  warehousesDir?: string;
+};
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function valueFrom(env: Env, fallbackEnv: Env, name: string): string | undefined {
+  return clean(env[name]) ?? clean(fallbackEnv[name]);
+}
+
+function resolveControlPlaneUrl(env: Env, fallbackEnv: Env): string | undefined {
+  const explicit = valueFrom(env, fallbackEnv, "WAREHOUSE_SYNC_API_URL");
+  if (explicit) return explicit;
+
+  const supabaseUrl = valueFrom(env, fallbackEnv, "WAREHOUSE_SUPABASE_URL");
+  if (!supabaseUrl) return undefined;
+  return `${supabaseUrl.replace(/\/+$/, "")}/functions/v1/warehouse`;
+}
+
+function resolveAnonKey(env: Env, fallbackEnv: Env): string | undefined {
+  return (
+    valueFrom(env, fallbackEnv, "WAREHOUSE_SYNC_SUPABASE_ANON_KEY")
+    ?? valueFrom(env, fallbackEnv, "SUPABASE_ANON_KEY")
+  );
+}
+
+function resolveWorkerToken(env: Env, fallbackEnv: Env): string | undefined {
+  return valueFrom(env, fallbackEnv, "WAREHOUSE_DEVICE_TOKEN");
+}
+
+function defaultLaunchAgentsDir(): string {
+  return path.join(os.homedir(), "Library", "LaunchAgents");
+}
+
+function loadWorkerLaunchAgentEnv(launchAgentsDir = defaultLaunchAgentsDir()): Env {
+  if (!fs.existsSync(launchAgentsDir)) return {};
+
+  const plistPaths = fs
+    .readdirSync(launchAgentsDir)
+    .filter((filename) => /^com\.warehouse-sync\.worker\..+\.plist$/.test(filename))
+    .map((filename) => path.join(launchAgentsDir, filename))
+    .sort((left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs);
+
+  for (const plistPath of plistPaths) {
+    try {
+      const raw = execFileSync("/usr/bin/plutil", ["-convert", "json", "-o", "-", plistPath], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      const parsed = JSON.parse(raw) as { EnvironmentVariables?: Env };
+      if (parsed.EnvironmentVariables) {
+        return parsed.EnvironmentVariables;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return {};
+}
+
+function defaultWarehousesDir(): string {
+  return path.join(os.homedir(), ".warehouse-sync", "warehouses");
+}
+
+function configEnablesQuickBooks(config: unknown): boolean {
+  if (!config || typeof config !== "object") return false;
+  const record = config as Record<string, unknown>;
+
+  const connectors = record.connectors;
+  if (
+    Array.isArray(connectors)
+    && connectors.some((connector) => String(connector).toLowerCase() === "quickbooks")
+  ) {
+    return true;
+  }
+
+  const schedule = record.schedule;
+  if (!schedule || typeof schedule !== "object") return false;
+  const quickbooks = (schedule as Record<string, unknown>).quickbooks;
+  if (!quickbooks || typeof quickbooks !== "object") return false;
+  return (quickbooks as Record<string, unknown>).enabled !== false;
+}
+
+function resolveQuickBooksWarehouseIdFromConfigs(warehousesDir = defaultWarehousesDir()): string | undefined {
+  if (!fs.existsSync(warehousesDir)) return undefined;
+
+  const ids = fs
+    .readdirSync(warehousesDir)
+    .filter((filename) => filename.endsWith(".json"))
+    .flatMap((filename) => {
+      const configPath = path.join(warehousesDir, filename);
+      try {
+        const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+        if (!configEnablesQuickBooks(config)) return [];
+        const id = clean(typeof config.id === "string" ? config.id : path.basename(filename, ".json"));
+        return id ? [id] : [];
+      } catch {
+        return [];
+      }
+    });
+
+  const uniqueIds = Array.from(new Set(ids));
+  return uniqueIds.length === 1 ? uniqueIds[0] : undefined;
+}
+
+function resolveWarehouseId(env: Env, fallbackEnv: Env, warehousesDir?: string): string | undefined {
+  return (
+    valueFrom(env, fallbackEnv, "WAREHOUSE_QUICKBOOKS_WAREHOUSE_ID")
+    ?? valueFrom(env, fallbackEnv, "WAREHOUSE_CLOUD_WAREHOUSE_ID")
+    ?? valueFrom(env, fallbackEnv, "WAREHOUSE_ID")
+    ?? resolveQuickBooksWarehouseIdFromConfigs(warehousesDir)
+  );
+}
+
+export function resolveWarehouseQuickBooksSyncConfig(
+  options: WarehouseTokenSyncOptions = {},
+): WarehouseQuickBooksSyncConfigResult {
+  const env = options.env ?? process.env;
+  const fallbackEnv = options.fallbackEnv ?? loadWorkerLaunchAgentEnv(options.launchAgentsDir);
+
+  const config = {
+    controlPlaneUrl: resolveControlPlaneUrl(env, fallbackEnv),
+    anonKey: resolveAnonKey(env, fallbackEnv),
+    workerToken: resolveWorkerToken(env, fallbackEnv),
+    warehouseId: resolveWarehouseId(env, fallbackEnv, options.warehousesDir),
+  };
+
+  const missing = [
+    config.controlPlaneUrl ? undefined : "WAREHOUSE_SYNC_API_URL or WAREHOUSE_SUPABASE_URL",
+    config.anonKey ? undefined : "WAREHOUSE_SYNC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY",
+    config.workerToken ? undefined : "WAREHOUSE_DEVICE_TOKEN",
+    config.warehouseId
+      ? undefined
+      : "WAREHOUSE_QUICKBOOKS_WAREHOUSE_ID, WAREHOUSE_CLOUD_WAREHOUSE_ID, WAREHOUSE_ID, or one QuickBooks warehouse config",
+  ].filter((name): name is string => Boolean(name));
+
+  if (missing.length > 0) {
+    return { ok: false, missing };
+  }
+
+  const { controlPlaneUrl, anonKey, workerToken, warehouseId } = config;
+  return {
+    ok: true,
+    config: {
+      controlPlaneUrl: controlPlaneUrl as string,
+      anonKey: anonKey as string,
+      workerToken: workerToken as string,
+      warehouseId: warehouseId as string,
+    },
+  };
+}
+
+export async function persistQuickBooksRefreshTokenToWarehouse(
+  refreshToken: string,
+  options: WarehouseTokenSyncOptions = {},
+): Promise<PersistQuickBooksRefreshTokenResult> {
+  const token = clean(refreshToken);
+  if (!token) {
+    throw new Error("QuickBooks refresh token sync requires a non-empty token");
+  }
+
+  const resolved = resolveWarehouseQuickBooksSyncConfig(options);
+  if (!resolved.ok) {
+    return {
+      synced: false,
+      skippedReason: `missing ${resolved.missing.join(", ")}`,
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (!fetchImpl) {
+    return {
+      synced: false,
+      skippedReason: "global fetch is unavailable",
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 15_000);
+
+  try {
+    const response = await fetchImpl(resolved.config.controlPlaneUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: resolved.config.anonKey,
+        "x-warehouse-worker-token": resolved.config.workerToken,
+      },
+      body: JSON.stringify({
+        action: "quickbooks.refresh_token.persist",
+        warehouse_id: resolved.config.warehouseId,
+        refresh_token: token,
+      }),
+      signal: controller.signal,
+    });
+
+    const responseText = await response.text().catch(() => "");
+    if (!response.ok) {
+      return {
+        synced: false,
+        skippedReason: `Warehouse QuickBooks token sync failed (${response.status} ${response.statusText}): `
+        + (responseText || "empty response"),
+      };
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      synced: false,
+      skippedReason: `Warehouse QuickBooks token sync request failed: ${message}`,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return { synced: true, warehouseId: resolved.config.warehouseId };
+}

--- a/src/handlers/download-quickbooks-attachable.handler.ts
+++ b/src/handlers/download-quickbooks-attachable.handler.ts
@@ -1,0 +1,71 @@
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { ToolResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+/**
+ * Download an attachable file from QuickBooks Online
+ * @param id The ID of the attachable to download
+ * @param outputPath Optional path to save the file (defaults to temp directory)
+ */
+export async function downloadQuickbooksAttachable(
+  id: string,
+  outputPath?: string
+): Promise<ToolResponse<{ filePath: string; fileName: string }>> {
+  try {
+    await quickbooksClient.authenticate();
+    const quickbooks = quickbooksClient.getQuickbooks();
+
+    // First get the attachable metadata
+    const attachable = await new Promise<any>((resolve, reject) => {
+      quickbooks.getAttachable(id, (err: any, result: any) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+
+    if (!attachable?.TempDownloadUri) {
+      return {
+        result: null,
+        isError: true,
+        error: "Attachable has no TempDownloadUri - file may not be available for download",
+      };
+    }
+
+    const fileName = attachable.FileName || `attachable_${id}`;
+    const downloadUrl = attachable.TempDownloadUri;
+
+    // Determine output path
+    const finalPath = outputPath || path.join(os.tmpdir(), `qb_${id}_${fileName}`);
+
+    // Download the file
+    const response = await fetch(downloadUrl);
+    if (!response.ok) {
+      return {
+        result: null,
+        isError: true,
+        error: `Failed to download file: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    fs.writeFileSync(finalPath, buffer);
+
+    return {
+      result: {
+        filePath: finalPath,
+        fileName: fileName,
+      },
+      isError: false,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/get-quickbooks-attachable.handler.ts
+++ b/src/handlers/get-quickbooks-attachable.handler.ts
@@ -1,0 +1,38 @@
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { ToolResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+
+/**
+ * Get an attachable from QuickBooks Online
+ * @param id The ID of the attachable to retrieve
+ */
+export async function getQuickbooksAttachable(id: string): Promise<ToolResponse<any>> {
+  try {
+    await quickbooksClient.authenticate();
+    const quickbooks = quickbooksClient.getQuickbooks();
+
+    return new Promise((resolve) => {
+      quickbooks.getAttachable(id, (err: any, attachable: any) => {
+        if (err) {
+          resolve({
+            result: null,
+            isError: true,
+            error: formatError(err),
+          });
+        } else {
+          resolve({
+            result: attachable,
+            isError: false,
+            error: null,
+          });
+        }
+      });
+    });
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/search-quickbooks-attachables.handler.ts
+++ b/src/handlers/search-quickbooks-attachables.handler.ts
@@ -1,0 +1,39 @@
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { ToolResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+
+/**
+ * Search for attachables in QuickBooks Online
+ * Can search by entity type and ID to find attachments linked to specific transactions
+ */
+export async function searchQuickbooksAttachables(criteria: any): Promise<ToolResponse<any>> {
+  try {
+    await quickbooksClient.authenticate();
+    const quickbooks = quickbooksClient.getQuickbooks();
+
+    return new Promise((resolve) => {
+      quickbooks.findAttachables(criteria, (err: any, result: any) => {
+        if (err) {
+          resolve({
+            result: null,
+            isError: true,
+            error: formatError(err),
+          });
+        } else {
+          const attachables = result?.QueryResponse?.Attachable || [];
+          resolve({
+            result: attachables,
+            isError: false,
+            error: null,
+          });
+        }
+      });
+    });
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/upload-quickbooks-attachable.handler.ts
+++ b/src/handlers/upload-quickbooks-attachable.handler.ts
@@ -1,0 +1,84 @@
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { ToolResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+import * as fs from "fs";
+import * as path from "path";
+
+// Common MIME types by extension
+const MIME_TYPES: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".csv": "text/csv",
+  ".txt": "text/plain",
+};
+
+/**
+ * Upload a file as an attachable to QuickBooks Online
+ * @param filePath Local path to the file to upload
+ * @param entityType Optional entity type to link to (e.g., 'Bill', 'Purchase', 'Invoice')
+ * @param entityId Optional entity ID to link to
+ */
+export async function uploadQuickbooksAttachable(
+  filePath: string,
+  entityType?: string,
+  entityId?: string
+): Promise<ToolResponse<any>> {
+  try {
+    // Verify file exists
+    if (!fs.existsSync(filePath)) {
+      return {
+        result: null,
+        isError: true,
+        error: `File not found: ${filePath}`,
+      };
+    }
+
+    await quickbooksClient.authenticate();
+    const quickbooks = quickbooksClient.getQuickbooks();
+
+    const fileName = path.basename(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || "application/octet-stream";
+
+    // Create a readable stream
+    const stream = fs.createReadStream(filePath);
+
+    return new Promise((resolve) => {
+      quickbooks.upload(
+        fileName,
+        contentType,
+        stream,
+        entityType || null,
+        entityId || null,
+        (err: any, attachable: any) => {
+          if (err) {
+            resolve({
+              result: null,
+              isError: true,
+              error: formatError(err),
+            });
+          } else {
+            resolve({
+              result: attachable,
+              isError: false,
+              error: null,
+            });
+          }
+        }
+      );
+    });
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,12 @@ import { UpdatePurchaseTool } from "./tools/update-purchase.tool.js";
 import { DeletePurchaseTool } from "./tools/delete-purchase.tool.js";
 import { SearchPurchasesTool } from "./tools/search-purchases.tool.js";
 
+// Attachable tools
+import { GetAttachableTool } from "./tools/get-attachable.tool.js";
+import { SearchAttachablesTool } from "./tools/search-attachables.tool.js";
+import { DownloadAttachableTool } from "./tools/download-attachable.tool.js";
+import { UploadAttachableTool } from "./tools/upload-attachable.tool.js";
+
 const main = async () => {
   // Create an MCP server
   const server = QuickbooksMCPServer.GetServer();
@@ -155,6 +161,12 @@ const main = async () => {
   RegisterTool(server, UpdatePurchaseTool);
   RegisterTool(server, DeletePurchaseTool);
   RegisterTool(server, SearchPurchasesTool);
+
+  // Add tools for attachables
+  RegisterTool(server, GetAttachableTool);
+  RegisterTool(server, SearchAttachablesTool);
+  RegisterTool(server, DownloadAttachableTool);
+  RegisterTool(server, UploadAttachableTool);
 
   // Start receiving messages on stdin and sending messages on stdout
   const transport = new StdioServerTransport();

--- a/src/tools/create-journal-entry.tool.ts
+++ b/src/tools/create-journal-entry.tool.ts
@@ -15,7 +15,32 @@ type ToolParams = z.infer<typeof toolSchema>;
 
 // Define the tool handler
 const toolHandler = async (args: any) => {
-  const response = await createQuickbooksJournalEntry(args.params.journalEntry);
+  // Robust extraction: handle various input shapes
+  let journalEntryData = args?.params?.journalEntry;
+  
+  // If journalEntry is a string (LLM sent stringified JSON), parse it
+  if (typeof journalEntryData === 'string') {
+    try {
+      journalEntryData = JSON.parse(journalEntryData);
+    } catch (e) {
+      return {
+        content: [
+          { type: "text" as const, text: `Error creating journal entry: journalEntry is a string but not valid JSON: ${journalEntryData.substring(0, 200)}` },
+        ],
+      };
+    }
+  }
+  
+  // Validate we have usable data
+  if (!journalEntryData || typeof journalEntryData !== 'object' || !journalEntryData.Line) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error creating journal entry: journalEntry must be an object with a Line array. Received: ${JSON.stringify(journalEntryData)?.substring(0, 500)}` },
+      ],
+    };
+  }
+  
+  const response = await createQuickbooksJournalEntry(journalEntryData);
 
   if (response.isError) {
     return {

--- a/src/tools/create-purchase.tool.ts
+++ b/src/tools/create-purchase.tool.ts
@@ -2,20 +2,69 @@ import { createQuickbooksPurchase } from "../handlers/create-quickbooks-purchase
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
-// Define the tool metadata
 const toolName = "create_purchase";
-const toolDescription = "Create a purchase in QuickBooks Online.";
+const toolDescription = "Create a purchase (expense/check) in QuickBooks Online. Requires AccountRef (bank account), PaymentType ('Cash', 'Check', or 'CreditCard'), and at least one Line item.";
 
-// Define the expected input schema for creating a purchase
-const toolSchema = z.object({
-  purchase: z.any(),
+// Schema for AccountBasedExpenseLineDetail (the most common line type for purchases)
+const purchaseLineSchema = z.object({
+  Amount: z.number(),
+  Description: z.string().optional(),
+  DetailType: z.literal("AccountBasedExpenseLineDetail"),
+  AccountBasedExpenseLineDetail: z.object({
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    ClassRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    CustomerRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    BillableStatus: z.string().optional(),
+    TaxCodeRef: z.object({
+      value: z.string(),
+    }).optional(),
+  }),
 });
 
-type ToolParams = z.infer<typeof toolSchema>;
+const toolSchema = z.object({
+  purchase: z.object({
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    PaymentType: z.enum(["Cash", "Check", "CreditCard"]),
+    Line: z.array(purchaseLineSchema),
+    EntityRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+      type: z.string().optional(),
+    }).optional(),
+    TxnDate: z.string().optional(),
+    DepartmentRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    PrivateNote: z.string().optional(),
+  }),
+});
 
-// Define the tool handler
-const toolHandler = async (args: any) => {
-  const response = await createQuickbooksPurchase(args.params.purchase);
+const toolHandler = async (args: { [x: string]: any }) => {
+  // Handle different argument structures from MCP SDK
+  const purchase = args.purchase || args.params?.purchase || args;
+
+  if (!purchase || !purchase.AccountRef) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error: Invalid args structure. Received keys: ${Object.keys(args).join(', ')}. Args: ${JSON.stringify(args).slice(0, 500)}` },
+      ],
+    };
+  }
+
+  const response = await createQuickbooksPurchase(purchase);
 
   if (response.isError) {
     return {
@@ -27,8 +76,7 @@ const toolHandler = async (args: any) => {
 
   return {
     content: [
-      { type: "text" as const, text: `Purchase created:` },
-      { type: "text" as const, text: JSON.stringify(response.result) },
+      { type: "text" as const, text: `Purchase created: ${JSON.stringify(response.result)}` },
     ],
   };
 };
@@ -38,4 +86,4 @@ export const CreatePurchaseTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: toolHandler,
-}; 
+};

--- a/src/tools/download-attachable.tool.ts
+++ b/src/tools/download-attachable.tool.ts
@@ -11,10 +11,10 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: any) => {
-  const response = await downloadQuickbooksAttachable(
-    args.params.id,
-    args.params.outputPath
-  );
+  const id = args.params?.id || args.id;
+  const outputPath = args.params?.outputPath || args.outputPath;
+
+  const response = await downloadQuickbooksAttachable(id, outputPath);
 
   if (response.isError) {
     return {

--- a/src/tools/download-attachable.tool.ts
+++ b/src/tools/download-attachable.tool.ts
@@ -1,0 +1,42 @@
+import { downloadQuickbooksAttachable } from "../handlers/download-quickbooks-attachable.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+
+const toolName = "download_attachable";
+const toolDescription = "Download an attachable (file attachment) from QuickBooks Online to local filesystem. Returns the local file path which can then be read/parsed.";
+
+const toolSchema = z.object({
+  id: z.string().describe("The QuickBooks attachable ID"),
+  outputPath: z.string().optional().describe("Optional path to save the file (defaults to temp directory)"),
+});
+
+const toolHandler = async (args: any) => {
+  const response = await downloadQuickbooksAttachable(
+    args.params.id,
+    args.params.outputPath
+  );
+
+  if (response.isError) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error downloading attachable: ${response.error}` },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Downloaded "${response.result!.fileName}" to: ${response.result!.filePath}`,
+      },
+    ],
+  };
+};
+
+export const DownloadAttachableTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/src/tools/get-attachable.tool.ts
+++ b/src/tools/get-attachable.tool.ts
@@ -1,0 +1,35 @@
+import { getQuickbooksAttachable } from "../handlers/get-quickbooks-attachable.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+
+const toolName = "get_attachable";
+const toolDescription = "Get an attachable (file attachment) by Id from QuickBooks Online. Returns metadata including TempDownloadUri for downloading the file.";
+
+const toolSchema = z.object({
+  id: z.string(),
+});
+
+const toolHandler = async (args: any) => {
+  const response = await getQuickbooksAttachable(args.params.id);
+
+  if (response.isError) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error getting attachable: ${response.error}` },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      { type: "text" as const, text: `Attachable retrieved: ${JSON.stringify(response.result)}` },
+    ],
+  };
+};
+
+export const GetAttachableTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/src/tools/get-attachable.tool.ts
+++ b/src/tools/get-attachable.tool.ts
@@ -10,7 +10,8 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: any) => {
-  const response = await getQuickbooksAttachable(args.params.id);
+  const id = args.params?.id || args.id;
+  const response = await getQuickbooksAttachable(id);
 
   if (response.isError) {
     return {

--- a/src/tools/search-attachables.tool.ts
+++ b/src/tools/search-attachables.tool.ts
@@ -1,0 +1,59 @@
+import { searchQuickbooksAttachables } from "../handlers/search-quickbooks-attachables.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+
+const toolName = "search_attachables";
+const toolDescription = "Search for attachables (file attachments) in QuickBooks Online. Provide entityType (e.g. 'Purchase', 'Bill') and entityId to find attachments for a specific transaction. Omit both to get all attachables.";
+
+const toolSchema = z.object({
+  entityType: z.string().optional().describe("Entity type to filter by: 'Purchase', 'Bill', 'Invoice', etc."),
+  entityId: z.string().optional().describe("Entity ID to filter by (e.g. '322')"),
+});
+
+const toolHandler = async (args: any) => {
+  const entityType = args.params?.entityType;
+  const entityId = args.params?.entityId;
+
+  // Always fetch all attachables - QB query syntax for array fields is unreliable
+  const response = await searchQuickbooksAttachables({ fetchAll: true });
+
+  if (response.isError) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error searching attachables: ${response.error}` },
+      ],
+    };
+  }
+
+  let attachables = response.result || [];
+
+  // Filter client-side if entityType and entityId provided
+  if (entityType && entityId) {
+    attachables = attachables.filter((att: any) => {
+      const refs = att.AttachableRef || [];
+      return refs.some((ref: any) =>
+        ref.EntityRef?.type === entityType &&
+        ref.EntityRef?.value === entityId
+      );
+    });
+  } else if (entityType) {
+    // Filter by just entity type
+    attachables = attachables.filter((att: any) => {
+      const refs = att.AttachableRef || [];
+      return refs.some((ref: any) => ref.EntityRef?.type === entityType);
+    });
+  }
+
+  return {
+    content: [
+      { type: "text" as const, text: `Found ${attachables.length} attachables: ${JSON.stringify(attachables)}` },
+    ],
+  };
+};
+
+export const SearchAttachablesTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/src/tools/update-bill.tool.ts
+++ b/src/tools/update-bill.tool.ts
@@ -7,27 +7,36 @@ const toolDescription = "Update a bill in QuickBooks Online.";
 const toolSchema = z.object({
   bill: z.object({
     Id: z.string(),
+    SyncToken: z.string(),
     Line: z.array(z.object({
       Amount: z.number(),
-      DetailType: z.string(),
-      Description: z.string(),
-      AccountRef: z.object({
-        value: z.string(),
-        name: z.string().optional(),
+      DetailType: z.literal("AccountBasedExpenseLineDetail"),
+      Description: z.string().optional(),
+      AccountBasedExpenseLineDetail: z.object({
+        AccountRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }),
+        ClassRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }).optional(),
+        BillableStatus: z.enum(["Billable", "NotBillable", "HasBeenBilled"]).optional(),
       }),
     })),
     VendorRef: z.object({
       value: z.string(),
       name: z.string().optional(),
     }),
-    DueDate: z.string(),
-    Balance: z.number(),
-    TotalAmt: z.number(),
+    DueDate: z.string().optional(),
+    TxnDate: z.string().optional(),
+    PrivateNote: z.string().optional(),
   }),
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await updateQuickbooksBill(args.bill);
+  const billInput = args.params?.bill || args.bill;
+  const response = await updateQuickbooksBill(billInput);
 
   if (response.isError) {
     return {
@@ -40,13 +49,13 @@ const toolHandler = async (args: { [x: string]: any }) => {
     };
   }
 
-  const bill = response.result;
+  const updatedBill = response.result;
 
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify(bill),
+        text: JSON.stringify(updatedBill),
       }
     ],
   };

--- a/src/tools/update-purchase.tool.ts
+++ b/src/tools/update-purchase.tool.ts
@@ -2,20 +2,73 @@ import { updateQuickbooksPurchase } from "../handlers/update-quickbooks-purchase
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
-// Define the tool metadata
 const toolName = "update_purchase";
-const toolDescription = "Update a purchase in QuickBooks Online.";
+const toolDescription = "Update a purchase (expense/check) in QuickBooks Online. Requires Id, SyncToken, PaymentType ('Cash', 'Check', or 'CreditCard'), and AccountRef (bank account) from the existing purchase.";
 
-// Define the expected input schema for updating a purchase
-const toolSchema = z.object({
-  purchase: z.any(),
+// Schema for AccountBasedExpenseLineDetail (the most common line type for purchases)
+const purchaseLineSchema = z.object({
+  Id: z.string().optional(),
+  Amount: z.number(),
+  Description: z.string().optional(),
+  DetailType: z.literal("AccountBasedExpenseLineDetail"),
+  AccountBasedExpenseLineDetail: z.object({
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    ClassRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    CustomerRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    BillableStatus: z.string().optional(),
+    TaxCodeRef: z.object({
+      value: z.string(),
+    }).optional(),
+  }),
 });
 
-type ToolParams = z.infer<typeof toolSchema>;
+const toolSchema = z.object({
+  purchase: z.object({
+    Id: z.string(),
+    SyncToken: z.string(),
+    Line: z.array(purchaseLineSchema),
+    AccountRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }),
+    PaymentType: z.enum(["Cash", "Check", "CreditCard"]),
+    EntityRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+      type: z.string().optional(),
+    }).optional(),
+    TxnDate: z.string().optional(),
+    DepartmentRef: z.object({
+      value: z.string(),
+      name: z.string().optional(),
+    }).optional(),
+    PrivateNote: z.string().optional(),
+    TotalAmt: z.number().optional(),
+  }),
+});
 
-// Define the tool handler
-const toolHandler = async (args: any) => {
-  const response = await updateQuickbooksPurchase(args.params.purchase);
+const toolHandler = async (args: { [x: string]: any }) => {
+  // Handle different argument structures from MCP SDK
+  const purchase = args.purchase || args.params?.purchase || args;
+
+  if (!purchase || !purchase.Id) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error: Invalid args structure. Received keys: ${Object.keys(args).join(', ')}. Args: ${JSON.stringify(args).slice(0, 500)}` },
+      ],
+    };
+  }
+
+  const response = await updateQuickbooksPurchase(purchase);
 
   if (response.isError) {
     return {
@@ -27,8 +80,7 @@ const toolHandler = async (args: any) => {
 
   return {
     content: [
-      { type: "text" as const, text: `Purchase updated:` },
-      { type: "text" as const, text: JSON.stringify(response.result) },
+      { type: "text" as const, text: `Purchase updated: ${JSON.stringify(response.result)}` },
     ],
   };
 };
@@ -38,4 +90,4 @@ export const UpdatePurchaseTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: toolHandler,
-}; 
+};

--- a/src/tools/upload-attachable.tool.ts
+++ b/src/tools/upload-attachable.tool.ts
@@ -12,10 +12,14 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: any) => {
+  const filePath = args.params?.filePath || args.filePath;
+  const entityType = args.params?.entityType || args.entityType;
+  const entityId = args.params?.entityId || args.entityId;
+
   const response = await uploadQuickbooksAttachable(
-    args.params.filePath,
-    args.params.entityType,
-    args.params.entityId
+    filePath,
+    entityType,
+    entityId
   );
 
   if (response.isError) {

--- a/src/tools/upload-attachable.tool.ts
+++ b/src/tools/upload-attachable.tool.ts
@@ -1,0 +1,45 @@
+import { uploadQuickbooksAttachable } from "../handlers/upload-quickbooks-attachable.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+
+const toolName = "upload_attachable";
+const toolDescription = "Upload a local file as an attachable to QuickBooks Online. Can optionally link it to a specific entity (Bill, Purchase, Invoice, etc.).";
+
+const toolSchema = z.object({
+  filePath: z.string().describe("Local path to the file to upload"),
+  entityType: z.string().optional().describe("Entity type to link to: 'Bill', 'Purchase', 'Invoice', 'Vendor', 'Customer', etc."),
+  entityId: z.string().optional().describe("Entity ID to link the attachment to"),
+});
+
+const toolHandler = async (args: any) => {
+  const response = await uploadQuickbooksAttachable(
+    args.params.filePath,
+    args.params.entityType,
+    args.params.entityId
+  );
+
+  if (response.isError) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error uploading attachable: ${response.error}` },
+      ],
+    };
+  }
+
+  const att = response.result;
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Uploaded successfully!\nAttachable ID: ${att.Id}\nFilename: ${att.FileName}${att.AttachableRef ? `\nLinked to: ${att.AttachableRef[0]?.EntityRef?.type} ${att.AttachableRef[0]?.EntityRef?.value}` : ""}`,
+      },
+    ],
+  };
+};
+
+export const UploadAttachableTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/src/types/node-quickbooks.d.ts
+++ b/src/types/node-quickbooks.d.ts
@@ -85,6 +85,12 @@ declare module 'node-quickbooks' {
     updatePurchase(purchaseData: object, callback: (err: any, purchase: any) => void): void;
     deletePurchase(idOrEntity: any, callback: (err: any, response: any) => void): void;
 
-    // You can add more methods as needed
+    // Attachable CRUD
+    findAttachables(options: object, callback: (err: any, attachables: any) => void): void;
+    createAttachable(attachableData: object, callback: (err: any, attachable: any) => void): void;
+    getAttachable(id: string, callback: (err: any, attachable: any) => void): void;
+    updateAttachable(attachableData: object, callback: (err: any, attachable: any) => void): void;
+    deleteAttachable(idOrEntity: any, callback: (err: any, response: any) => void): void;
+    upload(filename: string, contentType: string, stream: any, entityType: string | null, entityId: string | null, callback: (err: any, attachable: any) => void): void;
   }
 }

--- a/test/env-bootstrap.test.mjs
+++ b/test/env-bootstrap.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { bootstrapQuickBooksEnv } from "../dist/clients/env-bootstrap.js";
+
+const QUICKBOOKS_ENV_KEYS = [
+  "QUICKBOOKS_CLIENT_ID",
+  "QUICKBOOKS_CLIENT_SECRET",
+  "QUICKBOOKS_REFRESH_TOKEN",
+  "QUICKBOOKS_REALM_ID",
+  "QUICKBOOKS_ENVIRONMENT",
+  "QUICKBOOKS_REDIRECTURI",
+  "QUICKBOOKS_ENV_FILE",
+];
+
+function withQuickBooksEnv(updates, callback) {
+  const saved = new Map(QUICKBOOKS_ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of QUICKBOOKS_ENV_KEYS) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, updates);
+
+  try {
+    callback();
+  } finally {
+    for (const key of QUICKBOOKS_ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test("defaults QuickBooks bootstrap to sandbox and a creatable env file path", () => {
+  const envFilePath = path.join(
+    os.tmpdir(),
+    `quickbooks-env-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    ".env",
+  );
+  fs.mkdirSync(path.dirname(envFilePath), { recursive: true });
+  fs.writeFileSync(envFilePath, "");
+
+  withQuickBooksEnv({
+    QUICKBOOKS_CLIENT_ID: "client-id",
+    QUICKBOOKS_CLIENT_SECRET: "client-secret",
+    QUICKBOOKS_REFRESH_TOKEN: "refresh-token",
+    QUICKBOOKS_REALM_ID: "realm-id",
+    QUICKBOOKS_ENV_FILE: envFilePath,
+  }, () => {
+    const result = bootstrapQuickBooksEnv();
+
+    assert.equal(result.environment, "sandbox");
+    assert.equal(result.redirectUri, "http://localhost:8000/callback");
+    assert.equal(result.envFilePath, envFilePath);
+  });
+});

--- a/test/warehouse-token-sync.test.mjs
+++ b/test/warehouse-token-sync.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  persistQuickBooksRefreshTokenToWarehouse,
+  resolveWarehouseQuickBooksSyncConfig,
+} from "../dist/clients/warehouse-token-sync.js";
+
+test("resolves warehouse sync config from env and QuickBooks warehouse config", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "qb-token-sync-"));
+  const warehousesDir = path.join(tmpDir, "warehouses");
+  fs.mkdirSync(warehousesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(warehousesDir, "tcc.json"),
+    JSON.stringify({
+      id: "tcc",
+      connectors: ["quickbooks"],
+      schedule: { quickbooks: { enabled: true } },
+    }),
+  );
+
+  const result = resolveWarehouseQuickBooksSyncConfig({
+    env: {
+      WAREHOUSE_SYNC_API_URL: "https://example.test/functions/v1/warehouse",
+      WAREHOUSE_SYNC_SUPABASE_ANON_KEY: "anon-key",
+      WAREHOUSE_DEVICE_TOKEN: "worker-token",
+    },
+    warehousesDir,
+    fallbackEnv: {},
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.config.warehouseId, "tcc");
+  assert.equal(result.config.controlPlaneUrl, "https://example.test/functions/v1/warehouse");
+  assert.equal(result.config.anonKey, "anon-key");
+  assert.equal(result.config.workerToken, "worker-token");
+});
+
+test("resolves control-plane credentials from worker fallback env", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "qb-token-sync-"));
+  const warehousesDir = path.join(tmpDir, "warehouses");
+  fs.mkdirSync(warehousesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(warehousesDir, "tcc.json"),
+    JSON.stringify({
+      id: "tcc",
+      connectors: ["quickbooks"],
+    }),
+  );
+
+  const result = resolveWarehouseQuickBooksSyncConfig({
+    env: {},
+    fallbackEnv: {
+      WAREHOUSE_SYNC_API_URL: "https://fallback.test/functions/v1/warehouse",
+      WAREHOUSE_SYNC_SUPABASE_ANON_KEY: "fallback-anon",
+      WAREHOUSE_DEVICE_TOKEN: "fallback-worker-token",
+    },
+    warehousesDir,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.config.controlPlaneUrl, "https://fallback.test/functions/v1/warehouse");
+  assert.equal(result.config.anonKey, "fallback-anon");
+  assert.equal(result.config.workerToken, "fallback-worker-token");
+  assert.equal(result.config.warehouseId, "tcc");
+});
+
+test("persists QuickBooks refresh token to Warehouse control plane", async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+
+  const result = await persistQuickBooksRefreshTokenToWarehouse("rotated-refresh", {
+    env: {
+      WAREHOUSE_SYNC_API_URL: "https://example.test/functions/v1/warehouse",
+      WAREHOUSE_SYNC_SUPABASE_ANON_KEY: "anon-key",
+      WAREHOUSE_DEVICE_TOKEN: "worker-token",
+      WAREHOUSE_ID: "tcc",
+    },
+    fallbackEnv: {},
+    fetchImpl,
+  });
+
+  assert.equal(result.synced, true);
+  assert.equal(result.warehouseId, "tcc");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://example.test/functions/v1/warehouse");
+  assert.equal(calls[0].init.method, "POST");
+  assert.equal(calls[0].init.headers.apikey, "anon-key");
+  assert.equal(calls[0].init.headers["x-warehouse-worker-token"], "worker-token");
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    action: "quickbooks.refresh_token.persist",
+    warehouse_id: "tcc",
+    refresh_token: "rotated-refresh",
+  });
+});
+
+test("reports all supported warehouse id sources when sync config is missing", () => {
+  const result = resolveWarehouseQuickBooksSyncConfig({
+    env: {
+      WAREHOUSE_SYNC_API_URL: "https://example.test/functions/v1/warehouse",
+      WAREHOUSE_SYNC_SUPABASE_ANON_KEY: "anon-key",
+      WAREHOUSE_DEVICE_TOKEN: "worker-token",
+    },
+    fallbackEnv: {},
+    warehousesDir: path.join(os.tmpdir(), "missing-qb-warehouse-configs"),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.missing.join(", "),
+    /WAREHOUSE_QUICKBOOKS_WAREHOUSE_ID, WAREHOUSE_CLOUD_WAREHOUSE_ID, WAREHOUSE_ID/,
+  );
+});
+
+test("treats Warehouse control-plane HTTP failures as skipped sync", async () => {
+  const result = await persistQuickBooksRefreshTokenToWarehouse("rotated-refresh", {
+    env: {
+      WAREHOUSE_SYNC_API_URL: "https://example.test/functions/v1/warehouse",
+      WAREHOUSE_SYNC_SUPABASE_ANON_KEY: "anon-key",
+      WAREHOUSE_DEVICE_TOKEN: "worker-token",
+      WAREHOUSE_ID: "tcc",
+    },
+    fallbackEnv: {},
+    fetchImpl: async () => new Response("temporarily unavailable", {
+      status: 503,
+      statusText: "Service Unavailable",
+    }),
+  });
+
+  assert.equal(result.synced, false);
+  assert.match(result.skippedReason, /503 Service Unavailable/);
+});
+
+test("treats Warehouse control-plane network failures as skipped sync", async () => {
+  const result = await persistQuickBooksRefreshTokenToWarehouse("rotated-refresh", {
+    env: {
+      WAREHOUSE_SYNC_API_URL: "https://example.test/functions/v1/warehouse",
+      WAREHOUSE_SYNC_SUPABASE_ANON_KEY: "anon-key",
+      WAREHOUSE_DEVICE_TOKEN: "worker-token",
+      WAREHOUSE_ID: "tcc",
+    },
+    fallbackEnv: {},
+    fetchImpl: async () => {
+      throw new Error("network is down");
+    },
+  });
+
+  assert.equal(result.synced, false);
+  assert.match(result.skippedReason, /network is down/);
+});


### PR DESCRIPTION
## Summary

- **fix(update-bill)**: Add required `SyncToken` field to schema and fix `args.params` path issue
- **fix(purchase)**: Same fixes for create/update purchase tools with full Line item schema
- **feat(attachables)**: Add CRUD tools for QuickBooks file attachments (search, get, download, upload)

## Problem

The MCP SDK wraps tool arguments in a `params` object, but handlers were accessing `args.bill` directly instead of `args.params.bill`. Additionally, QuickBooks API requires `SyncToken` for all update operations, but it was missing from the Zod schemas.

## Changes

### Schema Fixes
- Add `SyncToken` to update-bill and update-purchase schemas
- Restructure Line items to use proper nested `AccountBasedExpenseLineDetail` 
- Support `ClassRef` for class/department tracking
- Remove computed fields (`Balance`, `TotalAmt`) that QB calculates

### Handler Fixes
- Fix argument access: `args.params?.bill || args.bill` for backwards compatibility
- Better error messages showing received args structure

### New Attachable Tools
- `search_attachables` - Find attachments by entityType/entityId
- `get_attachable` - Get attachment metadata and temporary download URL
- `download_attachable` - Download attachment to local filesystem
- `upload_attachable` - Upload new attachment to QuickBooks

## Test plan

- [x] Tested update-bill with 22 line items successfully
- [x] Verified SyncToken increments after update
- [x] Tested search_attachables to find bill attachments
- [x] Tested download_attachable to retrieve expense PDFs

🤖 Generated with [Claude Code](https://claude.ai/code)