### PR TITLE
feat: add search_budgets tool (read-only QBO Budget entity)

### DIFF
--- a/src/handlers/search-quickbooks-budgets.handler.ts
+++ b/src/handlers/search-quickbooks-budgets.handler.ts
@@ -1,0 +1,29 @@
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { ToolResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+
+export interface SearchBudgetsInput {
+  name?: string;
+  active?: boolean;
+  limit?: number;
+}
+
+export async function searchQuickbooksBudgets(data: SearchBudgetsInput): Promise<ToolResponse<any>> {
+  try {
+    await quickbooksClient.authenticate();
+    const quickbooks = quickbooksClient.getQuickbooks();
+    const criteria: Record<string, any> = {};
+    if (data.name) criteria.Name = data.name;
+    if (data.active !== undefined) criteria.Active = data.active;
+    if (data.limit) criteria.limit = data.limit;
+
+    return new Promise((resolve) => {
+      (quickbooks as any).findBudgets(criteria, (err: any, result: any) => {
+        if (err) resolve({ result: null, isError: true, error: formatError(err) });
+        else resolve({ result: result?.QueryResponse?.Budget || [], isError: false, error: null });
+      });
+    });
+  } catch (error) {
+    return { result: null, isError: true, error: formatError(error) };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,9 @@ import { GetPaymentMethodTool } from "./tools/get-payment-method.tool.js";
 import { UpdatePaymentMethodTool } from "./tools/update-payment-method.tool.js";
 import { SearchPaymentMethodsTool } from "./tools/search-payment-methods.tool.js";
 
+// Budget tools (read-only in QBO v3 API)
+import { SearchBudgetsTool } from "./tools/search-budgets.tool.js";
+
 // Tax Code tools
 import { GetTaxCodeTool } from "./tools/get-tax-code.tool.js";
 import { SearchTaxCodesTool } from "./tools/search-tax-codes.tool.js";
@@ -377,6 +380,9 @@ const main = async () => {
   RegisterTool(server, GetPaymentMethodTool);
   RegisterTool(server, UpdatePaymentMethodTool);
   RegisterTool(server, SearchPaymentMethodsTool);
+
+  // Add tools for budgets (read-only)
+  RegisterTool(server, SearchBudgetsTool);
 
   // Add tools for tax codes
   RegisterTool(server, GetTaxCodeTool);

--- a/src/tools/search-budgets.tool.ts
+++ b/src/tools/search-budgets.tool.ts
@@ -1,0 +1,19 @@
+import { searchQuickbooksBudgets } from "../handlers/search-quickbooks-budgets.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+
+const toolName = "search_budgets";
+const toolDescription = "Search for budgets in QuickBooks Online. Returns Budget records with nested BudgetDetail line items (Amount, BudgetDate, AccountRef, ClassRef, CustomerRef, DepartmentRef, LocationRef). Budget is read-only in the QBO v3 API.";
+const toolSchema = z.object({
+  name: z.string().optional().describe("Filter by budget name"),
+  active: z.boolean().optional().describe("Filter by active status"),
+  limit: z.number().optional().describe("Maximum results to return"),
+});
+
+const toolHandler = async ({ params }: any) => {
+  const response = await searchQuickbooksBudgets(params);
+  if (response.isError) return { content: [{ type: "text" as const, text: `Error: ${response.error}` }] };
+  return { content: [{ type: "text" as const, text: `Found ${response.result.length} budgets:` }, { type: "text" as const, text: JSON.stringify(response.result, null, 2) }] };
+};
+
+export const SearchBudgetsTool: ToolDefinition<typeof toolSchema> = { name: toolName, description: toolDescription, schema: toolSchema, handler: toolHandler };

--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -169,6 +169,9 @@ export const mockQuickBooksInstance = {
   updatePaymentMethod: jest.fn(),
   findPaymentMethods: jest.fn(),
 
+  // Budget methods (read-only in QBO v3 API)
+  findBudgets: jest.fn(),
+
   // TaxCode methods
   getTaxCode: jest.fn(),
   findTaxCodes: jest.fn(),

--- a/tests/unit/handlers/budget.handlers.test.ts
+++ b/tests/unit/handlers/budget.handlers.test.ts
@@ -1,0 +1,81 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+const { searchQuickbooksBudgets } = await import('../../../src/handlers/search-quickbooks-budgets.handler');
+
+describe('Budget Handlers', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  describe('searchQuickbooksBudgets', () => {
+    it('should return budgets from QueryResponse.Budget', async () => {
+      const mockBudgets = [
+        {
+          Id: '1',
+          Name: 'FY2026 Operating',
+          BudgetType: 'ProfitAndLoss',
+          StartDate: '2025-07-01',
+          EndDate: '2026-06-30',
+          Active: true,
+          BudgetDetail: [
+            { AccountRef: { value: '80', name: '40000 Revenue' }, Amount: 100000, BudgetDate: '2025-07-01' },
+          ],
+        },
+      ];
+      mockQuickBooksInstance.findBudgets.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: { Budget: mockBudgets } })
+      );
+
+      const result = await searchQuickbooksBudgets({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockBudgets);
+    });
+
+    it('should pass supported filters through to findBudgets', async () => {
+      mockQuickBooksInstance.findBudgets.mockImplementation((criteria: any, cb: any) => {
+        expect(criteria).toEqual({ Name: 'FY2026 Operating', Active: true, limit: 10 });
+        cb(null, { QueryResponse: { Budget: [] } });
+      });
+
+      const result = await searchQuickbooksBudgets({ name: 'FY2026 Operating', active: true, limit: 10 });
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should return an empty array when QueryResponse has no Budget key', async () => {
+      mockQuickBooksInstance.findBudgets.mockImplementation((_criteria: any, cb: any) =>
+        cb(null, { QueryResponse: {} })
+      );
+
+      const result = await searchQuickbooksBudgets({});
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual([]);
+    });
+
+    it('should propagate API errors', async () => {
+      mockQuickBooksInstance.findBudgets.mockImplementation((_criteria: any, cb: any) =>
+        cb(new Error('Query failed'), null)
+      );
+
+      const result = await searchQuickbooksBudgets({});
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('should propagate authentication errors', async () => {
+      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+      const result = await searchQuickbooksBudgets({});
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Auth failed');
+    });
+  });
+});

--- a/tests/unit/handlers/budget.prototype-shape.test.ts
+++ b/tests/unit/handlers/budget.prototype-shape.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Prototype-shape contract test for search_budgets.
+ *
+ * Exercises the handler against the real node-quickbooks prototype (not the
+ * hand-rolled mock) so any future drift between the handler's method name and
+ * the library's prototype method name fails loudly in CI without needing
+ * network or credentials.
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import QuickBooks from 'node-quickbooks';
+
+const mockQuickbooksClient = {
+  authenticate: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  getQuickbooks: jest.fn<() => QuickBooks>(),
+};
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+const { searchQuickbooksBudgets } = await import('../../../src/handlers/search-quickbooks-budgets.handler');
+
+describe('search_budgets prototype-shape contract', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockQuickbooksClient.authenticate.mockResolvedValue(undefined);
+  });
+
+  it('node-quickbooks exposes findBudgets on its prototype', () => {
+    expect(typeof (QuickBooks.prototype as any).findBudgets).toBe('function');
+  });
+
+  it('handler invokes a method that exists on the real QuickBooks prototype', async () => {
+    const qb = Object.create(QuickBooks.prototype) as QuickBooks;
+    mockQuickbooksClient.getQuickbooks.mockReturnValue(qb);
+
+    const spy = jest
+      .spyOn(QuickBooks.prototype as any, 'findBudgets')
+      .mockImplementation(function (this: unknown, _criteria: any, cb: any) {
+        cb(null, { QueryResponse: { Budget: [{ Id: '1', Name: 'FY26', BudgetType: 'ProfitAndLoss' }] } });
+      });
+
+    const result = await searchQuickbooksBudgets({ name: 'FY26' });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(false);
+    expect(result.result).toEqual([{ Id: '1', Name: 'FY26', BudgetType: 'ProfitAndLoss' }]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `search_budgets` MCP tool that exposes the QBO Budget entity for read-only retrieval, using the existing `node-quickbooks` `findBudgets` wrapper. Mirrors the shape of `search_classes`.

Motivation: the Budget entity (with its nested `BudgetDetail` line items) is the only first-class QBO object with no tool in this server today, which leaves callers unable to retrieve plan-vs-actual source data through MCP. The entity is read-only in the Intuit v3 API, so this PR only adds a search tool — no create/update/delete.

## What this adds

- `src/tools/search-budgets.tool.ts` — tool definition with filters `name`, `active`, `limit`
- `src/handlers/search-quickbooks-budgets.handler.ts` — thin wrapper over `quickbooks.findBudgets`, returning `QueryResponse.Budget || []`
- Registration in `src/index.ts` alongside the other search tools
- `findBudgets` entry in `tests/mocks/quickbooks.mock.ts`
- `tests/unit/handlers/budget.handlers.test.ts` — covers success, filter pass-through, empty `QueryResponse`, API errors, auth errors
- `tests/unit/handlers/budget.prototype-shape.test.ts` — a contract test that verifies the handler invokes a method that actually exists on `QuickBooks.prototype`. See "Testing note" below.

## What this does **not** add (and why)

- **No create / update / delete tools.** The Intuit v3 API does not support Budget mutations, so there is no library method to wrap.
- **No BudgetSummary or BudgetVsActuals report wrapper.** `node-quickbooks` does not expose those report prototypes, so there is nothing to call.

## Testing note: prototype-shape contract test

In addition to the normal handler unit test, this PR introduces a small prototype-shape contract test that runs the handler against the real `QuickBooks.prototype` (not the hand-rolled mock). It asserts:

1. `QuickBooks.prototype.findBudgets` is a function, and
2. The handler invokes that method on a real-prototype instance.

This runs offline (no network, no credentials) but catches the specific class of bug tracked in issue #34, where `get_general_ledger` called a non-existent library method but passed CI because the hand-rolled mock also had the typo. The same failure mode is possible for any handler that calls a library method via `(quickbooks as any).someMethod(...)`. If this pattern is useful, I'm happy to extend it to more handlers in a follow-up PR.

## Verification

- `npm test` — 342 tests pass (adds 7 new tests in `budget.handlers.test` and `budget.prototype-shape.test`)
- `npm run build` — clean
- Manually exercised against a live QBO sandbox and production company; returns `Budget[]` with full `BudgetDetail` line items as expected.

## Checklist

- [x] Unit tests added for the new handler
- [x] Prototype-shape contract test added
- [x] Handler wraps the library call with standard `formatError` error handling
- [x] Tool registered in `src/index.ts`
- [x] `npm test` passes
- [x] `npm run build` succeeds