### PR TITLE
feat: add item_ref support to update_time_activity

### DIFF
--- a/src/handlers/update-quickbooks-time-activity.handler.ts
+++ b/src/handlers/update-quickbooks-time-activity.handler.ts
@@ -9,6 +9,7 @@ export interface UpdateTimeActivityInput {
   minutes?: number;
   description?: string;
   billable_status?: "Billable" | "NotBillable" | "HasBeenBilled";
+  item_ref?: string;
 }
 
 export async function updateQuickbooksTimeActivity(data: UpdateTimeActivityInput): Promise<ToolResponse<any>> {
@@ -20,6 +21,7 @@ export async function updateQuickbooksTimeActivity(data: UpdateTimeActivityInput
     if (data.minutes !== undefined) payload.Minutes = data.minutes;
     if (data.description) payload.Description = data.description;
     if (data.billable_status) payload.BillableStatus = data.billable_status;
+    if (data.item_ref) payload.ItemRef = { value: data.item_ref };
 
     return new Promise((resolve) => {
       (quickbooks as any).updateTimeActivity(payload, (err: any, updated: any) => {

--- a/src/tools/update-time-activity.tool.ts
+++ b/src/tools/update-time-activity.tool.ts
@@ -11,6 +11,7 @@ const toolSchema = z.object({
   minutes: z.number().optional().describe("Minutes worked"),
   description: z.string().optional().describe("Description"),
   billable_status: z.enum(["Billable", "NotBillable", "HasBeenBilled"]).optional().describe("Billable status"),
+  item_ref: z.string().optional().describe("Service Item ID (ItemRef) — the QBO Item to associate with this time entry"),
 });
 
 const toolHandler = async ({ params }: any) => {


### PR DESCRIPTION
## Summary

The `create_time_activity` tool accepts `item_ref` (mapped to QBO `ItemRef`), but the symmetric `update_time_activity` tool does not. This means if a time entry is created without a service item, or with the wrong one, the only way to fix the `ItemRef` is to delete and recreate the entry — which loses the stable QBO `Id` and any downstream references.

This PR adds `item_ref` to `update_time_activity` so existing entries can be corrected in place, matching the create-side behavior.

## Changes

- `src/tools/update-time-activity.tool.ts` — add `item_ref: z.string().optional()` to the Zod schema
- `src/handlers/update-quickbooks-time-activity.handler.ts` — add `item_ref?: string` to the input interface and `if (data.item_ref) payload.ItemRef = { value: data.item_ref }` to the payload builder

Three lines added, no logic removed, no behavior change for callers that don't pass `item_ref`.

## Test plan

- [x] `npm run build` passes
- [x] Verified `item_ref` reaches `dist/` in both compiled files
- [ ] End-to-end exercise against QBO production (TimeActivity update with `item_ref` attached) — planned locally this week; happy to report results here once run
- [ ] No new unit tests added (the repo's existing update-tool pattern doesn't appear to exercise other optional fields in tests; happy to add one if the maintainers would like a precedent)