### PR TITLE
fix: load .env relative to compiled binary instead of process CWD

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -7,9 +7,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import open from 'open';
 
-dotenv.config();
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '..', '..', '.env') });
 const client_id = process.env.QUICKBOOKS_CLIENT_ID;
 const client_secret = process.env.QUICKBOOKS_CLIENT_SECRET;
 const refresh_token = process.env.QUICKBOOKS_REFRESH_TOKEN;


### PR DESCRIPTION
## Problem

`dotenv.config()` in `src/clients/quickbooks-client.ts:10` reads `.env` from `process.cwd()`. When the MCP server is registered with Claude Desktop, Claude Code, or any other stdio client that spawns the process from a directory other than the project root, `.env` is silently not loaded, and the server throws at import time:

```
Error: Client ID, Client Secret and Redirect URI must be set in environment variables
```

The README's own integration instructions trigger this. Both Claude Desktop's `claude_desktop_config.json` and `claude mcp add …` launch the stdio binary from a CWD outside the project, so the advertised integration doesn't work out of the box — users hit the error and either have to duplicate every secret into their MCP client config or wrap the command in a shell `cd`.

## Fix

Resolve `.env` relative to the compiled binary using `import.meta.url`, matching how `saveTokensToEnv()` already locates the same file at `src/clients/quickbooks-client.ts:157`:

```diff
- dotenv.config();
-
  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+ dotenv.config({ path: path.join(__dirname, '..', '..', '.env') });
```

Three-line change, no behavior change for users who were already running `node dist/index.js` from the project root (dotenv would find `.env` either way). Only affects the broken case.

## Test plan

- [x] Confirmed the server fails at import without this fix when launched via `claude mcp add quickbooks -s user -- node /abs/path/dist/index.js` (CWD is the client's, not the project's)
- [x] Confirmed it starts cleanly with the fix from the same registration
- [x] Confirmed `saveTokensToEnv()` still writes to the same location (both paths resolve to `<project>/.env`)
- [x] `pnpm run build` passes

## Notes

No unit tests exist for `quickbooks-client.ts` today — `dotenv.config()` runs as a side effect at module import, making the module not testable without refactoring. This PR keeps the scope minimal; happy to follow up with a testability refactor in a separate PR if the maintainers want.