### PR TITLE
feat: streamable http

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-slim AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
@@ -9,7 +9,7 @@ RUN npm run build
 FROM node:22-slim
 WORKDIR /app
 COPY --from=builder /app/package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /app/dist/ ./dist/
 USER node
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-slim AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+FROM node:22-slim
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist/ ./dist/
+USER node
+EXPOSE 8000
+ENV MCP_TRANSPORT=streamable-http
+CMD ["node", "dist/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -756,6 +756,18 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.14",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1245,9 +1257,9 @@
             }
         },
         "node_modules/@jest/reporters/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1276,13 +1288,13 @@
             }
         },
         "node_modules/@jest/reporters/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -1464,26 +1476,66 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.0.tgz",
-            "integrity": "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==",
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "license": "MIT",
             "dependencies": {
-                "ajv": "^6.12.6",
+                "@hono/node-server": "^1.19.9",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
                 "cors": "^2.8.5",
                 "cross-spawn": "^7.0.5",
                 "eventsource": "^3.0.2",
                 "eventsource-parser": "^3.0.0",
-                "express": "^5.0.1",
-                "express-rate-limit": "^7.5.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
-                "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.24.1"
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
             }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.12",
@@ -1919,21 +1971,23 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2262,6 +2316,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
             "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
             "dependencies": {
                 "mime-types": "^3.0.0",
                 "negotiator": "^1.0.0"
@@ -2292,9 +2347,11 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2305,6 +2362,45 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
             }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
@@ -2367,22 +2463,6 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/async": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2391,7 +2471,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
         },
         "node_modules/atob": {
             "version": "2.1.2",
@@ -2404,27 +2485,15 @@
                 "node": ">= 4.5.0"
             }
         },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
-        },
         "node_modules/axios": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/babel-jest": {
@@ -2542,14 +2611,6 @@
                 "baseline-browser-mapping": "dist/cli.js"
             }
         },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "node_modules/big-integer": {
             "version": "1.6.52",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -2564,22 +2625,27 @@
             "integrity": "sha512-sCXkOlWh201V9KAs6lXtzbPQHmVhys/wC0I1vaCjZzZtiskEeNJljIRqirGJ+M+WOf/KL7P7KSpUaqaR6BCq7w=="
         },
         "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/bplist-parser": {
@@ -2594,10 +2660,11 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2702,6 +2769,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2710,6 +2778,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -2722,6 +2791,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "get-intrinsic": "^1.3.0"
@@ -2772,11 +2842,6 @@
                 }
             ],
             "license": "CC-BY-4.0"
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -2932,6 +2997,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -2946,20 +3012,23 @@
             "dev": true
         },
         "node_modules/content-disposition": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/content-type": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2975,6 +3044,7 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2983,14 +3053,10 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
             "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.6.0"
             }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
         },
         "node_modules/cors": {
             "version": "2.8.5",
@@ -3028,17 +3094,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
             }
         },
         "node_modules/date-fns": {
@@ -3158,6 +3213,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3166,6 +3222,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -3195,6 +3252,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -3211,15 +3269,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -3231,7 +3280,8 @@
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.267",
@@ -3269,6 +3319,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -3287,6 +3338,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -3295,6 +3347,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -3303,6 +3356,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -3314,6 +3368,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -3337,7 +3392,8 @@
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -3531,6 +3587,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3605,17 +3662,19 @@
             }
         },
         "node_modules/express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
+                "body-parser": "^2.2.1",
                 "content-disposition": "^1.0.0",
                 "content-type": "^1.0.5",
                 "cookie": "^0.7.1",
                 "cookie-signature": "^1.2.1",
                 "debug": "^4.4.0",
+                "depd": "^2.0.0",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
@@ -3646,9 +3705,13 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+            "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "10.1.0"
+            },
             "engines": {
                 "node": ">= 16"
             },
@@ -3658,19 +3721,6 @@
             "peerDependencies": {
                 "express": ">= 4.11"
             }
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-            "engines": [
-                "node >=0.6.0"
-            ]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -3708,7 +3758,8 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -3716,18 +3767,35 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/fast-xml-parser": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-            "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+            "version": "4.5.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+            "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "strnum": "^1.1.1"
+                "strnum": "^1.0.5"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -3790,9 +3858,10 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
                 "encodeurl": "^2.0.0",
@@ -3802,7 +3871,11 @@
                 "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/find-up": {
@@ -3835,10 +3908,11 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-            "dev": true
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/fn.name": {
             "version": "1.1.0",
@@ -3846,15 +3920,16 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -3894,18 +3969,11 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -3921,6 +3989,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3929,6 +3998,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -3940,6 +4010,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3948,6 +4019,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
             "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4005,6 +4077,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -4038,6 +4111,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -4055,14 +4129,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
             }
         },
         "node_modules/glob": {
@@ -4114,6 +4180,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4135,9 +4202,9 @@
             "dev": true
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4156,27 +4223,6 @@
                 "uglify-js": "^3.1.4"
             }
         },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "deprecated": "this library is no longer supported",
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4190,6 +4236,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -4201,6 +4248,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -4222,6 +4270,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hono": {
+            "version": "4.12.14",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+            "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4230,40 +4287,23 @@
             "license": "MIT"
         },
         "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-            "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/http-errors/node_modules/statuses": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
             "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/human-signals": {
@@ -4275,14 +4315,19 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ignore": {
@@ -4381,10 +4426,20 @@
                 "node": ">=10"
             }
         },
+        "node_modules/ip-address": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -4495,7 +4550,8 @@
         "node_modules/is-promise": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "3.0.0",
@@ -4507,11 +4563,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
         },
         "node_modules/is-wsl": {
             "version": "2.2.0",
@@ -4542,11 +4593,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
@@ -4891,9 +4937,9 @@
             }
         },
         "node_modules/jest-config/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4922,13 +4968,13 @@
             }
         },
         "node_modules/jest-config/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5224,9 +5270,9 @@
             }
         },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5255,13 +5301,13 @@
             }
         },
         "node_modules/jest-runtime/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5322,9 +5368,9 @@
             }
         },
         "node_modules/jest-util/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5418,6 +5464,15 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/jose": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+            "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5426,21 +5481,17 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
-        },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -5468,26 +5519,23 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -5523,20 +5571,6 @@
                 "npm": ">=6"
             }
         },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
         "node_modules/jwa": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
@@ -5548,11 +5582,12 @@
             }
         },
         "node_modules/jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+            "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
+            "license": "MIT",
             "dependencies": {
-                "jwa": "^1.4.1",
+                "jwa": "^1.4.2",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -5726,6 +5761,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -5734,6 +5770,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
             "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -5742,6 +5779,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
             "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -5780,19 +5818,25 @@
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/mimic-fn": {
@@ -5807,10 +5851,11 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5868,6 +5913,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
             "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5887,16 +5933,18 @@
             "license": "MIT"
         },
         "node_modules/node-quickbooks": {
-            "version": "2.0.46",
-            "resolved": "https://registry.npmjs.org/node-quickbooks/-/node-quickbooks-2.0.46.tgz",
-            "integrity": "sha512-vLCjuEb+WbK/ry3nnBL6eUIePJ3UlUuoEz2Pdeq3NC8KLrgX9k6WKSz4r6texrxS1fQTZL0mQ2OkXbuL9oKNbg==",
+            "version": "2.0.50",
+            "resolved": "https://registry.npmjs.org/node-quickbooks/-/node-quickbooks-2.0.50.tgz",
+            "integrity": "sha512-9Pd29th8gRHXoUfrBcXSmCa3rXtrXUHQLT0GQpTn/gW+4vK5hfNndFhXDPJpsr7wCvFqzG+meBtEvot1WzO+kA==",
+            "license": "ISC",
             "dependencies": {
+                "axios": "^1.13.2",
                 "bluebird": "3.3.4",
                 "date-fns": "^2.9.0",
                 "fast-xml-parser": "^4.3.2",
+                "form-data": "^4.0.5",
+                "oauth-1.0a": "^2.2.6",
                 "querystring": "0.2.0",
-                "request": "2.88.0",
-                "request-debug": "0.2.0",
                 "underscore": "1.12.1",
                 "util": "0.10.3",
                 "uuid": "^8.3.2"
@@ -5944,13 +5992,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "engines": {
-                "node": "*"
-            }
+        "node_modules/oauth-1.0a": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+            "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==",
+            "license": "MIT"
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -5964,6 +6010,7 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5975,6 +6022,7 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -6128,6 +6176,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -6189,18 +6238,14 @@
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
-        },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -6210,10 +6255,11 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -6364,6 +6410,7 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
             "dependencies": {
                 "forwarded": "0.2.0",
                 "ipaddr.js": "1.9.1"
@@ -6373,33 +6420,13 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
-        "node_modules/psl": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/lupomontero"
-            }
-        },
-        "node_modules/psl/node_modules/punycode": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">=10"
             }
-        },
-        "node_modules/punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
         },
         "node_modules/pure-rand": {
             "version": "7.0.1",
@@ -6419,9 +6446,10 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
             },
@@ -6490,37 +6518,24 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/raw-body": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-            "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.7.0",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/raw-body/node_modules/iconv-lite": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/react-is": {
@@ -6555,99 +6570,20 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/request-debug": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/request-debug/-/request-debug-0.2.0.tgz",
-            "integrity": "sha512-NWYi/Gz4xKSkK1oPAsLLjMkSbp4aaW77fxPGe7uoKg1bgN7qXKVI5S/Cm/cubTKD62yJd7eKQLdlQ9QRLhgvvA==",
-            "dependencies": {
-                "stringify-clone": "^1.0.0"
-            }
-        },
-        "node_modules/request/node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
-        "node_modules/request/node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/request/node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/request/node_modules/qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/request/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6724,6 +6660,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
             "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
                 "depd": "^2.0.0",
@@ -6889,7 +6826,8 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.7.3",
@@ -6903,30 +6841,36 @@
             }
         },
         "node_modules/send": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
             "dependencies": {
-                "debug": "^4.3.5",
+                "debug": "^4.4.3",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
                 "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "mime-types": "^3.0.1",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
                 "ms": "^2.1.3",
                 "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
-                "statuses": "^2.0.1"
+                "statuses": "^2.0.2"
             },
             "engines": {
                 "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
             "dependencies": {
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
@@ -6935,12 +6879,17 @@
             },
             "engines": {
                 "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -6998,6 +6947,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3",
@@ -7013,12 +6963,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7031,6 +6982,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7048,6 +7000,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7113,30 +7066,6 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
-        "node_modules/sshpk": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -7172,6 +7101,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
             "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -7235,14 +7165,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/stringify-clone": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stringify-clone/-/stringify-clone-1.1.1.tgz",
-            "integrity": "sha512-LIFpvBnQJF3ZGoV770s3feH+wRVCMRSisI8fl1E57WfgKOZKUMaC1r4eJXybwGgXZ/iTTJoK/tsOku1GLPyyxQ==",
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/strip-ansi": {
@@ -7410,20 +7332,9 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6"
-            }
-        },
-        "node_modules/tough-cookie": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-            "dependencies": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            },
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/triple-beam": {
@@ -7528,22 +7439,6 @@
                 "node": ">=0.6.x"
             }
         },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7583,6 +7478,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
             "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
             "dependencies": {
                 "content-type": "^1.0.5",
                 "media-typer": "^1.1.0",
@@ -7654,9 +7550,10 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+            "license": "MIT"
         },
         "node_modules/undici-types": {
             "version": "6.21.0",
@@ -7668,6 +7565,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -7750,6 +7648,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -7758,6 +7657,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7809,19 +7709,6 @@
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
             }
         },
         "node_modules/walker": {
@@ -8045,11 +7932,12 @@
             }
         },
         "node_modules/zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "license": "ISC",
             "peerDependencies": {
-                "zod": "^3.24.1"
+                "zod": "^3.25.28 || ^4"
             }
         }
     },
@@ -8551,6 +8439,12 @@
                 "levn": "^0.4.1"
             }
         },
+        "@hono/node-server": {
+            "version": "1.19.14",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "requires": {}
+        },
         "@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -8888,9 +8782,9 @@
             },
             "dependencies": {
                 "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+                    "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
@@ -8911,12 +8805,12 @@
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.5",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-                    "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+                    "version": "9.0.9",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+                    "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^2.0.1"
+                        "brace-expansion": "^2.0.2"
                     }
                 }
             }
@@ -9058,22 +8952,45 @@
             }
         },
         "@modelcontextprotocol/sdk": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.0.tgz",
-            "integrity": "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==",
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
             "requires": {
-                "ajv": "^6.12.6",
+                "@hono/node-server": "^1.19.9",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
                 "cors": "^2.8.5",
                 "cross-spawn": "^7.0.5",
                 "eventsource": "^3.0.2",
                 "eventsource-parser": "^3.0.0",
-                "express": "^5.0.1",
-                "express-rate-limit": "^7.5.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
-                "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.24.1"
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.18.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+                    "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.3",
+                        "fast-uri": "^3.0.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
             }
         },
         "@napi-rs/wasm-runtime": {
@@ -9396,21 +9313,21 @@
             },
             "dependencies": {
                 "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+                    "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.5",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-                    "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+                    "version": "9.0.9",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+                    "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^2.0.1"
+                        "brace-expansion": "^2.0.2"
                     }
                 }
             }
@@ -9602,14 +9519,41 @@
             "requires": {}
         },
         "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
+            }
+        },
+        "ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "requires": {
+                "ajv": "^8.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.18.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+                    "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.3",
+                        "fast-uri": "^3.0.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
             }
         },
         "ansi-escapes": {
@@ -9652,19 +9596,6 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
-        "asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
-        },
         "async": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -9680,24 +9611,14 @@
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
-        },
-        "aws4": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
-        },
         "axios": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "babel-jest": {
@@ -9782,14 +9703,6 @@
             "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
             "dev": true
         },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
         "big-integer": {
             "version": "1.6.52",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -9801,19 +9714,19 @@
             "integrity": "sha512-sCXkOlWh201V9KAs6lXtzbPQHmVhys/wC0I1vaCjZzZtiskEeNJljIRqirGJ+M+WOf/KL7P7KSpUaqaR6BCq7w=="
         },
         "body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
             "requires": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             }
         },
         "bplist-parser": {
@@ -9825,9 +9738,9 @@
             }
         },
         "brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
@@ -9933,11 +9846,6 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
             "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
             "dev": true
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
         },
         "chalk": {
             "version": "4.1.2",
@@ -10059,12 +9967,9 @@
             "dev": true
         },
         "content-disposition": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-            "requires": {
-                "safe-buffer": "5.2.1"
-            }
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
         },
         "content-type": {
             "version": "1.0.5",
@@ -10086,11 +9991,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
             "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
-        },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
         },
         "cors": {
             "version": "2.8.5",
@@ -10119,14 +10019,6 @@
                 "rndm": "1.2.0",
                 "tsscmp": "1.0.6",
                 "uid-safe": "2.1.5"
-            }
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "requires": {
-                "assert-plus": "^1.0.0"
             }
         },
         "date-fns": {
@@ -10230,15 +10122,6 @@
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
-        },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
         },
         "ecdsa-sig-formatter": {
             "version": "1.0.11",
@@ -10504,17 +10387,18 @@
             }
         },
         "express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "requires": {
                 "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
+                "body-parser": "^2.2.1",
                 "content-disposition": "^1.0.0",
                 "content-type": "^1.0.5",
                 "cookie": "^0.7.1",
                 "cookie-signature": "^1.2.1",
                 "debug": "^4.4.0",
+                "depd": "^2.0.0",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
@@ -10538,20 +10422,12 @@
             }
         },
         "express-rate-limit": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
-            "requires": {}
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+            "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+            "requires": {
+                "ip-address": "10.1.0"
+            }
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -10585,7 +10461,8 @@
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -10593,12 +10470,17 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+        },
         "fast-xml-parser": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-            "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+            "version": "4.5.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+            "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
             "requires": {
-                "strnum": "^1.1.1"
+                "strnum": "^1.0.5"
             }
         },
         "fastq": {
@@ -10648,9 +10530,9 @@
             "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
         },
         "finalhandler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
             "requires": {
                 "debug": "^4.4.0",
                 "encodeurl": "^2.0.0",
@@ -10681,9 +10563,9 @@
             }
         },
         "flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true
         },
         "fn.name": {
@@ -10692,9 +10574,9 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
         },
         "foreground-child": {
             "version": "3.3.1",
@@ -10714,15 +10596,10 @@
                 }
             }
         },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
-        },
         "form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -10823,14 +10700,6 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
         },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -10878,9 +10747,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "dev": true,
             "requires": {
                 "minimist": "^1.2.5",
@@ -10888,20 +10757,6 @@
                 "source-map": "^0.6.1",
                 "uglify-js": "^3.1.4",
                 "wordwrap": "^1.0.0"
-            }
-        },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
-        },
-        "har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "requires": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
             }
         },
         "has-flag": {
@@ -10931,6 +10786,11 @@
                 "function-bind": "^1.1.2"
             }
         },
+        "hono": {
+            "version": "4.12.14",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+            "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="
+        },
         "html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10938,32 +10798,15 @@
             "dev": true
         },
         "http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "requires": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            },
-            "dependencies": {
-                "statuses": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-                    "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-                }
-            }
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             }
         },
         "human-signals": {
@@ -10972,9 +10815,9 @@
             "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="
         },
         "iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             }
@@ -11045,6 +10888,11 @@
                 "rsa-pem-from-mod-exp": "^0.8.4",
                 "winston": "^3.1.0"
             }
+        },
+        "ip-address": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -11122,11 +10970,6 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
             "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-        },
         "is-wsl": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -11146,11 +10989,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-        },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
         },
         "istanbul-lib-coverage": {
             "version": "3.2.2",
@@ -11376,9 +11214,9 @@
             },
             "dependencies": {
                 "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+                    "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
@@ -11399,12 +11237,12 @@
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.5",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-                    "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+                    "version": "9.0.9",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+                    "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^2.0.1"
+                        "brace-expansion": "^2.0.2"
                     }
                 }
             }
@@ -11627,9 +11465,9 @@
             },
             "dependencies": {
                 "brace-expansion": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+                    "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
@@ -11650,12 +11488,12 @@
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.5",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-                    "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+                    "version": "9.0.9",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+                    "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^2.0.1"
+                        "brace-expansion": "^2.0.2"
                     }
                 }
             }
@@ -11704,9 +11542,9 @@
             },
             "dependencies": {
                 "picomatch": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-                    "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+                    "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
                     "dev": true
                 }
             }
@@ -11773,6 +11611,11 @@
                 }
             }
         },
+        "jose": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+            "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11780,18 +11623,13 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
             }
-        },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
         },
         "jsesc": {
             "version": "3.1.0",
@@ -11811,26 +11649,22 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
-        "json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
         },
         "json5": {
             "version": "2.2.3",
@@ -11855,17 +11689,6 @@
                 "semver": "^7.5.4"
             }
         },
-        "jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            }
-        },
         "jwa": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
@@ -11877,11 +11700,11 @@
             }
         },
         "jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+            "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
             "requires": {
-                "jwa": "^1.4.1",
+                "jwa": "^1.4.2",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -12065,9 +11888,9 @@
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
         },
         "mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "requires": {
                 "mime-db": "^1.54.0"
             }
@@ -12078,9 +11901,9 @@
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
         },
         "minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
@@ -12133,17 +11956,18 @@
             "dev": true
         },
         "node-quickbooks": {
-            "version": "2.0.46",
-            "resolved": "https://registry.npmjs.org/node-quickbooks/-/node-quickbooks-2.0.46.tgz",
-            "integrity": "sha512-vLCjuEb+WbK/ry3nnBL6eUIePJ3UlUuoEz2Pdeq3NC8KLrgX9k6WKSz4r6texrxS1fQTZL0mQ2OkXbuL9oKNbg==",
+            "version": "2.0.50",
+            "resolved": "https://registry.npmjs.org/node-quickbooks/-/node-quickbooks-2.0.50.tgz",
+            "integrity": "sha512-9Pd29th8gRHXoUfrBcXSmCa3rXtrXUHQLT0GQpTn/gW+4vK5hfNndFhXDPJpsr7wCvFqzG+meBtEvot1WzO+kA==",
             "requires": {
+                "axios": "^1.13.2",
                 "bluebird": "3.3.4",
                 "date-fns": "^2.9.0",
                 "fast-xml-parser": "^4.3.2",
+                "form-data": "^4.0.5",
+                "oauth-1.0a": "^2.2.6",
                 "querystring": "0.2.0",
-                "request": "2.88.0",
-                "request-debug": "0.2.0",
-                "underscore": "1.12.1",
+                "underscore": "^1.13.8",
                 "util": "0.10.3",
                 "uuid": "^8.3.2"
             }
@@ -12175,10 +11999,10 @@
                 }
             }
         },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        "oauth-1.0a": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+            "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -12345,14 +12169,9 @@
             }
         },
         "path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="
-        },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
         },
         "picocolors": {
             "version": "1.1.1",
@@ -12361,9 +12180,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true
         },
         "pirates": {
@@ -12466,29 +12285,9 @@
             }
         },
         "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
-        "psl": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "requires": {
-                "punycode": "^2.3.1"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-                    "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-                }
-            }
-        },
-        "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
         },
         "pure-rand": {
             "version": "7.0.1",
@@ -12497,9 +12296,9 @@
             "dev": true
         },
         "qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
             "requires": {
                 "side-channel": "^1.1.0"
             }
@@ -12537,24 +12336,14 @@
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
         },
         "raw-body": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-            "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
             "requires": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.7.0",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-                    "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3.0.0"
-                    }
-                }
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             }
         },
         "react-is": {
@@ -12582,81 +12371,16 @@
                 "resolve": "^1.1.6"
             }
         },
-        "request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "mime-db": {
-                    "version": "1.52.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-                    "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-                },
-                "mime-types": {
-                    "version": "2.1.35",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-                    "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-                    "requires": {
-                        "mime-db": "1.52.0"
-                    }
-                },
-                "qs": {
-                    "version": "6.5.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-                    "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-                },
-                "uuid": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-                }
-            }
-        },
-        "request-debug": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/request-debug/-/request-debug-0.2.0.tgz",
-            "integrity": "sha512-NWYi/Gz4xKSkK1oPAsLLjMkSbp4aaW77fxPGe7uoKg1bgN7qXKVI5S/Cm/cubTKD62yJd7eKQLdlQ9QRLhgvvA==",
-            "requires": {
-                "stringify-clone": "^1.0.0"
-            }
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "resolve": {
             "version": "1.22.10",
@@ -12812,27 +12536,27 @@
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
         },
         "send": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
             "requires": {
-                "debug": "^4.3.5",
+                "debug": "^4.4.3",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
                 "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "mime-types": "^3.0.1",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
                 "ms": "^2.1.3",
                 "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
-                "statuses": "^2.0.1"
+                "statuses": "^2.0.2"
             }
         },
         "serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
             "requires": {
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
@@ -12892,12 +12616,12 @@
             }
         },
         "side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "requires": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             }
         },
         "side-channel-map": {
@@ -12960,22 +12684,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
-        },
-        "sshpk": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
         },
         "stack-trace": {
             "version": "0.0.10",
@@ -13048,11 +12756,6 @@
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
             }
-        },
-        "stringify-clone": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stringify-clone/-/stringify-clone-1.1.1.tgz",
-            "integrity": "sha512-LIFpvBnQJF3ZGoV770s3feH+wRVCMRSisI8fl1E57WfgKOZKUMaC1r4eJXybwGgXZ/iTTJoK/tsOku1GLPyyxQ=="
         },
         "strip-ansi": {
             "version": "6.0.1",
@@ -13159,15 +12862,6 @@
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
         },
-        "tough-cookie": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-            "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            }
-        },
         "triple-beam": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -13216,19 +12910,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
             "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
         },
         "type-check": {
             "version": "0.4.0",
@@ -13295,9 +12976,9 @@
             }
         },
         "underscore": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+            "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
         },
         "undici-types": {
             "version": "6.21.0",
@@ -13357,6 +13038,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             },
@@ -13364,7 +13046,8 @@
                 "punycode": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-                    "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+                    "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+                    "dev": true
                 }
             }
         },
@@ -13408,16 +13091,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
         },
         "walker": {
             "version": "1.0.8",
@@ -13573,9 +13246,9 @@
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
         },
         "zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
             "requires": {}
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.6.0",
+                "@modelcontextprotocol/sdk": "^1.8.0",
                 "dotenv": "^16.4.7",
                 "intuit-oauth": "^4.0.0",
                 "node-quickbooks": "^2.0.43",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
         "open": "^9.1.0",
         "zod": "^3.24.2"
     },
+    "overrides": {
+        "underscore": "^1.13.8"
+    },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.6.0",
+        "@modelcontextprotocol/sdk": "^1.8.0",
         "dotenv": "^16.4.7",
         "intuit-oauth": "^4.0.0",
         "node-quickbooks": "^2.0.43",

--- a/src/clients/auth-context.ts
+++ b/src/clients/auth-context.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface AuthContext {
+  accessToken: string;
+}
+
+export const authStorage = new AsyncLocalStorage<AuthContext>();
+
+export function getCurrentAccessToken(): string {
+  const ctx = authStorage.getStore();
+  if (!ctx?.accessToken) {
+    throw new Error("No access token in current request context");
+  }
+  return ctx.accessToken;
+}

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -22,7 +22,7 @@ const redirect_uri = process.env.QUICKBOOKS_REDIRECT_URI || 'http://localhost:80
 
 const isHttpTransport = process.env.MCP_TRANSPORT === 'streamable-http';
 
-// Only require client credentials for stdio mode (HTTP mode uses ToolHive for OAuth)
+// Only require client credentials for stdio mode (HTTP mode receives tokens via Authorization header)
 if (!isHttpTransport && (!client_id || !client_secret || !redirect_uri)) {
   throw Error("Client ID, Client Secret and Redirect URI must be set in environment variables");
 }
@@ -248,7 +248,7 @@ class QuickbooksClient {
   }
 }
 
-// Singleton for stdio mode (not created in HTTP mode where ToolHive handles OAuth)
+// Singleton for stdio mode (not created in HTTP mode where OAuth is handled externally)
 const stdioClient = !isHttpTransport
   ? new QuickbooksClient({
       clientId: client_id!,
@@ -265,22 +265,22 @@ export const quickbooksClient = stdioClient as QuickbooksClient;
 
 /**
  * Creates a per-request QuickBooks client using the provided access token.
- * Used in streamable-http mode where ToolHive injects the token via the
- * Authorization header on each request.
+ * Used in streamable-http mode where the upstream proxy or MCP client
+ * injects the token via the Authorization header on each request.
  */
 export function createQuickBooksClient(accessToken?: string): QuickBooks {
   const token = accessToken || getCurrentAccessToken();
   return new QuickBooks(
-    "",          // clientId — not needed, ToolHive handles OAuth
+    "",          // clientId — not needed, OAuth handled externally
     "",          // clientSecret — not needed
-    token,       // access token from ToolHive
+    token,       // access token from Authorization header
     false,       // no token secret (OAuth 2.0)
     realm_id || "",
     isSandbox,
     false,       // debug
     null,        // minor version
     "2.0",       // oauth version
-    ""           // refresh token — not needed, ToolHive handles refresh
+    ""           // refresh token — not needed, handled externally
   );
 }
 

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import open from 'open';
+import { getCurrentAccessToken } from "./auth-context.js";
 
 dotenv.config();
 
@@ -15,11 +16,14 @@ const client_secret = process.env.QUICKBOOKS_CLIENT_SECRET;
 const refresh_token = process.env.QUICKBOOKS_REFRESH_TOKEN;
 const realm_id = process.env.QUICKBOOKS_REALM_ID;
 const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'sandbox';
+const isSandbox = environment === 'sandbox';
 // Fix for Issue #5: Use env var with underscore (QUICKBOOKS_REDIRECT_URI)
 const redirect_uri = process.env.QUICKBOOKS_REDIRECT_URI || 'http://localhost:8000/callback';
 
-// Only throw error if client_id or client_secret is missing
-if (!client_id || !client_secret || !redirect_uri) {
+const isHttpTransport = process.env.MCP_TRANSPORT === 'streamable-http';
+
+// Only require client credentials for stdio mode (HTTP mode uses ToolHive for OAuth)
+if (!isHttpTransport && (!client_id || !client_secret || !redirect_uri)) {
   throw Error("Client ID, Client Secret and Redirect URI must be set in environment variables");
 }
 
@@ -244,11 +248,51 @@ class QuickbooksClient {
   }
 }
 
-export const quickbooksClient = new QuickbooksClient({
-  clientId: client_id,
-  clientSecret: client_secret,
-  refreshToken: refresh_token,
-  realmId: realm_id,
-  environment: environment,
-  redirectUri: redirect_uri,
-});
+// Singleton for stdio mode (not created in HTTP mode where ToolHive handles OAuth)
+const stdioClient = !isHttpTransport
+  ? new QuickbooksClient({
+      clientId: client_id!,
+      clientSecret: client_secret!,
+      refreshToken: refresh_token,
+      realmId: realm_id,
+      environment: environment,
+      redirectUri: redirect_uri,
+    })
+  : null;
+
+// Legacy export for auth-server.ts (only valid in stdio mode)
+export const quickbooksClient = stdioClient as QuickbooksClient;
+
+/**
+ * Creates a per-request QuickBooks client using the provided access token.
+ * Used in streamable-http mode where ToolHive injects the token via the
+ * Authorization header on each request.
+ */
+export function createQuickBooksClient(accessToken?: string): QuickBooks {
+  const token = accessToken || getCurrentAccessToken();
+  return new QuickBooks(
+    "",          // clientId — not needed, ToolHive handles OAuth
+    "",          // clientSecret — not needed
+    token,       // access token from ToolHive
+    false,       // no token secret (OAuth 2.0)
+    realm_id || "",
+    isSandbox,
+    false,       // debug
+    null,        // minor version
+    "2.0",       // oauth version
+    ""           // refresh token — not needed, ToolHive handles refresh
+  );
+}
+
+/**
+ * Gets a QuickBooks instance for the current request context.
+ * - stdio mode: authenticates using the singleton client (refreshes token if needed)
+ * - streamable-http mode: creates a per-request client with the injected access token
+ */
+export async function getQuickbooks(): Promise<QuickBooks> {
+  if (isHttpTransport) {
+    return createQuickBooksClient();
+  }
+  await stdioClient!.authenticate();
+  return stdioClient!.getQuickbooks();
+}

--- a/src/handlers/create-quickbooks-account.handler.ts
+++ b/src/handlers/create-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -52,8 +52,7 @@ function normalizeAccountPayload(payload: Record<string, any>): Record<string, a
 
 export async function createQuickbooksAccount(data: CreateAccountInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     // Build initial payload then normalize.
     const basePayload: any = {

--- a/src/handlers/create-quickbooks-attachable.handler.ts
+++ b/src/handlers/create-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -15,8 +15,7 @@ export interface CreateAttachableInput {
 
 export async function createQuickbooksAttachable(data: CreateAttachableInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { FileName: data.file_name };
     if (data.note) payload.Note = data.note;
     if (data.category) payload.Category = data.category;

--- a/src/handlers/create-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/create-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksBillPayment(billPaymentData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createBillPayment(billPaymentData, (err: any, billPayment: any) => {

--- a/src/handlers/create-quickbooks-bill.handler.ts
+++ b/src/handlers/create-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksBill(bill: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createBill(bill, (err: any, createdBill: any) => {

--- a/src/handlers/create-quickbooks-class.handler.ts
+++ b/src/handlers/create-quickbooks-class.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CreateClassInput {
 
 export async function createQuickbooksClass(data: CreateClassInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Name: data.name };
     if (data.parent_ref) payload.ParentRef = { value: data.parent_ref };
 

--- a/src/handlers/create-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/create-quickbooks-credit-memo.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -17,8 +17,7 @@ export interface CreateCreditMemoInput {
 
 export async function createQuickbooksCreditMemo(data: CreateCreditMemoInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const creditMemoPayload: any = {
       CustomerRef: { value: data.customer_ref },

--- a/src/handlers/create-quickbooks-customer.handler.ts
+++ b/src/handlers/create-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksCustomer(customerData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createCustomer(customerData, (err: any, customer: any) => {

--- a/src/handlers/create-quickbooks-department.handler.ts
+++ b/src/handlers/create-quickbooks-department.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CreateDepartmentInput {
 
 export async function createQuickbooksDepartment(data: CreateDepartmentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Name: data.name };
     if (data.parent_ref) payload.ParentRef = { value: data.parent_ref };
 

--- a/src/handlers/create-quickbooks-deposit.handler.ts
+++ b/src/handlers/create-quickbooks-deposit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ export interface CreateDepositInput {
 
 export async function createQuickbooksDeposit(data: CreateDepositInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       DepositToAccountRef: { value: data.deposit_to_account_ref },

--- a/src/handlers/create-quickbooks-employee.handler.ts
+++ b/src/handlers/create-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksEmployee(employeeData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createEmployee(employeeData, (err: any, employee: any) => {

--- a/src/handlers/create-quickbooks-estimate.handler.ts
+++ b/src/handlers/create-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksEstimate(estimateData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createEstimate(estimateData, (err: any, estimate: any) => {

--- a/src/handlers/create-quickbooks-invoice.handler.ts
+++ b/src/handlers/create-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -51,8 +51,7 @@ function normalizeInvoiceFields(obj: Record<string, any>): Record<string, any> {
 
 export async function createQuickbooksInvoice(data: CreateInvoiceInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const invoicePayload: any = {
       CustomerRef: { value: data.customer_ref },

--- a/src/handlers/create-quickbooks-item.handler.ts
+++ b/src/handlers/create-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface CreateItemInput {
 
 export async function createQuickbooksItem(data: CreateItemInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       Name: data.name,

--- a/src/handlers/create-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/create-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksJournalEntry(journalEntryData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createJournalEntry(journalEntryData, (err: any, journalEntry: any) => {

--- a/src/handlers/create-quickbooks-payment-method.handler.ts
+++ b/src/handlers/create-quickbooks-payment-method.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface CreatePaymentMethodInput {
 
 export async function createQuickbooksPaymentMethod(data: CreatePaymentMethodInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Name: data.name };
     if (data.type) payload.Type = data.type;
 

--- a/src/handlers/create-quickbooks-payment.handler.ts
+++ b/src/handlers/create-quickbooks-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -20,8 +20,7 @@ export interface CreatePaymentInput {
 
 export async function createQuickbooksPayment(data: CreatePaymentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const paymentPayload: any = {
       CustomerRef: { value: data.customer_ref },

--- a/src/handlers/create-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/create-quickbooks-purchase-order.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -23,8 +23,7 @@ export interface CreatePurchaseOrderInput {
 
 export async function createQuickbooksPurchaseOrder(data: CreatePurchaseOrderInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       VendorRef: { value: data.vendor_ref },

--- a/src/handlers/create-quickbooks-purchase.handler.ts
+++ b/src/handlers/create-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksPurchase(purchaseData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createPurchase(purchaseData, (err: any, purchase: any) => {

--- a/src/handlers/create-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/create-quickbooks-refund-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -19,8 +19,7 @@ export interface CreateRefundReceiptInput {
 
 export async function createQuickbooksRefundReceipt(data: CreateRefundReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const refundReceiptPayload: any = {
       CustomerRef: { value: data.customer_ref },

--- a/src/handlers/create-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/create-quickbooks-sales-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -19,8 +19,7 @@ export interface CreateSalesReceiptInput {
 
 export async function createQuickbooksSalesReceipt(data: CreateSalesReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const salesReceiptPayload: any = {
       CustomerRef: { value: data.customer_ref },

--- a/src/handlers/create-quickbooks-term.handler.ts
+++ b/src/handlers/create-quickbooks-term.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -15,8 +15,7 @@ export interface CreateTermInput {
 
 export async function createQuickbooksTerm(data: CreateTermInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Name: data.name };
     if (data.due_days !== undefined) payload.DueDays = data.due_days;
     if (data.discount_days !== undefined) payload.DiscountDays = data.discount_days;

--- a/src/handlers/create-quickbooks-time-activity.handler.ts
+++ b/src/handlers/create-quickbooks-time-activity.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -20,8 +20,7 @@ export interface CreateTimeActivityInput {
 
 export async function createQuickbooksTimeActivity(data: CreateTimeActivityInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       NameOf: data.name_of,

--- a/src/handlers/create-quickbooks-transfer.handler.ts
+++ b/src/handlers/create-quickbooks-transfer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface CreateTransferInput {
 
 export async function createQuickbooksTransfer(data: CreateTransferInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       FromAccountRef: { value: data.from_account_ref },

--- a/src/handlers/create-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/create-quickbooks-vendor-credit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ export interface CreateVendorCreditInput {
 
 export async function createQuickbooksVendorCredit(data: CreateVendorCreditInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       VendorRef: { value: data.vendor_ref },

--- a/src/handlers/create-quickbooks-vendor.handler.ts
+++ b/src/handlers/create-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksVendor(vendor: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.createVendor(vendor, (err: any, createdVendor: any) => {

--- a/src/handlers/delete-quickbooks-attachable.handler.ts
+++ b/src/handlers/delete-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface DeleteAttachableInput {
 
 export async function deleteQuickbooksAttachable(data: DeleteAttachableInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload = { Id: data.id, SyncToken: data.sync_token };
 
     return new Promise((resolve) => {

--- a/src/handlers/delete-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/delete-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksBillPayment(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.deleteBillPayment(idOrEntity, (err: any, billPayment: any) => {

--- a/src/handlers/delete-quickbooks-bill.handler.ts
+++ b/src/handlers/delete-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksBill(bill: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.deleteBill(bill, (err: any, deletedBill: any) => {

--- a/src/handlers/delete-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/delete-quickbooks-credit-memo.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksCreditMemo(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).deleteCreditMemo(idOrEntity, (err: any, response: any) => {

--- a/src/handlers/delete-quickbooks-customer.handler.ts
+++ b/src/handlers/delete-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksCustomer(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     // node‑quickbooks v1.0.32+ exposes deleteCustomer but some older builds don't.
     const hasDelete = typeof (quickbooks as any).deleteCustomer === "function";

--- a/src/handlers/delete-quickbooks-deposit.handler.ts
+++ b/src/handlers/delete-quickbooks-deposit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksDeposit(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).deleteDeposit(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/delete-quickbooks-employee.handler.ts
+++ b/src/handlers/delete-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksEmployee(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       // Helper to fetch entity when only ID supplied

--- a/src/handlers/delete-quickbooks-estimate.handler.ts
+++ b/src/handlers/delete-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksEstimate(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.deleteEstimate(idOrEntity, (err: any, response: any) => {

--- a/src/handlers/delete-quickbooks-invoice.handler.ts
+++ b/src/handlers/delete-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksInvoice(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       // Try deleteInvoice first if available

--- a/src/handlers/delete-quickbooks-item.handler.ts
+++ b/src/handlers/delete-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksItem(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       // Helper to fetch entity when only ID supplied

--- a/src/handlers/delete-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/delete-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksJournalEntry(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.deleteJournalEntry(idOrEntity, (err: any, journalEntry: any) => {

--- a/src/handlers/delete-quickbooks-payment.handler.ts
+++ b/src/handlers/delete-quickbooks-payment.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksPayment(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).deletePayment(idOrEntity, (err: any, response: any) => {

--- a/src/handlers/delete-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/delete-quickbooks-purchase-order.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksPurchaseOrder(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).deletePurchaseOrder(idOrEntity, (err: any, response: any) => {

--- a/src/handlers/delete-quickbooks-purchase.handler.ts
+++ b/src/handlers/delete-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksPurchase(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.deletePurchase(idOrEntity, (err: any, purchase: any) => {

--- a/src/handlers/delete-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/delete-quickbooks-refund-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksRefundReceipt(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).deleteRefundReceipt(idOrEntity, (err: any, response: any) => {

--- a/src/handlers/delete-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/delete-quickbooks-sales-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksSalesReceipt(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).deleteSalesReceipt(idOrEntity, (err: any, response: any) => {

--- a/src/handlers/delete-quickbooks-time-activity.handler.ts
+++ b/src/handlers/delete-quickbooks-time-activity.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksTimeActivity(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).deleteTimeActivity(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/delete-quickbooks-transfer.handler.ts
+++ b/src/handlers/delete-quickbooks-transfer.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksTransfer(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).deleteTransfer(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/delete-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/delete-quickbooks-vendor-credit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksVendorCredit(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).deleteVendorCredit(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/delete-quickbooks-vendor.handler.ts
+++ b/src/handlers/delete-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksVendor(vendor: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.deleteVendor(vendor, (err: any, deletedVendor: any) => {

--- a/src/handlers/get-quickbooks-account.handler.ts
+++ b/src/handlers/get-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksAccount(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getAccount(id, (err: any, account: any) => {

--- a/src/handlers/get-quickbooks-aged-payables.handler.ts
+++ b/src/handlers/get-quickbooks-aged-payables.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface AgedPayablesOptions {
 
 export async function getQuickbooksAgedPayables(options: AgedPayablesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.vendor) params.vendor = options.vendor;

--- a/src/handlers/get-quickbooks-aged-receivables.handler.ts
+++ b/src/handlers/get-quickbooks-aged-receivables.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface AgedReceivablesOptions {
 
 export async function getQuickbooksAgedReceivables(options: AgedReceivablesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.customer) params.customer = options.customer;

--- a/src/handlers/get-quickbooks-attachable.handler.ts
+++ b/src/handlers/get-quickbooks-attachable.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksAttachable(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getAttachable(id, (err: any, attachable: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-balance-sheet.handler.ts
+++ b/src/handlers/get-quickbooks-balance-sheet.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface BalanceSheetOptions {
 
 export async function getQuickbooksBalanceSheet(options: BalanceSheetOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/get-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksBillPayment(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.getBillPayment(id, (err: any, billPayment: any) => {

--- a/src/handlers/get-quickbooks-bill.handler.ts
+++ b/src/handlers/get-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksBill(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.getBill(id, (err: any, bill: any) => {

--- a/src/handlers/get-quickbooks-cash-flow.handler.ts
+++ b/src/handlers/get-quickbooks-cash-flow.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CashFlowOptions {
 
 export async function getQuickbooksCashFlow(options: CashFlowOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-class.handler.ts
+++ b/src/handlers/get-quickbooks-class.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksClass(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getClass(id, (err: any, cls: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-company-info.handler.ts
+++ b/src/handlers/get-quickbooks-company-info.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksCompanyInfo(companyId?: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const id = companyId || (quickbooks as any).realmId;
 
     return new Promise((resolve) => {

--- a/src/handlers/get-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/get-quickbooks-credit-memo.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksCreditMemo(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getCreditMemo(id, (err: any, creditMemo: any) => {

--- a/src/handlers/get-quickbooks-customer-balance.handler.ts
+++ b/src/handlers/get-quickbooks-customer-balance.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CustomerBalanceOptions {
 
 export async function getQuickbooksCustomerBalance(options: CustomerBalanceOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.customer) params.customer = options.customer;

--- a/src/handlers/get-quickbooks-customer-sales.handler.ts
+++ b/src/handlers/get-quickbooks-customer-sales.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface CustomerSalesOptions {
 
 export async function getQuickbooksCustomerSales(options: CustomerSalesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-customer.handler.ts
+++ b/src/handlers/get-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksCustomer(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getCustomer(id, (err: any, customer: any) => {

--- a/src/handlers/get-quickbooks-department.handler.ts
+++ b/src/handlers/get-quickbooks-department.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksDepartment(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getDepartment(id, (err: any, dept: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-deposit.handler.ts
+++ b/src/handlers/get-quickbooks-deposit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksDeposit(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getDeposit(id, (err: any, deposit: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-employee.handler.ts
+++ b/src/handlers/get-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksEmployee(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.getEmployee(id, (err: any, employee: any) => {

--- a/src/handlers/get-quickbooks-estimate.handler.ts
+++ b/src/handlers/get-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksEstimate(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.getEstimate(id, (err: any, estimate: any) => {

--- a/src/handlers/get-quickbooks-general-ledger.handler.ts
+++ b/src/handlers/get-quickbooks-general-ledger.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface GeneralLedgerOptions {
 
 export async function getQuickbooksGeneralLedger(options: GeneralLedgerOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/get-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksJournalEntry(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.getJournalEntry(id, (err: any, journalEntry: any) => {

--- a/src/handlers/get-quickbooks-payment-method.handler.ts
+++ b/src/handlers/get-quickbooks-payment-method.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksPaymentMethod(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getPaymentMethod(id, (err: any, method: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-payment.handler.ts
+++ b/src/handlers/get-quickbooks-payment.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksPayment(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getPayment(id, (err: any, payment: any) => {

--- a/src/handlers/get-quickbooks-profit-and-loss.handler.ts
+++ b/src/handlers/get-quickbooks-profit-and-loss.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ export interface ProfitAndLossOptions {
 
 export async function getQuickbooksProfitAndLoss(options: ProfitAndLossOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/get-quickbooks-purchase-order.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksPurchaseOrder(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getPurchaseOrder(id, (err: any, po: any) => {

--- a/src/handlers/get-quickbooks-purchase.handler.ts
+++ b/src/handlers/get-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksPurchase(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.getPurchase(id, (err: any, purchase: any) => {

--- a/src/handlers/get-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/get-quickbooks-refund-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksRefundReceipt(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getRefundReceipt(id, (err: any, refundReceipt: any) => {

--- a/src/handlers/get-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/get-quickbooks-sales-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksSalesReceipt(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getSalesReceipt(id, (err: any, salesReceipt: any) => {

--- a/src/handlers/get-quickbooks-tax-agency.handler.ts
+++ b/src/handlers/get-quickbooks-tax-agency.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTaxAgency(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getTaxAgency(id, (err: any, taxAgency: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-tax-code.handler.ts
+++ b/src/handlers/get-quickbooks-tax-code.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTaxCode(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getTaxCode(id, (err: any, taxCode: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-tax-rate.handler.ts
+++ b/src/handlers/get-quickbooks-tax-rate.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTaxRate(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getTaxRate(id, (err: any, taxRate: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-term.handler.ts
+++ b/src/handlers/get-quickbooks-term.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTerm(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getTerm(id, (err: any, term: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-time-activity.handler.ts
+++ b/src/handlers/get-quickbooks-time-activity.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTimeActivity(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getTimeActivity(id, (err: any, activity: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-transfer.handler.ts
+++ b/src/handlers/get-quickbooks-transfer.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTransfer(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getTransfer(id, (err: any, transfer: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-trial-balance.handler.ts
+++ b/src/handlers/get-quickbooks-trial-balance.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface TrialBalanceOptions {
 
 export async function getQuickbooksTrialBalance(options: TrialBalanceOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-vendor-balance.handler.ts
+++ b/src/handlers/get-quickbooks-vendor-balance.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface VendorBalanceOptions {
 
 export async function getQuickbooksVendorBalance(options: VendorBalanceOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.vendor) params.vendor = options.vendor;

--- a/src/handlers/get-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/get-quickbooks-vendor-credit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksVendorCredit(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getVendorCredit(id, (err: any, vc: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-vendor-expenses.handler.ts
+++ b/src/handlers/get-quickbooks-vendor-expenses.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface VendorExpensesOptions {
 
 export async function getQuickbooksVendorExpenses(options: VendorExpensesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-vendor.handler.ts
+++ b/src/handlers/get-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksVendor(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.getVendor(id, (err: any, vendor: any) => {

--- a/src/handlers/read-quickbooks-invoice.handler.ts
+++ b/src/handlers/read-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function readQuickbooksInvoice(invoiceId: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).getInvoice(invoiceId, (err: any, invoice: any) => {

--- a/src/handlers/read-quickbooks-item.handler.ts
+++ b/src/handlers/read-quickbooks-item.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function readQuickbooksItem(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).getItem(id, (err: any, item: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/search-quickbooks-accounts.handler.ts
+++ b/src/handlers/search-quickbooks-accounts.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";
@@ -7,8 +7,7 @@ export type AccountSearchCriteria = QuickbooksSearchCriteriaInput;
 
 export async function searchQuickbooksAccounts(criteria: AccountSearchCriteria): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const normalizedCriteria = buildQuickbooksSearchCriteria(criteria);
 

--- a/src/handlers/search-quickbooks-attachables.handler.ts
+++ b/src/handlers/search-quickbooks-attachables.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchAttachablesInput {
 
 export async function searchQuickbooksAttachables(data: SearchAttachablesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.file_name) criteria.FileName = data.file_name;
     if (data.content_type) criteria.ContentType = data.content_type;

--- a/src/handlers/search-quickbooks-bill-payments.handler.ts
+++ b/src/handlers/search-quickbooks-bill-payments.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksBillPayments(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-bills.handler.ts
+++ b/src/handlers/search-quickbooks-bills.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function searchQuickbooksBills(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).findBills(criteria as any, (err: any, bills: any) => {

--- a/src/handlers/search-quickbooks-classes.handler.ts
+++ b/src/handlers/search-quickbooks-classes.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchClassesInput {
 
 export async function searchQuickbooksClasses(data: SearchClassesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;

--- a/src/handlers/search-quickbooks-credit-memos.handler.ts
+++ b/src/handlers/search-quickbooks-credit-memos.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchCreditMemosInput {
 
 export async function searchQuickbooksCreditMemos(data: SearchCreditMemosInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria: Record<string, any> = {};
 

--- a/src/handlers/search-quickbooks-customers.handler.ts
+++ b/src/handlers/search-quickbooks-customers.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function searchQuickbooksCustomers(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).findCustomers(criteria as any, (err: any, customers: any) => {

--- a/src/handlers/search-quickbooks-departments.handler.ts
+++ b/src/handlers/search-quickbooks-departments.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchDepartmentsInput {
 
 export async function searchQuickbooksDepartments(data: SearchDepartmentsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;

--- a/src/handlers/search-quickbooks-deposits.handler.ts
+++ b/src/handlers/search-quickbooks-deposits.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchDepositsInput {
 
 export async function searchQuickbooksDeposits(data: SearchDepositsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
     if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };

--- a/src/handlers/search-quickbooks-employees.handler.ts
+++ b/src/handlers/search-quickbooks-employees.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksEmployees(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-estimates.handler.ts
+++ b/src/handlers/search-quickbooks-estimates.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function searchQuickbooksEstimates(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).findEstimates(criteria as any, (err: any, estimates: any) => {

--- a/src/handlers/search-quickbooks-invoices.handler.ts
+++ b/src/handlers/search-quickbooks-invoices.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";
@@ -10,8 +10,7 @@ export type InvoiceSearchCriteria = QuickbooksSearchCriteriaInput;
  */
 export async function searchQuickbooksInvoices(criteria: InvoiceSearchCriteria): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const normalizedCriteria = buildQuickbooksSearchCriteria(criteria);
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-items.handler.ts
+++ b/src/handlers/search-quickbooks-items.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";
@@ -7,8 +7,7 @@ export type ItemSearchCriteria = QuickbooksSearchCriteriaInput;
 
 export async function searchQuickbooksItems(criteria: ItemSearchCriteria): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const normalizedCriteria = buildQuickbooksSearchCriteria(criteria);
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-journal-entries.handler.ts
+++ b/src/handlers/search-quickbooks-journal-entries.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksJournalEntries(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-payment-methods.handler.ts
+++ b/src/handlers/search-quickbooks-payment-methods.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchPaymentMethodsInput {
 
 export async function searchQuickbooksPaymentMethods(data: SearchPaymentMethodsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;

--- a/src/handlers/search-quickbooks-payments.handler.ts
+++ b/src/handlers/search-quickbooks-payments.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -12,8 +12,7 @@ export interface SearchPaymentsInput {
 
 export async function searchQuickbooksPayments(data: SearchPaymentsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria: Record<string, any> = {};
 

--- a/src/handlers/search-quickbooks-purchase-orders.handler.ts
+++ b/src/handlers/search-quickbooks-purchase-orders.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchPurchaseOrdersInput {
 
 export async function searchQuickbooksPurchaseOrders(data: SearchPurchaseOrdersInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria: Record<string, any> = {};
     if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;

--- a/src/handlers/search-quickbooks-purchases.handler.ts
+++ b/src/handlers/search-quickbooks-purchases.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksPurchases(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-refund-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-refund-receipts.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchRefundReceiptsInput {
 
 export async function searchQuickbooksRefundReceipts(data: SearchRefundReceiptsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria: Record<string, any> = {};
 

--- a/src/handlers/search-quickbooks-sales-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-sales-receipts.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchSalesReceiptsInput {
 
 export async function searchQuickbooksSalesReceipts(data: SearchSalesReceiptsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const criteria: Record<string, any> = {};
 

--- a/src/handlers/search-quickbooks-tax-agencies.handler.ts
+++ b/src/handlers/search-quickbooks-tax-agencies.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface SearchTaxAgenciesInput {
 
 export async function searchQuickbooksTaxAgencies(data: SearchTaxAgenciesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.DisplayName = data.name;
     if (data.limit) criteria.limit = data.limit;

--- a/src/handlers/search-quickbooks-tax-codes.handler.ts
+++ b/src/handlers/search-quickbooks-tax-codes.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchTaxCodesInput {
 
 export async function searchQuickbooksTaxCodes(data: SearchTaxCodesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;

--- a/src/handlers/search-quickbooks-tax-rates.handler.ts
+++ b/src/handlers/search-quickbooks-tax-rates.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchTaxRatesInput {
 
 export async function searchQuickbooksTaxRates(data: SearchTaxRatesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;

--- a/src/handlers/search-quickbooks-terms.handler.ts
+++ b/src/handlers/search-quickbooks-terms.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchTermsInput {
 
 export async function searchQuickbooksTerms(data: SearchTermsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;

--- a/src/handlers/search-quickbooks-time-activities.handler.ts
+++ b/src/handlers/search-quickbooks-time-activities.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface SearchTimeActivitiesInput {
 
 export async function searchQuickbooksTimeActivities(data: SearchTimeActivitiesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.employee_ref) criteria.EmployeeRef = data.employee_ref;
     if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;

--- a/src/handlers/search-quickbooks-transfers.handler.ts
+++ b/src/handlers/search-quickbooks-transfers.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchTransfersInput {
 
 export async function searchQuickbooksTransfers(data: SearchTransfersInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
     if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };

--- a/src/handlers/search-quickbooks-vendor-credits.handler.ts
+++ b/src/handlers/search-quickbooks-vendor-credits.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface SearchVendorCreditsInput {
 
 export async function searchQuickbooksVendorCredits(data: SearchVendorCreditsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const criteria: Record<string, any> = {};
     if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;
     if (data.limit) criteria.limit = data.limit;

--- a/src/handlers/search-quickbooks-vendors.handler.ts
+++ b/src/handlers/search-quickbooks-vendors.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function searchQuickbooksVendors(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       (quickbooks as any).findVendors(criteria as any, (err: any, vendors: any) => {

--- a/src/handlers/update-quickbooks-account.handler.ts
+++ b/src/handlers/update-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -48,8 +48,7 @@ function normalizePatch(patch: Record<string, any>): Record<string, any> {
 
 export async function updateQuickbooksAccount({ account_id, patch }: UpdateAccountInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const existing: any = await new Promise((res, rej) => {
       (quickbooks as any).getAccount(account_id, (e: any, acc: any) => (e ? rej(e) : res(acc)));
     });

--- a/src/handlers/update-quickbooks-attachable.handler.ts
+++ b/src/handlers/update-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateAttachableInput {
 
 export async function updateQuickbooksAttachable(data: UpdateAttachableInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.file_name) payload.FileName = data.file_name;
     if (data.note) payload.Note = data.note;

--- a/src/handlers/update-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/update-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksBillPayment(billPaymentData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updateBillPayment(billPaymentData, (err: any, billPayment: any) => {

--- a/src/handlers/update-quickbooks-bill.handler.ts
+++ b/src/handlers/update-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksBill(bill: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updateBill(bill, (err: any, updatedBill: any) => {

--- a/src/handlers/update-quickbooks-class.handler.ts
+++ b/src/handlers/update-quickbooks-class.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdateClassInput {
 
 export async function updateQuickbooksClass(data: UpdateClassInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;

--- a/src/handlers/update-quickbooks-company-info.handler.ts
+++ b/src/handlers/update-quickbooks-company-info.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -21,8 +21,7 @@ export interface UpdateCompanyInfoInput {
 
 export async function updateQuickbooksCompanyInfo(data: UpdateCompanyInfoInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.company_name) payload.CompanyName = data.company_name;
     if (data.legal_name) payload.LegalName = data.legal_name;

--- a/src/handlers/update-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/update-quickbooks-credit-memo.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateCreditMemoInput {
 
 export async function updateQuickbooksCreditMemo(data: UpdateCreditMemoInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       Id: data.id,

--- a/src/handlers/update-quickbooks-customer.handler.ts
+++ b/src/handlers/update-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksCustomer(customerData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updateCustomer(customerData, (err: any, customer: any) => {

--- a/src/handlers/update-quickbooks-department.handler.ts
+++ b/src/handlers/update-quickbooks-department.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdateDepartmentInput {
 
 export async function updateQuickbooksDepartment(data: UpdateDepartmentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;

--- a/src/handlers/update-quickbooks-deposit.handler.ts
+++ b/src/handlers/update-quickbooks-deposit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface UpdateDepositInput {
 
 export async function updateQuickbooksDeposit(data: UpdateDepositInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.private_note) payload.PrivateNote = data.private_note;
 

--- a/src/handlers/update-quickbooks-employee.handler.ts
+++ b/src/handlers/update-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksEmployee(employeeData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updateEmployee(employeeData, (err: any, employee: any) => {

--- a/src/handlers/update-quickbooks-estimate.handler.ts
+++ b/src/handlers/update-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksEstimate(estimateData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updateEstimate(estimateData, (err: any, estimate: any) => {

--- a/src/handlers/update-quickbooks-invoice.handler.ts
+++ b/src/handlers/update-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface UpdateInvoiceInput {
 
 export async function updateQuickbooksInvoice({ invoice_id, patch }: UpdateInvoiceInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     // Need SyncToken; fetch existing invoice first
     const existing: any = await new Promise((res, rej) => {

--- a/src/handlers/update-quickbooks-item.handler.ts
+++ b/src/handlers/update-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface UpdateItemInput {
 
 export async function updateQuickbooksItem({ item_id, patch }: UpdateItemInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     // Need SyncToken; fetch existing item first
     const existing: any = await new Promise((res, rej) => {

--- a/src/handlers/update-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/update-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksJournalEntry(journalEntryData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updateJournalEntry(journalEntryData, (err: any, journalEntry: any) => {

--- a/src/handlers/update-quickbooks-payment-method.handler.ts
+++ b/src/handlers/update-quickbooks-payment-method.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdatePaymentMethodInput {
 
 export async function updateQuickbooksPaymentMethod(data: UpdatePaymentMethodInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;

--- a/src/handlers/update-quickbooks-payment.handler.ts
+++ b/src/handlers/update-quickbooks-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface UpdatePaymentInput {
 
 export async function updateQuickbooksPayment(data: UpdatePaymentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const paymentPayload: any = {
       Id: data.id,

--- a/src/handlers/update-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/update-quickbooks-purchase-order.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdatePurchaseOrderInput {
 
 export async function updateQuickbooksPurchaseOrder(data: UpdatePurchaseOrderInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       Id: data.id,

--- a/src/handlers/update-quickbooks-purchase.handler.ts
+++ b/src/handlers/update-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksPurchase(purchaseData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updatePurchase(purchaseData, (err: any, purchase: any) => {

--- a/src/handlers/update-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-refund-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateRefundReceiptInput {
 
 export async function updateQuickbooksRefundReceipt(data: UpdateRefundReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       Id: data.id,

--- a/src/handlers/update-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-sales-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateSalesReceiptInput {
 
 export async function updateQuickbooksSalesReceipt(data: UpdateSalesReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     const payload: any = {
       Id: data.id,

--- a/src/handlers/update-quickbooks-term.handler.ts
+++ b/src/handlers/update-quickbooks-term.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -14,8 +14,7 @@ export interface UpdateTermInput {
 
 export async function updateQuickbooksTerm(data: UpdateTermInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;

--- a/src/handlers/update-quickbooks-time-activity.handler.ts
+++ b/src/handlers/update-quickbooks-time-activity.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface UpdateTimeActivityInput {
 
 export async function updateQuickbooksTimeActivity(data: UpdateTimeActivityInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.hours !== undefined) payload.Hours = data.hours;
     if (data.minutes !== undefined) payload.Minutes = data.minutes;

--- a/src/handlers/update-quickbooks-transfer.handler.ts
+++ b/src/handlers/update-quickbooks-transfer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface UpdateTransferInput {
 
 export async function updateQuickbooksTransfer(data: UpdateTransferInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.from_account_ref) payload.FromAccountRef = { value: data.from_account_ref };
     if (data.to_account_ref) payload.ToAccountRef = { value: data.to_account_ref };

--- a/src/handlers/update-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/update-quickbooks-vendor-credit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdateVendorCreditInput {
 
 export async function updateQuickbooksVendorCredit(data: UpdateVendorCreditInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.vendor_ref) payload.VendorRef = { value: data.vendor_ref };
     if (data.private_note) payload.PrivateNote = data.private_note;

--- a/src/handlers/update-quickbooks-vendor.handler.ts
+++ b/src/handlers/update-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksVendor(vendor: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await getQuickbooks();
 
     return new Promise((resolve) => {
       quickbooks.updateVendor(vendor, (err: any, updatedVendor: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { QuickbooksMCPServer } from "./server/qbo-mcp-server.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { QuickbooksMCPServer, createMcpServer } from "./server/qbo-mcp-server.js";
+import { RegisterTool } from "./helpers/register-tool.js";
+import { authStorage } from "./clients/auth-context.js";
+import http from "node:http";
+
 // import { ListInvoicesTool } from "./tools/list-invoices.tool.js";
 // import { CreateCustomerTool } from "./tools/create-customer.tool.js";
 import { CreateInvoiceTool } from "./tools/create-invoice.tool.js";
-import { RegisterTool } from "./helpers/register-tool.js";
 import { ReadInvoiceTool } from "./tools/read-invoice.tool.js";
 import { SearchInvoicesTool } from "./tools/search-invoices.tool.js";
 import { UpdateInvoiceTool } from "./tools/update-invoice.tool.js";
@@ -197,230 +202,296 @@ import { GetAgedPayablesTool } from "./tools/get-aged-payables.tool.js";
 import { GetVendorExpensesTool } from "./tools/get-vendor-expenses.tool.js";
 import { GetVendorBalanceTool } from "./tools/get-vendor-balance.tool.js";
 
-const main = async () => {
-  // Create an MCP server
-  const server = QuickbooksMCPServer.GetServer();
-  // Add tools for customers
+function registerAllTools(server: McpServer) {
+  // Customers
   RegisterTool(server, CreateCustomerTool);
   RegisterTool(server, GetCustomerTool);
   RegisterTool(server, UpdateCustomerTool);
   RegisterTool(server, DeleteCustomerTool);
   RegisterTool(server, SearchCustomersTool);
-  // Add tools for estimates
+
+  // Estimates
   RegisterTool(server, CreateEstimateTool);
   RegisterTool(server, GetEstimateTool);
   RegisterTool(server, UpdateEstimateTool);
   RegisterTool(server, DeleteEstimateTool);
   RegisterTool(server, SearchEstimatesTool);
-  
-  // Add tools for bills
+
+  // Bills
   RegisterTool(server, CreateBillTool);
   RegisterTool(server, UpdateBillTool);
   RegisterTool(server, DeleteBillTool);
   RegisterTool(server, GetBillTool);
   RegisterTool(server, SearchBillsTool);
 
-
-  // Add tool to read a single invoice
+  // Invoices
   RegisterTool(server, ReadInvoiceTool);
-
-  // Add tool to search invoices
   RegisterTool(server, SearchInvoicesTool);
-
-  // Add tool to create invoice
   RegisterTool(server, CreateInvoiceTool);
-
-  // Add tool to update invoice
   RegisterTool(server, UpdateInvoiceTool);
   RegisterTool(server, DeleteInvoiceTool);
 
-  // Chart of accounts tools
+  // Accounts
   RegisterTool(server, CreateAccountTool);
   RegisterTool(server, GetAccountTool);
   RegisterTool(server, UpdateAccountTool);
   RegisterTool(server, SearchAccountsTool);
 
-  // Add tool to read item
+  // Items
   RegisterTool(server, ReadItemTool);
   RegisterTool(server, SearchItemsTool);
   RegisterTool(server, CreateItemTool);
   RegisterTool(server, UpdateItemTool);
   RegisterTool(server, DeleteItemTool);
 
-  // // Add a tool to create a customer
-  // RegisterTool(server, CreateCustomerTool);
-
-  // // Add tool to list accounts
-  // RegisterTool(server, ListAccountsTool);
-
-  // // Add tool to update a customer
-  // RegisterTool(server, UpdateCustomerTool);
-
-  // Add tools for vendors
+  // Vendors
   RegisterTool(server, CreateVendorTool);
   RegisterTool(server, UpdateVendorTool);
   RegisterTool(server, DeleteVendorTool);
   RegisterTool(server, GetVendorTool);
   RegisterTool(server, SearchVendorsTool);
 
-  // Add tools for employees
+  // Employees
   RegisterTool(server, CreateEmployeeTool);
   RegisterTool(server, GetEmployeeTool);
   RegisterTool(server, UpdateEmployeeTool);
   RegisterTool(server, DeleteEmployeeTool);
   RegisterTool(server, SearchEmployeesTool);
 
-  // Add tools for journal entries
+  // Journal Entries
   RegisterTool(server, CreateJournalEntryTool);
   RegisterTool(server, GetJournalEntryTool);
   RegisterTool(server, UpdateJournalEntryTool);
   RegisterTool(server, DeleteJournalEntryTool);
   RegisterTool(server, SearchJournalEntriesTool);
 
-  // Add tools for bill payments
+  // Bill Payments
   RegisterTool(server, CreateBillPaymentTool);
   RegisterTool(server, GetBillPaymentTool);
   RegisterTool(server, UpdateBillPaymentTool);
   RegisterTool(server, DeleteBillPaymentTool);
   RegisterTool(server, SearchBillPaymentsTool);
 
-  // Add tools for purchases
+  // Purchases
   RegisterTool(server, CreatePurchaseTool);
   RegisterTool(server, GetPurchaseTool);
   RegisterTool(server, UpdatePurchaseTool);
   RegisterTool(server, DeletePurchaseTool);
   RegisterTool(server, SearchPurchasesTool);
 
-  // Add tools for payments
+  // Payments
   RegisterTool(server, CreatePaymentTool);
   RegisterTool(server, GetPaymentTool);
   RegisterTool(server, UpdatePaymentTool);
   RegisterTool(server, DeletePaymentTool);
   RegisterTool(server, SearchPaymentsTool);
 
-  // Add tools for sales receipts
+  // Sales Receipts
   RegisterTool(server, CreateSalesReceiptTool);
   RegisterTool(server, GetSalesReceiptTool);
   RegisterTool(server, UpdateSalesReceiptTool);
   RegisterTool(server, DeleteSalesReceiptTool);
   RegisterTool(server, SearchSalesReceiptsTool);
 
-  // Add tools for credit memos
+  // Credit Memos
   RegisterTool(server, CreateCreditMemoTool);
   RegisterTool(server, GetCreditMemoTool);
   RegisterTool(server, UpdateCreditMemoTool);
   RegisterTool(server, DeleteCreditMemoTool);
   RegisterTool(server, SearchCreditMemosTool);
 
-  // Add tools for refund receipts
+  // Refund Receipts
   RegisterTool(server, CreateRefundReceiptTool);
   RegisterTool(server, GetRefundReceiptTool);
   RegisterTool(server, UpdateRefundReceiptTool);
   RegisterTool(server, DeleteRefundReceiptTool);
   RegisterTool(server, SearchRefundReceiptsTool);
 
-  // Add tools for purchase orders
+  // Purchase Orders
   RegisterTool(server, CreatePurchaseOrderTool);
   RegisterTool(server, GetPurchaseOrderTool);
   RegisterTool(server, UpdatePurchaseOrderTool);
   RegisterTool(server, DeletePurchaseOrderTool);
   RegisterTool(server, SearchPurchaseOrdersTool);
 
-  // Add tools for vendor credits
+  // Vendor Credits
   RegisterTool(server, CreateVendorCreditTool);
   RegisterTool(server, GetVendorCreditTool);
   RegisterTool(server, UpdateVendorCreditTool);
   RegisterTool(server, DeleteVendorCreditTool);
   RegisterTool(server, SearchVendorCreditsTool);
 
-  // Add tools for deposits
+  // Deposits
   RegisterTool(server, CreateDepositTool);
   RegisterTool(server, GetDepositTool);
   RegisterTool(server, UpdateDepositTool);
   RegisterTool(server, DeleteDepositTool);
   RegisterTool(server, SearchDepositsTool);
 
-  // Add tools for transfers
+  // Transfers
   RegisterTool(server, CreateTransferTool);
   RegisterTool(server, GetTransferTool);
   RegisterTool(server, UpdateTransferTool);
   RegisterTool(server, DeleteTransferTool);
   RegisterTool(server, SearchTransfersTool);
 
-  // Add tools for time activities
+  // Time Activities
   RegisterTool(server, CreateTimeActivityTool);
   RegisterTool(server, GetTimeActivityTool);
   RegisterTool(server, UpdateTimeActivityTool);
   RegisterTool(server, DeleteTimeActivityTool);
   RegisterTool(server, SearchTimeActivitiesTool);
 
-  // Add tools for classes
+  // Classes
   RegisterTool(server, CreateClassTool);
   RegisterTool(server, GetClassTool);
   RegisterTool(server, UpdateClassTool);
   RegisterTool(server, SearchClassesTool);
 
-  // Add tools for departments
+  // Departments
   RegisterTool(server, CreateDepartmentTool);
   RegisterTool(server, GetDepartmentTool);
   RegisterTool(server, UpdateDepartmentTool);
   RegisterTool(server, SearchDepartmentsTool);
 
-  // Add tools for terms
+  // Terms
   RegisterTool(server, CreateTermTool);
   RegisterTool(server, GetTermTool);
   RegisterTool(server, UpdateTermTool);
   RegisterTool(server, SearchTermsTool);
 
-  // Add tools for payment methods
+  // Payment Methods
   RegisterTool(server, CreatePaymentMethodTool);
   RegisterTool(server, GetPaymentMethodTool);
   RegisterTool(server, UpdatePaymentMethodTool);
   RegisterTool(server, SearchPaymentMethodsTool);
 
-  // Add tools for tax codes
+  // Tax Codes
   RegisterTool(server, GetTaxCodeTool);
   RegisterTool(server, SearchTaxCodesTool);
 
-  // Add tools for tax rates
+  // Tax Rates
   RegisterTool(server, GetTaxRateTool);
   RegisterTool(server, SearchTaxRatesTool);
 
-  // Add tools for tax agencies
+  // Tax Agencies
   RegisterTool(server, GetTaxAgencyTool);
   RegisterTool(server, SearchTaxAgenciesTool);
 
-  // Add tools for company info
+  // Company Info
   RegisterTool(server, GetCompanyInfoTool);
   RegisterTool(server, UpdateCompanyInfoTool);
 
-  // Add tools for attachables
+  // Attachables
   RegisterTool(server, CreateAttachableTool);
   RegisterTool(server, GetAttachableTool);
   RegisterTool(server, UpdateAttachableTool);
   RegisterTool(server, DeleteAttachableTool);
   RegisterTool(server, SearchAttachablesTool);
 
-  // Add financial report tools
+  // Financial Reports
   RegisterTool(server, GetBalanceSheetTool);
   RegisterTool(server, GetProfitAndLossTool);
   RegisterTool(server, GetCashFlowTool);
   RegisterTool(server, GetTrialBalanceTool);
   RegisterTool(server, GetGeneralLedgerTool);
 
-  // Add sales/AR report tools
+  // Sales/AR Reports
   RegisterTool(server, GetCustomerSalesTool);
   RegisterTool(server, GetAgedReceivablesTool);
   RegisterTool(server, GetCustomerBalanceTool);
 
-  // Add expense/AP report tools
+  // Expense/AP Reports
   RegisterTool(server, GetAgedPayablesTool);
   RegisterTool(server, GetVendorExpensesTool);
   RegisterTool(server, GetVendorBalanceTool);
+}
 
-  // Start receiving messages on stdin and sending messages on stdout
+async function startStdioTransport() {
+  const server = QuickbooksMCPServer.GetServer();
+  registerAllTools(server);
   const transport = new StdioServerTransport();
   await server.connect(transport);
+}
+
+async function startHttpTransport() {
+  const port = parseInt(process.env.PORT || "8000", 10);
+
+  const httpServer = http.createServer(async (req, res) => {
+    // Extract Bearer token from Authorization header
+    const authHeader = req.headers.authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+
+    // Run MCP handling inside AsyncLocalStorage context so tool handlers
+    // can access the per-request access token
+    authStorage.run({ accessToken: token }, async () => {
+      try {
+        const url = new URL(req.url || "/", `http://localhost:${port}`);
+
+        if (url.pathname === "/health") {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("ok");
+          return;
+        }
+
+        if (url.pathname !== "/mcp") {
+          res.writeHead(404);
+          res.end();
+          return;
+        }
+
+        if (req.method === "POST") {
+          // Stateless mode: new server + transport per request
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+          });
+          const server = createMcpServer();
+          registerAllTools(server);
+          await server.connect(transport);
+
+          // Parse request body
+          const body = await new Promise<string>((resolve) => {
+            let data = "";
+            req.on("data", (chunk: Buffer) => { data += chunk.toString(); });
+            req.on("end", () => resolve(data));
+          });
+
+          await transport.handleRequest(req, res, JSON.parse(body));
+        } else if (req.method === "GET") {
+          // SSE not supported in stateless mode
+          res.writeHead(405, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "SSE not supported in stateless mode" }));
+        } else if (req.method === "DELETE") {
+          // Session termination — no-op in stateless mode
+          res.writeHead(200);
+          res.end();
+        } else {
+          res.writeHead(405);
+          res.end();
+        }
+      } catch (error) {
+        console.error("Error handling MCP request:", error);
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+      }
+    });
+  });
+
+  httpServer.listen(port, () => {
+    console.log(`QuickBooks MCP server listening on port ${port} (streamable-http)`);
+  });
+}
+
+const main = async () => {
+  const transportMode = process.env.MCP_TRANSPORT || "stdio";
+
+  if (transportMode === "streamable-http") {
+    await startHttpTransport();
+  } else {
+    await startStdioTransport();
+  }
 };
 
 main().catch((error) => {

--- a/src/server/qbo-mcp-server.ts
+++ b/src/server/qbo-mcp-server.ts
@@ -1,13 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function createMcpServer(): McpServer {
-  return new McpServer({
-    name: "QuickBooks Online MCP Server",
-    version: "1.0.0",
-    capabilities: {
-      tools: {},
-    },
-  });
+  return new McpServer(
+    { name: "QuickBooks Online MCP Server", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
 }
 
 export class QuickbooksMCPServer {

--- a/src/server/qbo-mcp-server.ts
+++ b/src/server/qbo-mcp-server.ts
@@ -1,5 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+export function createMcpServer(): McpServer {
+  return new McpServer({
+    name: "QuickBooks Online MCP Server",
+    version: "1.0.0",
+    capabilities: {
+      tools: {},
+    },
+  });
+}
+
 export class QuickbooksMCPServer {
   private static instance: McpServer | null = null;
 
@@ -7,13 +17,7 @@ export class QuickbooksMCPServer {
 
   public static GetServer(): McpServer {
     if (QuickbooksMCPServer.instance === null) {
-      QuickbooksMCPServer.instance = new McpServer({
-        name: "QuickBooks Online MCP Server",
-        version: "1.0.0",
-        capabilities: {
-          tools: {},
-        },
-      });
+      QuickbooksMCPServer.instance = createMcpServer();
     }
     return QuickbooksMCPServer.instance;
   }

--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -210,12 +210,9 @@ export const mockQuickBooksInstance = {
   reportSalesTaxLiability: jest.fn(),
 };
 
-// Mock QuickBooks client
-export const mockQuickbooksClient = {
-  authenticate: jest.fn<() => Promise<typeof mockQuickBooksInstance>>().mockResolvedValue(mockQuickBooksInstance),
-  getQuickbooks: jest.fn<() => typeof mockQuickBooksInstance>().mockReturnValue(mockQuickBooksInstance),
-  refreshAccessToken: jest.fn<() => Promise<{ access_token: string; expires_in: number }>>().mockResolvedValue({ access_token: 'mock-token', expires_in: 3600 }),
-};
+// Mock getQuickbooks function (replaces the old singleton client mock)
+export const mockGetQuickbooks = jest.fn<() => Promise<typeof mockQuickBooksInstance>>()
+  .mockResolvedValue(mockQuickBooksInstance);
 
 // Helper to create a successful callback mock
 export function mockSuccessCallback<T>(data: T) {
@@ -248,8 +245,6 @@ export function resetAllMocks() {
       (mock as jest.Mock).mockReset();
     }
   });
-  mockQuickbooksClient.authenticate.mockReset();
-  mockQuickbooksClient.getQuickbooks.mockReset();
-  (mockQuickbooksClient.getQuickbooks as any).mockReturnValue(mockQuickBooksInstance);
-  (mockQuickbooksClient.authenticate as any).mockResolvedValue(mockQuickBooksInstance);
+  mockGetQuickbooks.mockReset();
+  mockGetQuickbooks.mockResolvedValue(mockQuickBooksInstance);
 }

--- a/tests/unit/handlers/class.handlers.test.ts
+++ b/tests/unit/handlers/class.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -70,7 +70,7 @@ describe('Class Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksClass('123');
 
@@ -109,7 +109,7 @@ describe('Class Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksClass({ id: '123', sync_token: '0', name: 'Test' });
 
@@ -163,7 +163,7 @@ describe('Class Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksClasses({});
 
@@ -174,7 +174,7 @@ describe('Class Handlers', () => {
 
   describe('createQuickbooksClass', () => {
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksClass({ name: 'Test' });
 

--- a/tests/unit/handlers/company-attachable.handlers.test.ts
+++ b/tests/unit/handlers/company-attachable.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -128,7 +128,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksCompanyInfo({ id: '1', sync_token: '0' });
 
@@ -139,7 +139,7 @@ describe('Company and Attachable Handlers', () => {
 
   describe('getQuickbooksCompanyInfo auth errors', () => {
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCompanyInfo();
 
@@ -184,7 +184,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksAttachable({ file_name: 'test.pdf' });
 
@@ -214,7 +214,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksAttachable('1');
 
@@ -249,7 +249,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksAttachable({ id: '1', sync_token: '0' });
 
@@ -278,7 +278,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksAttachable({ id: '1', sync_token: '0' });
 
@@ -325,7 +325,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksAttachables({});
 

--- a/tests/unit/handlers/credit-memo.handlers.test.ts
+++ b/tests/unit/handlers/credit-memo.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -43,7 +43,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksCreditMemo({ customer_ref: 'cust-1', line_items: [] });
 
@@ -92,7 +92,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCreditMemo('123');
 
@@ -122,7 +122,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksCreditMemo({ id: '123', sync_token: '0' });
 
@@ -167,7 +167,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksCreditMemo({ id: '123', sync_token: '0' });
 
@@ -215,7 +215,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksCreditMemos({});
 

--- a/tests/unit/handlers/department-term-paymentmethod.handlers.test.ts
+++ b/tests/unit/handlers/department-term-paymentmethod.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -91,7 +91,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
       });
 
       it('should handle authentication errors', async () => {
-        (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+        (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
         const result = await searchQuickbooksDepartments({});
 
@@ -112,7 +112,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should create department - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksDepartment({ name: 'Test' });
 
@@ -131,7 +131,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should get department - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksDepartment('1');
 
@@ -150,7 +150,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should update department - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksDepartment({ id: '1', sync_token: '0' });
 
@@ -260,7 +260,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
       });
 
       it('should handle authentication errors', async () => {
-        (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+        (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
         const result = await searchQuickbooksTerms({});
 
@@ -281,7 +281,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should create term - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksTerm({ name: 'Test', due_days: 30 });
 
@@ -300,7 +300,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should get term - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTerm('1');
 
@@ -319,7 +319,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should update term - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksTerm({ id: '1', sync_token: '0' });
 
@@ -403,7 +403,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
       });
 
       it('should handle authentication errors', async () => {
-        (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+        (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
         const result = await searchQuickbooksPaymentMethods({});
 
@@ -424,7 +424,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should create payment method - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksPaymentMethod({ name: 'Test', type: 'NON_CREDIT_CARD' });
 
@@ -443,7 +443,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should get payment method - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksPaymentMethod('1');
 
@@ -462,7 +462,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should update payment method - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksPaymentMethod({ id: '1', sync_token: '0' });
 

--- a/tests/unit/handlers/deposit-transfer.handlers.test.ts
+++ b/tests/unit/handlers/deposit-transfer.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -77,7 +77,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should create a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksDeposit({
         deposit_to_account_ref: 'account-1',
@@ -97,7 +97,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should get a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksDeposit('1');
 
@@ -136,7 +136,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should update a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksDeposit({ id: '1', sync_token: '0' });
 
@@ -163,7 +163,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should delete a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksDeposit({ id: '1', sync_token: '0' });
 
@@ -202,7 +202,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should search deposits - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksDeposits({});
 
@@ -274,7 +274,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should get a transfer - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTransfer('1');
 
@@ -319,7 +319,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should update a transfer - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksTransfer({ id: '1', sync_token: '0' });
 
@@ -346,7 +346,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should delete a transfer - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksTransfer({ id: '1', sync_token: '0' });
 
@@ -375,7 +375,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should search transfers - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTransfers({});
 
@@ -419,7 +419,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Token expired'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Token expired'));
 
       const result = await createQuickbooksTransfer({
         from_account_ref: 'account-1',

--- a/tests/unit/handlers/payment.handlers.test.ts
+++ b/tests/unit/handlers/payment.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -42,7 +42,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksPayment({ customer_ref: 'cust-1', total_amt: 100 });
 
@@ -95,7 +95,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksPayment('123');
 
@@ -161,7 +161,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksPayment({ id: '123', sync_token: '0', total_amt: 150 });
 
@@ -193,7 +193,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksPayment({ id: '123', sync_token: '0' });
 
@@ -237,7 +237,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksPayments({ limit: 10 });
 

--- a/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
+++ b/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -57,7 +57,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should create a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksRefundReceipt({
         customer_ref: 'cust-1',
@@ -90,7 +90,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should get a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksRefundReceipt('1');
 
@@ -131,7 +131,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should update a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksRefundReceipt({ id: '1', sync_token: '0' });
 
@@ -158,7 +158,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should delete a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksRefundReceipt({ id: '1', sync_token: '0' });
 
@@ -187,7 +187,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should search refund receipts - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksRefundReceipts({});
 
@@ -267,7 +267,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should create a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksPurchaseOrder({
         vendor_ref: 'vendor-1',
@@ -300,7 +300,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should get a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksPurchaseOrder('1');
 
@@ -341,7 +341,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should update a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksPurchaseOrder({ id: '1', sync_token: '0' });
 
@@ -368,7 +368,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should delete a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksPurchaseOrder({ id: '1', sync_token: '0' });
 
@@ -397,7 +397,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should search purchase orders - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksPurchaseOrders({});
 
@@ -469,7 +469,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should create a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksVendorCredit({
         vendor_ref: 'vendor-1',
@@ -502,7 +502,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should get a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksVendorCredit('1');
 
@@ -542,7 +542,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should update a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksVendorCredit({ id: '1', sync_token: '0' });
 
@@ -569,7 +569,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should delete a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksVendorCredit({ id: '1', sync_token: '0' });
 
@@ -598,7 +598,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should search vendor credits - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksVendorCredits({});
 

--- a/tests/unit/handlers/reports.handlers.test.ts
+++ b/tests/unit/handlers/reports.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -60,7 +60,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksBalanceSheet({});
 
@@ -115,7 +115,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksProfitAndLoss({});
 
@@ -158,7 +158,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCashFlow({});
 
@@ -201,7 +201,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTrialBalance({});
 
@@ -247,7 +247,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksGeneralLedger({});
 
@@ -291,7 +291,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCustomerSales({});
 
@@ -337,7 +337,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksAgedReceivables({});
 
@@ -380,7 +380,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCustomerBalance({});
 
@@ -425,7 +425,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksAgedPayables({});
 
@@ -470,7 +470,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksVendorExpenses({});
 
@@ -513,7 +513,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksVendorBalance({});
 

--- a/tests/unit/handlers/sales-receipt.handlers.test.ts
+++ b/tests/unit/handlers/sales-receipt.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -43,7 +43,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksSalesReceipt({ customer_ref: 'cust-1', line_items: [] });
 
@@ -94,7 +94,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksSalesReceipt('123');
 
@@ -139,7 +139,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksSalesReceipt({ id: '123', sync_token: '0' });
 
@@ -168,7 +168,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksSalesReceipt({ id: '123', sync_token: '0' });
 
@@ -201,7 +201,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksSalesReceipts({});
 

--- a/tests/unit/handlers/tax-entities.handlers.test.ts
+++ b/tests/unit/handlers/tax-entities.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -75,7 +75,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTaxCodes({});
 
@@ -97,7 +97,7 @@ describe('Tax Entity Handlers', () => {
 
   describe('getQuickbooksTaxCode auth tests', () => {
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTaxCode('1');
 
@@ -128,7 +128,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTaxRate('1');
 
@@ -171,7 +171,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTaxRates({});
 
@@ -213,7 +213,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTaxAgency('1');
 
@@ -267,7 +267,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTaxAgencies({});
 

--- a/tests/unit/handlers/time-activity.handlers.test.ts
+++ b/tests/unit/handlers/time-activity.handlers.test.ts
@@ -1,9 +1,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockGetQuickbooks, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  getQuickbooks: mockGetQuickbooks,
 }));
 
 // Dynamic imports after mock setup
@@ -58,7 +58,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksTimeActivity({ name_of: 'Vendor' });
 
@@ -112,7 +112,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTimeActivity('123');
 
@@ -158,7 +158,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksTimeActivity({ id: '123', sync_token: '0' });
 
@@ -187,7 +187,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksTimeActivity({ id: '123', sync_token: '0' });
 
@@ -220,7 +220,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockGetQuickbooks as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTimeActivities({});
 


### PR DESCRIPTION
## Summary

Adds streamable-http transport and per-user OAuth support for multi-user deployments. The server can now run in two modes selected by the `MCP_TRANSPORT` environment variable:

- **`stdio`** (default) — original behavior, unchanged. For local dev and `npx` usage.
- **`streamable-http`** — HTTP server on port 8000 for containerized/remote deployments.

In HTTP mode, an upstream OAuth proxy or MCP client handles the OAuth2 lifecycle with Intuit and injects the user's access token into each request via the `Authorization: Bearer` header. The MCP server extracts that token per-request and creates a per-request QuickBooks client — no stored credentials, no singleton client, stateless.

## What changed

### Auth architecture (`src/clients/`)
- **New `auth-context.ts`** — `AsyncLocalStorage`-based per-request token context. The HTTP server wraps each inbound request in `authStorage.run()`, and handlers read the token via `getCurrentAccessToken()`.
- **Refactored `quickbooks-client.ts`** — Env var validation guarded for HTTP mode (client credentials not needed when OAuth is handled externally). Added `createQuickBooksClient()` per-request factory and `getQuickbooks()` convenience function that auto-selects between the stdio singleton and the HTTP per-request factory. The `quickbooksClient` singleton export is preserved for `auth-server.ts` / `npm run auth` backward compatibility.

### Transport selection (`src/index.ts`, `src/server/qbo-mcp-server.ts`)
- Tool registration extracted into `registerAllTools()` for reuse across transports.
- **stdio mode**: uses the existing `QuickbooksMCPServer` singleton + `StdioServerTransport`.
- **streamable-http mode**: stateless HTTP server using `StreamableHTTPServerTransport` from MCP SDK. Each POST to `/mcp` creates a fresh server+transport, with the Bearer token injected into `AsyncLocalStorage` context. Includes `/health` endpoint for liveness probes.
- `createMcpServer()` factory exported from `qbo-mcp-server.ts` for HTTP mode (stateless: new server per request).

### Handler updates (139 files)
Mechanical find-and-replace across all handler files:
```diff
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { getQuickbooks } from "../clients/quickbooks-client.js";
 ...
-  await quickbooksClient.authenticate();
-  const quickbooks = quickbooksClient.getQuickbooks();
+  const quickbooks = await getQuickbooks();
```

### Deployment
- **`Dockerfile`** — Multi-stage build (`node:22-slim`), runs as non-root `node` user, sets `MCP_TRANSPORT=streamable-http`, exposes port 8000.
- **`.github/workflows/build.yml`** — Builds and pushes Docker image to GHCR on push to `main`.
- **MCP SDK** bumped from `^1.6.0` to `^1.8.0` (installed v1.20.0) for `StreamableHTTPServerTransport`.

### Tests
- Updated `quickbooks.mock.ts`: replaced `mockQuickbooksClient` (authenticate + getQuickbooks) with `mockGetQuickbooks` (single async mock matching the new `getQuickbooks()` signature).
- All 11 handler test files updated to use the new mock pattern.
- **335 tests pass, 100% coverage maintained.**

## Environment variables

| Variable | Mode | Required | Description |
|---|---|---|---|
| `MCP_TRANSPORT` | both | No | `stdio` (default) or `streamable-http` |
| `QUICKBOOKS_REALM_ID` | both | **Yes** | QBO company ID |
| `QUICKBOOKS_ENVIRONMENT` | both | No | `sandbox` or `production` (default: `sandbox`) |
| `QUICKBOOKS_CLIENT_ID` | stdio | Yes | OAuth client ID (local dev only) |
| `QUICKBOOKS_CLIENT_SECRET` | stdio | Yes | OAuth client secret (local dev only) |
| `QUICKBOOKS_REFRESH_TOKEN` | stdio | Yes | Refresh token (local dev only) |
| `PORT` | http | No | HTTP listen port (default: `8000`) |

## Test plan

- [x] `npm run build` compiles cleanly (TypeScript strict mode)
- [x] `npm test` — 335 tests pass, 100% coverage
- [x] `MCP_TRANSPORT=stdio` (default) works identically to before
- [ ] `MCP_TRANSPORT=streamable-http` starts HTTP server on port 8000
- [ ] Bearer token extraction from `Authorization` header works end-to-end
- [ ] Docker image builds and runs with `MCP_TRANSPORT=streamable-http`
- [ ] `npm run auth` still works for local stdio development flow