### PR TITLE
fix: unwrap SDK envelope in search handlers, preserve criteria filters

### DIFF
--- a/src/handlers/search-quickbooks-employees.handler.ts
+++ b/src/handlers/search-quickbooks-employees.handler.ts
@@ -23,7 +23,7 @@ export async function searchQuickbooksEmployees(params: any): Promise<ToolRespon
           });
         } else {
           resolve({
-            result: employees,
+            result: employees?.QueryResponse?.Employee || [],
             isError: false,
             error: null,
           });

--- a/src/handlers/search-quickbooks-purchases.handler.ts
+++ b/src/handlers/search-quickbooks-purchases.handler.ts
@@ -23,7 +23,7 @@ export async function searchQuickbooksPurchases(params: any): Promise<ToolRespon
           });
         } else {
           resolve({
-            result: purchases,
+            result: purchases?.QueryResponse?.Purchase || [],
             isError: false,
             error: null,
           });

--- a/src/helpers/build-quickbooks-search-criteria.ts
+++ b/src/helpers/build-quickbooks-search-criteria.ts
@@ -10,6 +10,8 @@ export interface QuickbooksFilter {
 export interface AdvancedQuickbooksSearchOptions {
   /** Array of filter objects that map to QuickBooks query filters */
   filters?: QuickbooksFilter[];
+  /** Alias for filters — accepted by several tool schemas */
+  criteria?: QuickbooksFilter[];
   /** Sort ascending by the provided field */
   asc?: string;
   /** Sort descending by the provided field */
@@ -53,6 +55,7 @@ export function buildQuickbooksSearchCriteria(
   // If the input is a plain object that does NOT look like advanced options, forward as-is
   const possibleAdvancedKeys: (keyof AdvancedQuickbooksSearchOptions)[] = [
     "filters",
+    "criteria",
     "asc",
     "desc",
     "limit",
@@ -75,8 +78,9 @@ export function buildQuickbooksSearchCriteria(
   const options = input as AdvancedQuickbooksSearchOptions;
   const criteriaArr: Array<Record<string, any>> = [];
 
-  // Convert filters
-  options.filters?.forEach((f) => {
+  // Convert filters (accept both "filters" and "criteria" as the key)
+  const filterList = options.filters ?? options.criteria;
+  filterList?.forEach((f) => {
     criteriaArr.push({ field: f.field, value: f.value, operator: f.operator });
   });
 

--- a/tests/unit/handlers/purchase-employee-search.handlers.test.ts
+++ b/tests/unit/handlers/purchase-employee-search.handlers.test.ts
@@ -1,0 +1,111 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+// Dynamic imports after mock setup
+const { searchQuickbooksPurchases } = await import('../../../src/handlers/search-quickbooks-purchases.handler');
+const { searchQuickbooksEmployees } = await import('../../../src/handlers/search-quickbooks-employees.handler');
+
+describe('search_purchases – Fixes #14', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  it('should return the entity array, not the raw SDK envelope', async () => {
+    const mockPurchases = [{ Id: '1', TotalAmt: 50 }, { Id: '2', TotalAmt: 75 }];
+    (mockQuickBooksInstance.findPurchases as jest.Mock).mockImplementation(
+      (_criteria: any, cb: any) => cb(null, { QueryResponse: { Purchase: mockPurchases, maxResults: 2, startPosition: 1 }, time: '2026-01-01' })
+    );
+
+    const result = await searchQuickbooksPurchases({});
+
+    expect(result.isError).toBe(false);
+    // Must be the unwrapped array, not the full SDK response
+    expect(result.result).toEqual(mockPurchases);
+    expect(result.result).not.toHaveProperty('QueryResponse');
+  });
+
+  it('should return empty array when no purchases match', async () => {
+    (mockQuickBooksInstance.findPurchases as jest.Mock).mockImplementation(
+      (_criteria: any, cb: any) => cb(null, { QueryResponse: {}, time: '2026-01-01' })
+    );
+
+    const result = await searchQuickbooksPurchases({});
+
+    expect(result.isError).toBe(false);
+    expect(result.result).toEqual([]);
+  });
+
+  it('should handle API errors', async () => {
+    (mockQuickBooksInstance.findPurchases as jest.Mock).mockImplementation(
+      (_criteria: any, cb: any) => cb(new Error('API Error'), null)
+    );
+
+    const result = await searchQuickbooksPurchases({});
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('should handle authentication errors', async () => {
+    (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+    const result = await searchQuickbooksPurchases({});
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('Auth failed');
+  });
+});
+
+describe('search_employees – Fixes #15', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  it('should return the entity array, not the raw SDK envelope', async () => {
+    const mockEmployees = [{ Id: '1', DisplayName: 'Alice' }, { Id: '2', DisplayName: 'Bob' }];
+    (mockQuickBooksInstance.findEmployees as jest.Mock).mockImplementation(
+      (_criteria: any, cb: any) => cb(null, { QueryResponse: { Employee: mockEmployees, maxResults: 2, startPosition: 1 }, time: '2026-01-01' })
+    );
+
+    const result = await searchQuickbooksEmployees({});
+
+    expect(result.isError).toBe(false);
+    // Must be the unwrapped array, not the full SDK response
+    expect(result.result).toEqual(mockEmployees);
+    expect(result.result).not.toHaveProperty('QueryResponse');
+  });
+
+  it('should return empty array when no employees match', async () => {
+    (mockQuickBooksInstance.findEmployees as jest.Mock).mockImplementation(
+      (_criteria: any, cb: any) => cb(null, { QueryResponse: {}, time: '2026-01-01' })
+    );
+
+    const result = await searchQuickbooksEmployees({});
+
+    expect(result.isError).toBe(false);
+    expect(result.result).toEqual([]);
+  });
+
+  it('should handle API errors', async () => {
+    (mockQuickBooksInstance.findEmployees as jest.Mock).mockImplementation(
+      (_criteria: any, cb: any) => cb(new Error('API Error'), null)
+    );
+
+    const result = await searchQuickbooksEmployees({});
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('should handle authentication errors', async () => {
+    (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+    const result = await searchQuickbooksEmployees({});
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('Auth failed');
+  });
+});

--- a/tests/unit/helpers/build-quickbooks-search-criteria.test.ts
+++ b/tests/unit/helpers/build-quickbooks-search-criteria.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildQuickbooksSearchCriteria } from '../../../src/helpers/build-quickbooks-search-criteria';
+
+describe('buildQuickbooksSearchCriteria – Fixes #13', () => {
+  it('should pass through a simple criteria object', () => {
+    const input = { Name: 'Foo' };
+    expect(buildQuickbooksSearchCriteria(input)).toEqual(input);
+  });
+
+  it('should pass through an array as-is', () => {
+    const input = [{ field: 'Name', value: 'Foo', operator: '=' }];
+    expect(buildQuickbooksSearchCriteria(input)).toEqual(input);
+  });
+
+  it('should convert advanced options with filters', () => {
+    const input = {
+      filters: [{ field: 'TxnDate', value: '2026-01-01', operator: '>=' }],
+      limit: 10,
+      asc: 'TxnDate',
+    };
+    const result = buildQuickbooksSearchCriteria(input) as Array<Record<string, any>>;
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toContainEqual({ field: 'TxnDate', value: '2026-01-01', operator: '>=' });
+    expect(result).toContainEqual({ field: 'asc', value: 'TxnDate' });
+    expect(result).toContainEqual({ field: 'limit', value: 10 });
+  });
+
+  it('should accept "criteria" as an alias for "filters" and not drop them', () => {
+    // This is the exact scenario from issue #13: criteria + pagination params
+    const input = {
+      criteria: [{ field: 'TxnDate', value: '2026-01-01', operator: '>=' }],
+      limit: 10,
+      asc: 'TxnDate',
+    };
+    const result = buildQuickbooksSearchCriteria(input) as Array<Record<string, any>>;
+
+    expect(Array.isArray(result)).toBe(true);
+    // The filter must NOT be silently dropped
+    expect(result).toContainEqual({ field: 'TxnDate', value: '2026-01-01', operator: '>=' });
+    expect(result).toContainEqual({ field: 'asc', value: 'TxnDate' });
+    expect(result).toContainEqual({ field: 'limit', value: 10 });
+  });
+
+  it('should prefer "filters" over "criteria" if both are provided', () => {
+    const input = {
+      filters: [{ field: 'Name', value: 'A', operator: '=' }],
+      criteria: [{ field: 'Name', value: 'B', operator: '=' }],
+    };
+    const result = buildQuickbooksSearchCriteria(input) as Array<Record<string, any>>;
+
+    expect(result).toContainEqual({ field: 'Name', value: 'A', operator: '=' });
+    expect(result).not.toContainEqual({ field: 'Name', value: 'B', operator: '=' });
+  });
+
+  it('should handle desc, offset, count, and fetchAll options', () => {
+    const input = { desc: 'MetaData.CreateTime', offset: 5, count: true, fetchAll: true };
+    const result = buildQuickbooksSearchCriteria(input) as Array<Record<string, any>>;
+
+    expect(result).toContainEqual({ field: 'desc', value: 'MetaData.CreateTime' });
+    expect(result).toContainEqual({ field: 'offset', value: 5 });
+    expect(result).toContainEqual({ field: 'count', value: true });
+    expect(result).toContainEqual({ field: 'fetchAll', value: true });
+  });
+
+  it('should return empty object when advanced options are all empty', () => {
+    const input = { filters: [] };
+    const result = buildQuickbooksSearchCriteria(input);
+    expect(result).toEqual({});
+  });
+
+  it('should pass through null/undefined as a simple criteria object', () => {
+    // Not advanced, so returned as-is per the pass-through logic
+    expect(buildQuickbooksSearchCriteria(null as any)).toBeNull();
+    expect(buildQuickbooksSearchCriteria(undefined as any)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #13
Fixes #14
Fixes #15

## Summary

- **#14** — `search_purchases` returns raw SDK envelope instead of entity array. Changed to unwrap `QueryResponse.Purchase || []`.
- **#15** — `search_employees` returns raw SDK envelope instead of entity array. Changed to unwrap `QueryResponse.Employee || []`.
- **#13** — `search_purchases` silently drops filter criteria when pagination params are present. `buildQuickbooksSearchCriteria` now accepts `criteria` as an alias for `filters`, so filters are preserved when mixed with `limit`/`asc`/`desc`.

## Changes

- `src/handlers/search-quickbooks-purchases.handler.ts` — unwrap SDK response
- `src/handlers/search-quickbooks-employees.handler.ts` — unwrap SDK response
- `src/helpers/build-quickbooks-search-criteria.ts` — add `criteria` to `AdvancedQuickbooksSearchOptions` interface and detection list, use as fallback when `filters` is absent

## Test plan

- [x] 16 new tests covering all three fixes
- [x] 351 total tests pass with 100% coverage
- [x] `npm run build` compiles cleanly
- [x] Rebased on upstream `main`

🤖 Generated with [Claude Code](https://claude.ai/code)