### PR TITLE
fix: nest `AccountRef` inside `AccountBasedExpenseLineDetail` in bill schemas

### DIFF
--- a/src/tools/create-bill.tool.ts
+++ b/src/tools/create-bill.tool.ts
@@ -10,9 +10,11 @@ const toolSchema = z.object({
       Amount: z.number(),
       DetailType: z.string(),
       Description: z.string(),
-      AccountRef: z.object({
-        value: z.string(),
-        name: z.string().optional(),
+      AccountBasedExpenseLineDetail: z.object({
+        AccountRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }),
       }),
     })),
     VendorRef: z.object({

--- a/src/tools/update-bill.tool.ts
+++ b/src/tools/update-bill.tool.ts
@@ -11,9 +11,11 @@ const toolSchema = z.object({
       Amount: z.number(),
       DetailType: z.string(),
       Description: z.string(),
-      AccountRef: z.object({
-        value: z.string(),
-        name: z.string().optional(),
+      AccountBasedExpenseLineDetail: z.object({
+        AccountRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }),
       }),
     })),
     VendorRef: z.object({


### PR DESCRIPTION
Fixes #27.

## Problem

The `create-bill` and `update-bill` tool schemas place `AccountRef` at the top of each expense line item:

```ts
Line: z.array(z.object({
  Amount, DetailType, Description,
  AccountRef: z.object({ value, name }),
}))
```

QuickBooks Online's Bill entity requires `AccountRef` to be nested inside an `AccountBasedExpenseLineDetail` object on each line item. Sending `AccountRef` at the line-item top level causes QBO to reject the request.

## Fix

Update both schemas to match the documented QBO shape:

```ts
Line: z.array(z.object({
  Amount, DetailType, Description,
  AccountBasedExpenseLineDetail: z.object({
    AccountRef: z.object({ value, name }),
  }),
}))
```

Handlers already forward the payload verbatim to the QBO SDK, so no handler changes are needed.

## Tests

No new tests added. The existing test suite is broken on `main` (see #29 / #30), and tool-schema files cannot currently be imported from tests without triggering a `TS2589` "type instantiation is excessively deep" error on the `ToolDefinition<typeof toolSchema>` export — a latent issue independent of this change. Happy to add schema-validation tests in a follow-up once the tool-file generics are relaxed or the test infra is sorted.

## Relation to other PRs

#12 restructures `update-bill` Line items similarly as part of a larger change (also modifies purchase tools and adds attachable tools). This PR is a focused, schema-only fix that covers both `create-bill` and `update-bill` without touching unrelated areas, so it may be easier to review and land independently.
