### PR TITLE
fix: resolve Issue #20 - bill/vendor tools fail due to missing args.params unwrapping

### DIFF
--- a/src/tools/create-bill.tool.ts
+++ b/src/tools/create-bill.tool.ts
@@ -26,7 +26,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await createQuickbooksBill(args.bill);
+  const response = await createQuickbooksBill(args.params.bill);
 
   if (response.isError) {
     return {

--- a/src/tools/create-vendor.tool.ts
+++ b/src/tools/create-vendor.tool.ts
@@ -27,7 +27,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await createQuickbooksVendor(args.vendor);
+  const response = await createQuickbooksVendor(args.params.vendor);
 
   if (response.isError) {
     return {

--- a/src/tools/delete-bill.tool.ts
+++ b/src/tools/delete-bill.tool.ts
@@ -12,7 +12,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await deleteQuickbooksBill(args.bill);
+  const response = await deleteQuickbooksBill(args.params.bill);
 
   if (response.isError) {
     return {

--- a/src/tools/delete-vendor.tool.ts
+++ b/src/tools/delete-vendor.tool.ts
@@ -12,7 +12,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await deleteQuickbooksVendor(args.vendor);
+  const response = await deleteQuickbooksVendor(args.params.vendor);
 
   if (response.isError) {
     return {

--- a/src/tools/get-bill.tool.ts
+++ b/src/tools/get-bill.tool.ts
@@ -9,7 +9,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await getQuickbooksBill(args.id);
+  const response = await getQuickbooksBill(args.params.id);
 
   if (response.isError) {
     return {

--- a/src/tools/get-vendor.tool.ts
+++ b/src/tools/get-vendor.tool.ts
@@ -9,7 +9,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await getQuickbooksVendor(args.id);
+  const response = await getQuickbooksVendor(args.params.id);
 
   if (response.isError) {
     return {

--- a/src/tools/update-bill.tool.ts
+++ b/src/tools/update-bill.tool.ts
@@ -27,7 +27,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await updateQuickbooksBill(args.bill);
+  const response = await updateQuickbooksBill(args.params.bill);
 
   if (response.isError) {
     return {

--- a/src/tools/update-vendor.tool.ts
+++ b/src/tools/update-vendor.tool.ts
@@ -29,7 +29,7 @@ const toolSchema = z.object({
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {
-  const response = await updateQuickbooksVendor(args.vendor);
+  const response = await updateQuickbooksVendor(args.params.vendor);
 
   if (response.isError) {
     return {

--- a/tests/unit/handlers/bill.handlers.test.ts
+++ b/tests/unit/handlers/bill.handlers.test.ts
@@ -1,0 +1,229 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+// Dynamic imports after mock setup
+const { createQuickbooksBill } = await import('../../../src/handlers/create-quickbooks-bill.handler');
+const { getQuickbooksBill } = await import('../../../src/handlers/get-quickbooks-bill.handler');
+const { updateQuickbooksBill } = await import('../../../src/handlers/update-quickbooks-bill.handler');
+const { deleteQuickbooksBill } = await import('../../../src/handlers/delete-quickbooks-bill.handler');
+const { searchQuickbooksBills } = await import('../../../src/handlers/search-quickbooks-bills.handler');
+
+describe('Bill Handlers', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  describe('createQuickbooksBill', () => {
+    it('should create a bill successfully', async () => {
+      const mockBill = { Id: '1', TotalAmt: 500, Balance: 500 };
+      mockQuickBooksInstance.createBill.mockImplementation((_payload: any, cb: any) => cb(null, mockBill));
+
+      const result = await createQuickbooksBill({
+        Line: [{ Amount: 500, DetailType: 'AccountBasedExpenseLineDetail', Description: 'Office supplies', AccountRef: { value: '1' } }],
+        VendorRef: { value: '56' },
+        DueDate: '2026-05-01',
+        Balance: 500,
+        TotalAmt: 500,
+      });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockBill);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.createBill.mockImplementation((_payload: any, cb: any) =>
+        cb(new Error('SAXParseException: Premature end of file'), null)
+      );
+
+      const result = await createQuickbooksBill({});
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await createQuickbooksBill({});
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('getQuickbooksBill', () => {
+    it('should get a bill by ID', async () => {
+      const mockBill = { Id: '1', TotalAmt: 500, Balance: 500 };
+      mockQuickBooksInstance.getBill.mockImplementation((_id: any, cb: any) => cb(null, mockBill));
+
+      const result = await getQuickbooksBill('1');
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockBill);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.getBill.mockImplementation((_id: any, cb: any) =>
+        cb(new Error('Not found'), null)
+      );
+
+      const result = await getQuickbooksBill('999');
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await getQuickbooksBill('1');
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('updateQuickbooksBill', () => {
+    it('should update a bill', async () => {
+      const mockUpdated = { Id: '1', TotalAmt: 750, SyncToken: '1' };
+      mockQuickBooksInstance.updateBill.mockImplementation((_payload: any, cb: any) => cb(null, mockUpdated));
+
+      const result = await updateQuickbooksBill({ Id: '1', SyncToken: '0', TotalAmt: 750 });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockUpdated);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.updateBill.mockImplementation((_payload: any, cb: any) =>
+        cb(new Error('Update failed'), null)
+      );
+
+      const result = await updateQuickbooksBill({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await updateQuickbooksBill({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('deleteQuickbooksBill', () => {
+    it('should delete a bill', async () => {
+      const mockDeleted = { Id: '1', status: 'Deleted' };
+      mockQuickBooksInstance.deleteBill.mockImplementation((_payload: any, cb: any) => cb(null, mockDeleted));
+
+      const result = await deleteQuickbooksBill({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockDeleted);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.deleteBill.mockImplementation((_payload: any, cb: any) =>
+        cb(new Error('Delete failed'), null)
+      );
+
+      const result = await deleteQuickbooksBill({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await deleteQuickbooksBill({ Id: '1', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('searchQuickbooksBills', () => {
+    it('should search bills', async () => {
+      const mockBills = [{ Id: '1', TotalAmt: 500 }, { Id: '2', TotalAmt: 300 }];
+      mockQuickBooksInstance.findBills.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Bill: mockBills } })
+      );
+
+      const result = await searchQuickbooksBills({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockBills);
+    });
+
+    it('should search bills with array criteria', async () => {
+      mockQuickBooksInstance.findBills.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Bill: [{ Id: '1', TotalAmt: 500 }] } })
+      );
+
+      const result = await searchQuickbooksBills([
+        { field: 'TotalAmt', value: '500', operator: '>' },
+      ]);
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toHaveLength(1);
+    });
+
+    it('should use default empty criteria when none provided', async () => {
+      mockQuickBooksInstance.findBills.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Bill: [] } })
+      );
+
+      const result = await searchQuickbooksBills();
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual([]);
+    });
+
+    it('should return totalCount for count queries', async () => {
+      mockQuickBooksInstance.findBills.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { totalCount: 42 } })
+      );
+
+      const result = await searchQuickbooksBills({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toBe(42);
+    });
+
+    it('should handle empty QueryResponse', async () => {
+      mockQuickBooksInstance.findBills.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: {} })
+      );
+
+      const result = await searchQuickbooksBills({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual([]);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.findBills.mockImplementation((_criteria: any, cb: any) =>
+        cb(new Error('Search failed'), null)
+      );
+
+      const result = await searchQuickbooksBills({});
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await searchQuickbooksBills({});
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+});

--- a/tests/unit/handlers/vendor.handlers.test.ts
+++ b/tests/unit/handlers/vendor.handlers.test.ts
@@ -1,0 +1,226 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+// Dynamic imports after mock setup
+const { createQuickbooksVendor } = await import('../../../src/handlers/create-quickbooks-vendor.handler');
+const { getQuickbooksVendor } = await import('../../../src/handlers/get-quickbooks-vendor.handler');
+const { updateQuickbooksVendor } = await import('../../../src/handlers/update-quickbooks-vendor.handler');
+const { deleteQuickbooksVendor } = await import('../../../src/handlers/delete-quickbooks-vendor.handler');
+const { searchQuickbooksVendors } = await import('../../../src/handlers/search-quickbooks-vendors.handler');
+
+describe('Vendor Handlers', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  describe('createQuickbooksVendor', () => {
+    it('should create a vendor successfully', async () => {
+      const mockVendor = { Id: '56', DisplayName: 'Acme Corp' };
+      mockQuickBooksInstance.createVendor.mockImplementation((_payload: any, cb: any) => cb(null, mockVendor));
+
+      const result = await createQuickbooksVendor({
+        DisplayName: 'Acme Corp',
+        CompanyName: 'Acme Corp',
+      });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockVendor);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.createVendor.mockImplementation((_payload: any, cb: any) =>
+        cb(new Error('SAXParseException: Premature end of file'), null)
+      );
+
+      const result = await createQuickbooksVendor({});
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await createQuickbooksVendor({});
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('getQuickbooksVendor', () => {
+    it('should get a vendor by ID', async () => {
+      const mockVendor = { Id: '56', DisplayName: 'Acme Corp' };
+      mockQuickBooksInstance.getVendor.mockImplementation((_id: any, cb: any) => cb(null, mockVendor));
+
+      const result = await getQuickbooksVendor('56');
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockVendor);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.getVendor.mockImplementation((_id: any, cb: any) =>
+        cb(new Error('Not found'), null)
+      );
+
+      const result = await getQuickbooksVendor('999');
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await getQuickbooksVendor('56');
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('updateQuickbooksVendor', () => {
+    it('should update a vendor', async () => {
+      const mockUpdated = { Id: '56', DisplayName: 'Acme Corp Updated', SyncToken: '1' };
+      mockQuickBooksInstance.updateVendor.mockImplementation((_payload: any, cb: any) => cb(null, mockUpdated));
+
+      const result = await updateQuickbooksVendor({ Id: '56', SyncToken: '0', DisplayName: 'Acme Corp Updated' });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockUpdated);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.updateVendor.mockImplementation((_payload: any, cb: any) =>
+        cb(new Error('Update failed'), null)
+      );
+
+      const result = await updateQuickbooksVendor({ Id: '56', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await updateQuickbooksVendor({ Id: '56', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('deleteQuickbooksVendor', () => {
+    it('should delete a vendor', async () => {
+      const mockDeleted = { Id: '56', status: 'Deleted' };
+      mockQuickBooksInstance.deleteVendor.mockImplementation((_payload: any, cb: any) => cb(null, mockDeleted));
+
+      const result = await deleteQuickbooksVendor({ Id: '56', SyncToken: '0' });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockDeleted);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.deleteVendor.mockImplementation((_payload: any, cb: any) =>
+        cb(new Error('Delete failed'), null)
+      );
+
+      const result = await deleteQuickbooksVendor({ Id: '56', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await deleteQuickbooksVendor({ Id: '56', SyncToken: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+
+  describe('searchQuickbooksVendors', () => {
+    it('should search vendors', async () => {
+      const mockVendors = [{ Id: '56', DisplayName: 'Acme' }, { Id: '57', DisplayName: 'Globex' }];
+      mockQuickBooksInstance.findVendors.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Vendor: mockVendors } })
+      );
+
+      const result = await searchQuickbooksVendors({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockVendors);
+    });
+
+    it('should search vendors with array criteria', async () => {
+      mockQuickBooksInstance.findVendors.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Vendor: [{ Id: '56', DisplayName: 'Acme' }] } })
+      );
+
+      const result = await searchQuickbooksVendors([
+        { field: 'DisplayName', value: 'Acme', operator: 'LIKE' },
+      ]);
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toHaveLength(1);
+    });
+
+    it('should use default empty criteria when none provided', async () => {
+      mockQuickBooksInstance.findVendors.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Vendor: [] } })
+      );
+
+      const result = await searchQuickbooksVendors();
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual([]);
+    });
+
+    it('should return totalCount for count queries', async () => {
+      mockQuickBooksInstance.findVendors.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { totalCount: 15 } })
+      );
+
+      const result = await searchQuickbooksVendors({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toBe(15);
+    });
+
+    it('should handle empty QueryResponse', async () => {
+      mockQuickBooksInstance.findVendors.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: {} })
+      );
+
+      const result = await searchQuickbooksVendors({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual([]);
+    });
+
+    it('should handle API errors', async () => {
+      mockQuickBooksInstance.findVendors.mockImplementation((_criteria: any, cb: any) =>
+        cb(new Error('Search failed'), null)
+      );
+
+      const result = await searchQuickbooksVendors({});
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await searchQuickbooksVendors({});
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Error: Auth failed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #20.

Eight bill/vendor tool handlers (`create-bill`, `update-bill`, `delete-bill`, `get-bill`, `create-vendor`, `update-vendor`, `delete-vendor`, `get-vendor`) silently fail because they access `args.bill`, `args.vendor`, or `args.id` directly. However, `RegisterTool` wraps every tool schema under `{ params: schema }`, so the handler actually receives `args.params.bill`, `args.params.vendor`, and `args.params.id`.

All other tools in the codebase (added in #10) already use `args.params.*` correctly. These 8 tools predate that PR and were never updated.

## Changes

- **Bug fix (8 files, 1-line change each):** `args.X` → `args.params.X` in all bill/vendor tool handlers
- **Tests (2 new files, 38 tests):** Unit tests for bill and vendor handlers covering create, get, update, delete, and search operations — including error handling, auth failures, count queries, array-form criteria, and default parameters

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` passes — 373 tests, 100% coverage across statements, branches, functions, and lines
- [x] No unrelated changes included