### PR TITLE
fix: unwrap args.params in vendor and bill tool handlers (#20)

### DIFF
--- a/src/tools/create-bill.tool.ts
+++ b/src/tools/create-bill.tool.ts
@@ -26,7 +26,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await createQuickbooksBill(args.bill);
+  const response = await createQuickbooksBill(args.params.bill);
 
   if (response.isError) {
     return {

--- a/src/tools/create-vendor.tool.ts
+++ b/src/tools/create-vendor.tool.ts
@@ -27,7 +27,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await createQuickbooksVendor(args.vendor);
+  const response = await createQuickbooksVendor(args.params.vendor);
 
   if (response.isError) {
     return {

--- a/src/tools/delete-bill.tool.ts
+++ b/src/tools/delete-bill.tool.ts
@@ -12,7 +12,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await deleteQuickbooksBill(args.bill);
+  const response = await deleteQuickbooksBill(args.params.bill);
 
   if (response.isError) {
     return {

--- a/src/tools/delete-vendor.tool.ts
+++ b/src/tools/delete-vendor.tool.ts
@@ -12,7 +12,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await deleteQuickbooksVendor(args.vendor);
+  const response = await deleteQuickbooksVendor(args.params.vendor);
 
   if (response.isError) {
     return {

--- a/src/tools/get-bill.tool.ts
+++ b/src/tools/get-bill.tool.ts
@@ -9,7 +9,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await getQuickbooksBill(args.id);
+  const response = await getQuickbooksBill(args.params.id);
 
   if (response.isError) {
     return {

--- a/src/tools/get-vendor.tool.ts
+++ b/src/tools/get-vendor.tool.ts
@@ -9,7 +9,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await getQuickbooksVendor(args.id);
+  const response = await getQuickbooksVendor(args.params.id);
 
   if (response.isError) {
     return {

--- a/src/tools/update-bill.tool.ts
+++ b/src/tools/update-bill.tool.ts
@@ -27,7 +27,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await updateQuickbooksBill(args.bill);
+  const response = await updateQuickbooksBill(args.params.bill);
 
   if (response.isError) {
     return {

--- a/src/tools/update-vendor.tool.ts
+++ b/src/tools/update-vendor.tool.ts
@@ -29,7 +29,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await updateQuickbooksVendor(args.vendor);
+  const response = await updateQuickbooksVendor(args.params.vendor);
 
   if (response.isError) {
     return {

--- a/tests/unit/handlers/vendor-bill.handlers.test.ts
+++ b/tests/unit/handlers/vendor-bill.handlers.test.ts
@@ -1,0 +1,366 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+// Dynamic imports after mock setup
+const { createQuickbooksVendor } = await import('../../../src/handlers/create-quickbooks-vendor.handler');
+const { getQuickbooksVendor } = await import('../../../src/handlers/get-quickbooks-vendor.handler');
+const { updateQuickbooksVendor } = await import('../../../src/handlers/update-quickbooks-vendor.handler');
+const { deleteQuickbooksVendor } = await import('../../../src/handlers/delete-quickbooks-vendor.handler');
+const { searchQuickbooksVendors } = await import('../../../src/handlers/search-quickbooks-vendors.handler');
+const { createQuickbooksBill } = await import('../../../src/handlers/create-quickbooks-bill.handler');
+const { getQuickbooksBill } = await import('../../../src/handlers/get-quickbooks-bill.handler');
+const { updateQuickbooksBill } = await import('../../../src/handlers/update-quickbooks-bill.handler');
+const { deleteQuickbooksBill } = await import('../../../src/handlers/delete-quickbooks-bill.handler');
+const { searchQuickbooksBills } = await import('../../../src/handlers/search-quickbooks-bills.handler');
+
+describe('Vendor and Bill Handlers', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Vendor Handlers
+  // ---------------------------------------------------------------------------
+
+  describe('createQuickbooksVendor', () => {
+    it('should create a vendor successfully', async () => {
+      mockQuickBooksInstance.createVendor.mockImplementation((payload: any, cb: any) =>
+        cb(null, { Id: '1', DisplayName: 'Acme Corp' })
+      );
+
+      const result = await createQuickbooksVendor({ DisplayName: 'Acme Corp' });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toMatchObject({ Id: '1' });
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await createQuickbooksVendor({ DisplayName: 'Acme Corp' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error on QBO API failure', async () => {
+      mockQuickBooksInstance.createVendor.mockImplementation((payload: any, cb: any) =>
+        cb(new Error('Create failed'), null)
+      );
+
+      const result = await createQuickbooksVendor({ DisplayName: 'Acme Corp' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Create failed');
+    });
+  });
+
+  describe('getQuickbooksVendor', () => {
+    it('should get a vendor by ID successfully', async () => {
+      mockQuickBooksInstance.getVendor.mockImplementation((id: any, cb: any) =>
+        cb(null, { Id: id, DisplayName: 'Acme Corp' })
+      );
+
+      const result = await getQuickbooksVendor('42');
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toMatchObject({ Id: '42' });
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await getQuickbooksVendor('42');
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error when vendor is not found', async () => {
+      mockQuickBooksInstance.getVendor.mockImplementation((id: any, cb: any) =>
+        cb(new Error('Not found'), null)
+      );
+
+      const result = await getQuickbooksVendor('999');
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Not found');
+    });
+  });
+
+  describe('updateQuickbooksVendor', () => {
+    it('should update a vendor successfully', async () => {
+      mockQuickBooksInstance.updateVendor.mockImplementation((payload: any, cb: any) =>
+        cb(null, { Id: '1', DisplayName: 'Updated Corp', SyncToken: '1' })
+      );
+
+      const result = await updateQuickbooksVendor({
+        Id: '1',
+        SyncToken: '0',
+        DisplayName: 'Updated Corp',
+      });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toMatchObject({ SyncToken: '1' });
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await updateQuickbooksVendor({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error on QBO API failure', async () => {
+      mockQuickBooksInstance.updateVendor.mockImplementation((payload: any, cb: any) =>
+        cb(new Error('Update failed'), null)
+      );
+
+      const result = await updateQuickbooksVendor({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Update failed');
+    });
+  });
+
+  describe('deleteQuickbooksVendor', () => {
+    it('should delete a vendor successfully', async () => {
+      mockQuickBooksInstance.deleteVendor.mockImplementation((payload: any, cb: any) =>
+        cb(null, { Id: '1', status: 'Deleted' })
+      );
+
+      const result = await deleteQuickbooksVendor({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await deleteQuickbooksVendor({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error on QBO API failure', async () => {
+      mockQuickBooksInstance.deleteVendor.mockImplementation((payload: any, cb: any) =>
+        cb(new Error('Delete failed'), null)
+      );
+
+      const result = await deleteQuickbooksVendor({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Delete failed');
+    });
+  });
+
+  describe('searchQuickbooksVendors', () => {
+    it('should search vendors with default criteria', async () => {
+      mockQuickBooksInstance.findVendors.mockImplementation((criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Vendor: [{ Id: '1' }] } })
+      );
+
+      const result = await searchQuickbooksVendors();
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should search vendors with criteria object', async () => {
+      mockQuickBooksInstance.findVendors.mockImplementation((criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Vendor: [{ Id: '1', DisplayName: 'Acme' }] } })
+      );
+
+      const result = await searchQuickbooksVendors({ DisplayName: 'Acme' });
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await searchQuickbooksVendors();
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Bill Handlers
+  // ---------------------------------------------------------------------------
+
+  describe('createQuickbooksBill', () => {
+    const sampleBill = {
+      Line: [{ Amount: 100, DetailType: 'AccountBasedExpenseLineDetail', AccountRef: { value: '1' } }],
+      VendorRef: { value: '42' },
+    };
+
+    it('should create a bill successfully', async () => {
+      mockQuickBooksInstance.createBill.mockImplementation((payload: any, cb: any) =>
+        cb(null, { Id: '10', TotalAmt: 100 })
+      );
+
+      const result = await createQuickbooksBill(sampleBill);
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toMatchObject({ Id: '10' });
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await createQuickbooksBill(sampleBill);
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error on QBO API failure', async () => {
+      mockQuickBooksInstance.createBill.mockImplementation((payload: any, cb: any) =>
+        cb(new Error('Create failed'), null)
+      );
+
+      const result = await createQuickbooksBill(sampleBill);
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Create failed');
+    });
+  });
+
+  describe('getQuickbooksBill', () => {
+    it('should get a bill by ID successfully', async () => {
+      mockQuickBooksInstance.getBill.mockImplementation((id: any, cb: any) =>
+        cb(null, { Id: id, TotalAmt: 200 })
+      );
+
+      const result = await getQuickbooksBill('10');
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toMatchObject({ Id: '10' });
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await getQuickbooksBill('10');
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error when bill is not found', async () => {
+      mockQuickBooksInstance.getBill.mockImplementation((id: any, cb: any) =>
+        cb(new Error('Not found'), null)
+      );
+
+      const result = await getQuickbooksBill('999');
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Not found');
+    });
+  });
+
+  describe('updateQuickbooksBill', () => {
+    it('should update a bill successfully', async () => {
+      mockQuickBooksInstance.updateBill.mockImplementation((payload: any, cb: any) =>
+        cb(null, { Id: '10', SyncToken: '1', TotalAmt: 150 })
+      );
+
+      const result = await updateQuickbooksBill({ Id: '10', SyncToken: '0', TotalAmt: 150 });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toMatchObject({ SyncToken: '1' });
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await updateQuickbooksBill({ Id: '10', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error on QBO API failure', async () => {
+      mockQuickBooksInstance.updateBill.mockImplementation((payload: any, cb: any) =>
+        cb(new Error('Update failed'), null)
+      );
+
+      const result = await updateQuickbooksBill({ Id: '10', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Update failed');
+    });
+  });
+
+  describe('deleteQuickbooksBill', () => {
+    it('should delete a bill successfully', async () => {
+      mockQuickBooksInstance.deleteBill.mockImplementation((payload: any, cb: any) =>
+        cb(null, { Id: '10', status: 'Deleted' })
+      );
+
+      const result = await deleteQuickbooksBill({ Id: '10', SyncToken: '0' });
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await deleteQuickbooksBill({ Id: '10', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+
+    it('should return an error on QBO API failure', async () => {
+      mockQuickBooksInstance.deleteBill.mockImplementation((payload: any, cb: any) =>
+        cb(new Error('Delete failed'), null)
+      );
+
+      const result = await deleteQuickbooksBill({ Id: '10', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Delete failed');
+    });
+  });
+
+  describe('searchQuickbooksBills', () => {
+    it('should search bills with default criteria', async () => {
+      mockQuickBooksInstance.findBills.mockImplementation((criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Bill: [{ Id: '10' }] } })
+      );
+
+      const result = await searchQuickbooksBills();
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should search bills with criteria object', async () => {
+      mockQuickBooksInstance.findBills.mockImplementation((criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Bill: [{ Id: '10' }] } })
+      );
+
+      const result = await searchQuickbooksBills({ VendorRef: '42' });
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should return an error on authentication failure', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await searchQuickbooksBills();
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+  });
+});


### PR DESCRIPTION
[Fixes #20](https://github.com/intuit/quickbooks-online-mcp-server/issues/20)

## What's broken

`RegisterTool` in `src/server/register-tool.ts` wraps every tool schema with `{ params: toolDefinition.schema }`, so the MCP SDK delivers arguments as `{ params: { ...fields } }`. All other tool handlers correctly access `args.params.X` — but the 8 vendor/bill tool handlers access `args.vendor`, `args.bill`, or `args.id` directly, receiving `undefined`.

## Errors this causes

| Tool | Error |
|------|-------|
| `create-vendor`, `create-bill` | `SAXParseException: Premature end of file` — undefined passed to node-quickbooks → empty HTTP body to QBO |
| `update-vendor`, `update-bill` | `TypeError: Cannot read properties of undefined (reading 'Id')` — JS crash before reaching QBO |
| `get-vendor`, `get-bill` | Silent failure — called with undefined ID |
| `delete-vendor`, `delete-bill` | Silent failure — called with undefined object |

## Fix

One-line change in each of the 8 affected tool handlers:
- `args.vendor` → `args.params.vendor`
- `args.bill` → `args.params.bill`
- `args.id` → `args.params.id`

## Tests

Adds `tests/unit/handlers/vendor-bill.handlers.test.ts` — 30 unit tests covering all vendor and bill handler functions (create, get, update, delete, search for each). These handlers had no test coverage previously. All 365 tests pass.