### PR TITLE
fix: pass capabilities as second `McpServer` argument

### DIFF
--- a/src/server/qbo-mcp-server.ts
+++ b/src/server/qbo-mcp-server.ts
@@ -7,13 +7,17 @@ export class QuickbooksMCPServer {
 
   public static GetServer(): McpServer {
     if (QuickbooksMCPServer.instance === null) {
-      QuickbooksMCPServer.instance = new McpServer({
-        name: "QuickBooks Online MCP Server",
-        version: "1.0.0",
-        capabilities: {
-          tools: {},
+      QuickbooksMCPServer.instance = new McpServer(
+        {
+          name: "QuickBooks Online MCP Server",
+          version: "1.0.0",
         },
-      });
+        {
+          capabilities: {
+            tools: {},
+          },
+        }
+      );
     }
     return QuickbooksMCPServer.instance;
   }


### PR DESCRIPTION
Fixes #24.

## Problem

`src/server/qbo-mcp-server.ts` fails to compile with:

```
src/server/qbo-mcp-server.ts(13,9): error TS2353: Object literal may only
specify known properties, and 'capabilities' does not exist in type
'{ version: string; name: string; ... }'
```

The `McpServer` constructor from `@modelcontextprotocol/sdk` takes server implementation info in its first argument and server options (including `capabilities`) in its second argument. The current code nests `capabilities` inside the first argument, which the SDK's `Implementation` type does not allow.

## Fix

Split the single object into the two-argument form:

```ts
new McpServer(
  { name: "...", version: "..." },
  { capabilities: { tools: {} } }
)
```

## Verification

- Build fails on `main` with TS2353 on line 13
- Build passes with this change
