### PR TITLE
fix: add missing `@jest/globals` devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@jest/globals": "^30.3.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.13.10",
         "eslint": "^9.22.0",


### PR DESCRIPTION
Fixes #29.

## Problem

The test suite imports from `@jest/globals` throughout `tests/unit/`:

```ts
import { jest, describe, it, expect, beforeEach } from '@jest/globals';
```

but `@jest/globals` is not declared in `devDependencies`. On a fresh install, 11 of 12 test suites fail to compile with:

```
Cannot find module '@jest/globals' or its corresponding type declarations.
```

335 tests are skipped as a result.

## Fix

Add `@jest/globals` to `devDependencies` at `^30.3.0` (compatible with the installed `jest@^30.2.0`).

## Verification

- Before: 11 test suites fail, 6 tests pass (only `format-error.test.ts` runs)
- After: 12 test suites pass, 335 tests pass, coverage thresholds met
