### PR TITLE
fix: balance sheet date, per-call token refresh, OAuth loop on empty env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ coverage
 tokens.json
 
 start.cmd
+
+# Local capture output (may contain real account balances)
+capture-*.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ coverage
 .env
 .env.local
 .env.*.local
+tokens.json
+
+start.cmd

--- a/scripts/capture-balance-sheet-raw.mjs
+++ b/scripts/capture-balance-sheet-raw.mjs
@@ -1,0 +1,45 @@
+// Raw capture: bypass the handler and call reportBalanceSheet directly
+// so we control exactly which params reach QBO.
+import { QuickbooksClient } from "../dist/clients/quickbooks-client.js";
+
+const qb = await QuickbooksClient.getInstance();
+
+function callBS(params) {
+  return new Promise((resolve, reject) => {
+    qb.reportBalanceSheet(params, (err, report) => err ? reject(err) : resolve(report));
+  });
+}
+
+async function show(label, params) {
+  console.log(`\n=== ${label} ===`);
+  console.log("Request params:", JSON.stringify(params));
+  const t0 = Date.now();
+  try {
+    const r = await callBS(params);
+    console.log(`Elapsed: ${Date.now() - t0}ms`);
+    console.log("Header.StartPeriod:", r?.Header?.StartPeriod);
+    console.log("Header.EndPeriod:  ", r?.Header?.EndPeriod);
+    // Last few summary rows for totals comparison
+    const summaries = [];
+    (function walk(rows) {
+      const arr = Array.isArray(rows) ? rows : rows?.Row;
+      if (!arr) return;
+      for (const row of (Array.isArray(arr) ? arr : [arr])) {
+        if (row?.Summary?.ColData) summaries.push(row.Summary.ColData.map(c => c.value).join(" | "));
+        if (row?.Rows) walk(row.Rows);
+      }
+    })(r?.Rows);
+    console.log("Key summary rows:");
+    summaries.filter(s => /Total (Assets|Liabilities|Equity|Liabilities And Equity)/.test(s)).forEach(s => console.log("  " + s));
+  } catch (e) {
+    console.log("ERROR:", e?.message || e, e?.Fault || "");
+  }
+}
+
+const END = process.argv[2] || "2024-12-31";
+
+await show(`end_date=${END} only (no start_date)`, { end_date: END });
+await show(`end_date=${END} + start_date=2024-01-01`, { end_date: END, start_date: "2024-01-01" });
+await show(`end_date=${END} only, params object literal`, { end_date: END });
+
+process.exit(0);

--- a/scripts/capture-balance-sheet.mjs
+++ b/scripts/capture-balance-sheet.mjs
@@ -1,0 +1,58 @@
+// Capture two Balance Sheet responses that differ ONLY in whether start_date
+// is passed. Designed to settle the PR #41 review question: does QBO silently
+// drop end_date when start_date is absent?
+//
+// Usage:
+//   node scripts/capture-balance-sheet.mjs <END_DATE>
+//   (END_DATE defaults to 2025-06-30)
+//
+// Pipes both responses to stdout. Redact business name / PII before posting.
+
+import { getQuickbooksBalanceSheet } from "../dist/handlers/get-quickbooks-balance-sheet.handler.js";
+
+const end_date = process.argv[2] || "2025-06-30";
+
+function redact(obj) {
+  const s = JSON.stringify(obj, null, 2);
+  // Redact CompanyName, common PII fields if present
+  return s
+    .replace(/"CompanyName":\s*"[^"]*"/g, '"CompanyName": "<REDACTED>"')
+    .replace(/"ReportName":\s*"[^"]*"/g, '"ReportName": "BalanceSheet"');
+}
+
+async function run(label, opts) {
+  console.log(`\n=== ${label} ===`);
+  console.log("Request opts:", JSON.stringify(opts));
+  const t0 = Date.now();
+  const res = await getQuickbooksBalanceSheet(opts);
+  console.log(`Elapsed: ${Date.now() - t0}ms`);
+  if (res.isError) {
+    console.log("ERROR:", res.error);
+    return;
+  }
+  // Print only the Header (date params QBO echoes back) and a few key totals.
+  const header = res.result?.Header;
+  console.log("Header:", redact(header));
+  // Walk rows to find Total Assets / Total Liabilities And Equity summary rows
+  const summary = [];
+  function walk(rows) {
+    if (!rows) return;
+    const arr = Array.isArray(rows) ? rows : rows.Row;
+    if (!arr) return;
+    for (const r of (Array.isArray(arr) ? arr : [arr])) {
+      if (r?.Summary?.ColData) {
+        const cells = r.Summary.ColData.map(c => c.value).join(" | ");
+        summary.push(cells);
+      }
+      if (r?.Rows) walk(r.Rows);
+    }
+  }
+  walk(res.result?.Rows);
+  console.log("Summary rows (last 10):");
+  console.log(summary.slice(-10).join("\n"));
+}
+
+await run("WITH start_date (2025-01-01)", { end_date, start_date: "2025-01-01" });
+await run("WITHOUT start_date", { end_date });
+
+process.exit(0);

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -13,7 +13,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // This matters when the MCP server is spawned by a host (e.g. Claude Code,
 // Cursor) whose working directory is not the project root — without this,
 // dotenv silently finds nothing and startup fails.
-dotenv.config({ path: path.join(__dirname, '..', '..', '.env') });
+//
+// Use override: true so that values from .env always win over any empty-string
+// placeholders a host app (e.g. Claude Desktop) may inject via its env config.
+// This prevents the server from starting with blank REFRESH_TOKEN / REALM_ID
+// even when the host config has those keys set to "".
+dotenv.config({ path: path.join(__dirname, '..', '..', '.env'), override: true });
 
 // Register once at module level — registering inside startOAuthFlow() would
 // accumulate duplicate handlers on every OAuth call.
@@ -37,7 +42,11 @@ if (!client_id || !client_secret || !redirect_uri) {
   throw Error("Client ID, Client Secret and Redirect URI must be set in environment variables");
 }
 
-class QuickbooksClient {
+// ── QuickbooksClient ─────────────────────────────────────────────────────────
+// Exported so handlers can call QuickbooksClient.getInstance() directly,
+// which checks token freshness on every invocation rather than only at startup.
+
+export class QuickbooksClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
   private refreshToken?: string;
@@ -49,6 +58,14 @@ class QuickbooksClient {
   private oauthClient: OAuthClient;
   private isAuthenticating: boolean = false;
   private redirectUri: string;
+
+  // Refresh 5 minutes before actual expiry to avoid edge cases
+  private static readonly TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+  // Shared in-flight refresh promise so that concurrent callers all await the
+  // same network request rather than racing to use (and rotate) the refresh
+  // token simultaneously.
+  private refreshInFlight?: Promise<{ access_token: string; expires_in: number }>;
 
   constructor(config: {
     clientId: string;
@@ -70,6 +87,11 @@ class QuickbooksClient {
       environment: this.environment,
       redirectUri: this.redirectUri,
     });
+  }
+
+  private isTokenExpiredOrExpiringSoon(): boolean {
+    if (!this.accessToken || !this.accessTokenExpiry) return true;
+    return this.accessTokenExpiry <= new Date(Date.now() + QuickbooksClient.TOKEN_REFRESH_BUFFER_MS);
   }
 
   private async startOAuthFlow(): Promise<void> {
@@ -97,12 +119,12 @@ class QuickbooksClient {
           try {
             const response = await this.oauthClient.createToken(req.url);
             const tokens = response.token;
-            
+
             // Save tokens
             this.refreshToken = tokens.refresh_token;
             this.realmId = tokens.realmId;
             this.saveTokensToEnv();
-            
+
             // Send success response
             res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end(`
@@ -122,7 +144,7 @@ class QuickbooksClient {
                 </body>
               </html>
             `);
-            
+
             // Close server after a short delay
             setTimeout(() => {
               server.close();
@@ -219,11 +241,6 @@ class QuickbooksClient {
     }
   }
 
-  // Shared in-flight refresh promise so that concurrent callers all await the
-  // same network request rather than racing to use (and rotate) the refresh
-  // token simultaneously.
-  private refreshInFlight?: Promise<{ access_token: string; expires_in: number }>;
-
   async refreshAccessToken() {
     if (!this.refreshToken) {
       await this.startOAuthFlow();
@@ -297,40 +314,51 @@ class QuickbooksClient {
     return this.refreshInFlight;
   }
 
-  async authenticate() {
+  async authenticate(): Promise<QuickBooks> {
     if (!this.refreshToken || !this.realmId) {
       await this.startOAuthFlow();
-      
+
       // Verify we have both tokens after OAuth flow
       if (!this.refreshToken || !this.realmId) {
         throw new Error('Failed to obtain required tokens from OAuth flow');
       }
     }
 
-    // Check if token exists and is still valid
-    const now = new Date();
-    if (!this.accessToken || !this.accessTokenExpiry || this.accessTokenExpiry <= now) {
-      const tokenResponse = await this.refreshAccessToken();
-      this.accessToken = tokenResponse.access_token;
+    // Silently refresh if token is expired or expiring soon
+    if (this.isTokenExpiredOrExpiringSoon()) {
+      await this.refreshAccessToken();
     }
-    
-    // At this point we know all tokens are available
+
+    // Always rebuild with the current fresh access token
     this.quickbooksInstance = new QuickBooks(
       this.clientId,
       this.clientSecret,
-      this.accessToken,
+      this.accessToken!,
       false, // no token secret for OAuth 2.0
-      this.realmId!, // Safe to use ! here as we checked above
-      this.environment === 'sandbox', // use the sandbox?
+      this.realmId!,
+      this.environment === 'sandbox',
       false, // debug?
-      null, // minor version
+      null,  // minor version
       '2.0', // oauth version
       this.refreshToken
     );
-    
+
     return this.quickbooksInstance;
   }
-  
+
+  // ── Called by every handler on every request ─────────────────────────────
+  // Checks token freshness on each invocation so handlers stay functional
+  // across 60-minute token boundaries without server restarts.
+  static async getInstance(): Promise<QuickBooks> {
+    if (quickbooksClient.isTokenExpiredOrExpiringSoon()) {
+      await quickbooksClient.authenticate();
+    }
+    if (!quickbooksClient.quickbooksInstance) {
+      await quickbooksClient.authenticate();
+    }
+    return quickbooksClient.quickbooksInstance!;
+  }
+
   getQuickbooks() {
     if (!this.quickbooksInstance) {
       throw new Error('Quickbooks not authenticated. Call authenticate() first');

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -67,6 +67,11 @@ export class QuickbooksClient {
   // token simultaneously.
   private refreshInFlight?: Promise<{ access_token: string; expires_in: number }>;
 
+  // Shared in-flight authenticate promise. Guards the cold-start path so two
+  // concurrent first callers cannot both pass the freshness check and both
+  // invoke startOAuthFlow() / rebuild the QuickBooks instance.
+  private authInFlight?: Promise<QuickBooks>;
+
   constructor(config: {
     clientId: string;
     clientSecret: string;
@@ -315,35 +320,47 @@ export class QuickbooksClient {
   }
 
   async authenticate(): Promise<QuickBooks> {
-    if (!this.refreshToken || !this.realmId) {
-      await this.startOAuthFlow();
+    if (this.authInFlight) {
+      return this.authInFlight;
+    }
 
-      // Verify we have both tokens after OAuth flow
-      if (!this.refreshToken || !this.realmId) {
-        throw new Error('Failed to obtain required tokens from OAuth flow');
+    this.authInFlight = (async () => {
+      try {
+        if (!this.refreshToken || !this.realmId) {
+          await this.startOAuthFlow();
+
+          // Verify we have both tokens after OAuth flow
+          if (!this.refreshToken || !this.realmId) {
+            throw new Error('Failed to obtain required tokens from OAuth flow');
+          }
+        }
+
+        // Silently refresh if token is expired or expiring soon
+        if (this.isTokenExpiredOrExpiringSoon()) {
+          await this.refreshAccessToken();
+        }
+
+        // Always rebuild with the current fresh access token
+        this.quickbooksInstance = new QuickBooks(
+          this.clientId,
+          this.clientSecret,
+          this.accessToken!,
+          false, // no token secret for OAuth 2.0
+          this.realmId!,
+          this.environment === 'sandbox',
+          false, // debug?
+          null,  // minor version
+          '2.0', // oauth version
+          this.refreshToken
+        );
+
+        return this.quickbooksInstance;
+      } finally {
+        this.authInFlight = undefined;
       }
-    }
+    })();
 
-    // Silently refresh if token is expired or expiring soon
-    if (this.isTokenExpiredOrExpiringSoon()) {
-      await this.refreshAccessToken();
-    }
-
-    // Always rebuild with the current fresh access token
-    this.quickbooksInstance = new QuickBooks(
-      this.clientId,
-      this.clientSecret,
-      this.accessToken!,
-      false, // no token secret for OAuth 2.0
-      this.realmId!,
-      this.environment === 'sandbox',
-      false, // debug?
-      null,  // minor version
-      '2.0', // oauth version
-      this.refreshToken
-    );
-
-    return this.quickbooksInstance;
+    return this.authInFlight;
   }
 
   // ── Called by every handler on every request ─────────────────────────────

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -10,9 +10,9 @@ import open from 'open';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Resolve .env relative to the installed module (../../.env from dist/clients/).
-// This matters when the MCP server is spawned by a host (e.g. Claude Code,
-// Cursor) whose working directory is not the project root — without this,
-// dotenv silently finds nothing and startup fails.
+// This matters when the MCP server is spawned by a host (e.g. Claude Desktop,
+// Claude Code, Cursor) whose working directory is not the project root —
+// without this, dotenv silently finds nothing and startup fails.
 //
 // Use override: true so that values from .env always win over any empty-string
 // placeholders a host app (e.g. Claude Desktop) may inject via its env config.

--- a/src/handlers/create-quickbooks-account.handler.ts
+++ b/src/handlers/create-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -52,8 +52,7 @@ function normalizeAccountPayload(payload: Record<string, any>): Record<string, a
 
 export async function createQuickbooksAccount(data: CreateAccountInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     // Build initial payload then normalize.
     const basePayload: any = {

--- a/src/handlers/create-quickbooks-account.handler.ts
+++ b/src/handlers/create-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-attachable.handler.ts
+++ b/src/handlers/create-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-attachable.handler.ts
+++ b/src/handlers/create-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -15,8 +15,7 @@ export interface CreateAttachableInput {
 
 export async function createQuickbooksAttachable(data: CreateAttachableInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { FileName: data.file_name };
     if (data.note) payload.Note = data.note;
     if (data.category) payload.Category = data.category;
@@ -40,3 +39,4 @@ export async function createQuickbooksAttachable(data: CreateAttachableInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/create-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksBillPayment(billPaymentData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.createBillPayment(billPaymentData, (err: any, billPayment: any) => {

--- a/src/handlers/create-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/create-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-bill.handler.ts
+++ b/src/handlers/create-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksBill(bill: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     // Auto-nest flat line items into QBO's expected nested structure.
     // If caller sends AccountRef at line level (legacy shape), move it under AccountBasedExpenseLineDetail.

--- a/src/handlers/create-quickbooks-bill.handler.ts
+++ b/src/handlers/create-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-class.handler.ts
+++ b/src/handlers/create-quickbooks-class.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-class.handler.ts
+++ b/src/handlers/create-quickbooks-class.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CreateClassInput {
 
 export async function createQuickbooksClass(data: CreateClassInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Name: data.name };
     if (data.parent_ref) payload.ParentRef = { value: data.parent_ref };
 
@@ -25,3 +24,4 @@ export async function createQuickbooksClass(data: CreateClassInput): Promise<Too
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/create-quickbooks-credit-memo.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/create-quickbooks-credit-memo.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -17,8 +17,7 @@ export interface CreateCreditMemoInput {
 
 export async function createQuickbooksCreditMemo(data: CreateCreditMemoInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const creditMemoPayload: any = {
       CustomerRef: { value: data.customer_ref },
@@ -59,3 +58,4 @@ export async function createQuickbooksCreditMemo(data: CreateCreditMemoInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-customer.handler.ts
+++ b/src/handlers/create-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-customer.handler.ts
+++ b/src/handlers/create-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksCustomer(customerData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.createCustomer(customerData, (err: any, customer: any) => {

--- a/src/handlers/create-quickbooks-department.handler.ts
+++ b/src/handlers/create-quickbooks-department.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CreateDepartmentInput {
 
 export async function createQuickbooksDepartment(data: CreateDepartmentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Name: data.name };
     if (data.parent_ref) payload.ParentRef = { value: data.parent_ref };
 
@@ -25,3 +24,4 @@ export async function createQuickbooksDepartment(data: CreateDepartmentInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-department.handler.ts
+++ b/src/handlers/create-quickbooks-department.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-deposit.handler.ts
+++ b/src/handlers/create-quickbooks-deposit.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-deposit.handler.ts
+++ b/src/handlers/create-quickbooks-deposit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ export interface CreateDepositInput {
 
 export async function createQuickbooksDeposit(data: CreateDepositInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       DepositToAccountRef: { value: data.deposit_to_account_ref },
@@ -46,3 +45,4 @@ export async function createQuickbooksDeposit(data: CreateDepositInput): Promise
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-employee.handler.ts
+++ b/src/handlers/create-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-employee.handler.ts
+++ b/src/handlers/create-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksEmployee(employeeData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.createEmployee(employeeData, (err: any, employee: any) => {

--- a/src/handlers/create-quickbooks-estimate.handler.ts
+++ b/src/handlers/create-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksEstimate(estimateData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.createEstimate(estimateData, (err: any, estimate: any) => {

--- a/src/handlers/create-quickbooks-estimate.handler.ts
+++ b/src/handlers/create-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-invoice.handler.ts
+++ b/src/handlers/create-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-invoice.handler.ts
+++ b/src/handlers/create-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -51,8 +51,7 @@ function normalizeInvoiceFields(obj: Record<string, any>): Record<string, any> {
 
 export async function createQuickbooksInvoice(data: CreateInvoiceInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const invoicePayload: any = {
       CustomerRef: { value: data.customer_ref },

--- a/src/handlers/create-quickbooks-item.handler.ts
+++ b/src/handlers/create-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-item.handler.ts
+++ b/src/handlers/create-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface CreateItemInput {
 
 export async function createQuickbooksItem(data: CreateItemInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       Name: data.name,

--- a/src/handlers/create-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/create-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/create-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksJournalEntry(journalEntryData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.createJournalEntry(journalEntryData, (err: any, journalEntry: any) => {

--- a/src/handlers/create-quickbooks-payment-method.handler.ts
+++ b/src/handlers/create-quickbooks-payment-method.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-payment-method.handler.ts
+++ b/src/handlers/create-quickbooks-payment-method.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface CreatePaymentMethodInput {
 
 export async function createQuickbooksPaymentMethod(data: CreatePaymentMethodInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Name: data.name };
     if (data.type) payload.Type = data.type;
 
@@ -24,3 +23,4 @@ export async function createQuickbooksPaymentMethod(data: CreatePaymentMethodInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-payment.handler.ts
+++ b/src/handlers/create-quickbooks-payment.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-payment.handler.ts
+++ b/src/handlers/create-quickbooks-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -20,8 +20,7 @@ export interface CreatePaymentInput {
 
 export async function createQuickbooksPayment(data: CreatePaymentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const paymentPayload: any = {
       CustomerRef: { value: data.customer_ref },
@@ -63,3 +62,4 @@ export async function createQuickbooksPayment(data: CreatePaymentInput): Promise
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/create-quickbooks-purchase-order.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/create-quickbooks-purchase-order.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -23,8 +23,7 @@ export interface CreatePurchaseOrderInput {
 
 export async function createQuickbooksPurchaseOrder(data: CreatePurchaseOrderInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       VendorRef: { value: data.vendor_ref },
@@ -67,3 +66,4 @@ export async function createQuickbooksPurchaseOrder(data: CreatePurchaseOrderInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-purchase.handler.ts
+++ b/src/handlers/create-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksPurchase(purchaseData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.createPurchase(purchaseData, (err: any, purchase: any) => {

--- a/src/handlers/create-quickbooks-purchase.handler.ts
+++ b/src/handlers/create-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/create-quickbooks-refund-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -19,8 +19,7 @@ export interface CreateRefundReceiptInput {
 
 export async function createQuickbooksRefundReceipt(data: CreateRefundReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const refundReceiptPayload: any = {
       CustomerRef: { value: data.customer_ref },
@@ -67,3 +66,4 @@ export async function createQuickbooksRefundReceipt(data: CreateRefundReceiptInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/create-quickbooks-refund-receipt.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/create-quickbooks-sales-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -19,8 +19,7 @@ export interface CreateSalesReceiptInput {
 
 export async function createQuickbooksSalesReceipt(data: CreateSalesReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const salesReceiptPayload: any = {
       CustomerRef: { value: data.customer_ref },
@@ -67,3 +66,4 @@ export async function createQuickbooksSalesReceipt(data: CreateSalesReceiptInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/create-quickbooks-sales-receipt.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-term.handler.ts
+++ b/src/handlers/create-quickbooks-term.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -15,8 +15,7 @@ export interface CreateTermInput {
 
 export async function createQuickbooksTerm(data: CreateTermInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Name: data.name };
     if (data.due_days !== undefined) payload.DueDays = data.due_days;
     if (data.discount_days !== undefined) payload.DiscountDays = data.discount_days;
@@ -36,3 +35,4 @@ export async function createQuickbooksTerm(data: CreateTermInput): Promise<ToolR
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-term.handler.ts
+++ b/src/handlers/create-quickbooks-term.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-time-activity.handler.ts
+++ b/src/handlers/create-quickbooks-time-activity.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-time-activity.handler.ts
+++ b/src/handlers/create-quickbooks-time-activity.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -20,8 +20,7 @@ export interface CreateTimeActivityInput {
 
 export async function createQuickbooksTimeActivity(data: CreateTimeActivityInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       NameOf: data.name_of,
@@ -50,3 +49,4 @@ export async function createQuickbooksTimeActivity(data: CreateTimeActivityInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-transfer.handler.ts
+++ b/src/handlers/create-quickbooks-transfer.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-transfer.handler.ts
+++ b/src/handlers/create-quickbooks-transfer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface CreateTransferInput {
 
 export async function createQuickbooksTransfer(data: CreateTransferInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       FromAccountRef: { value: data.from_account_ref },
@@ -34,3 +33,4 @@ export async function createQuickbooksTransfer(data: CreateTransferInput): Promi
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/create-quickbooks-vendor-credit.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/create-quickbooks-vendor-credit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ export interface CreateVendorCreditInput {
 
 export async function createQuickbooksVendorCredit(data: CreateVendorCreditInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       VendorRef: { value: data.vendor_ref },
@@ -44,3 +43,4 @@ export async function createQuickbooksVendorCredit(data: CreateVendorCreditInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/create-quickbooks-vendor.handler.ts
+++ b/src/handlers/create-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/create-quickbooks-vendor.handler.ts
+++ b/src/handlers/create-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function createQuickbooksVendor(vendor: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.createVendor(vendor, (err: any, createdVendor: any) => {

--- a/src/handlers/delete-quickbooks-attachable.handler.ts
+++ b/src/handlers/delete-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface DeleteAttachableInput {
 
 export async function deleteQuickbooksAttachable(data: DeleteAttachableInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload = { Id: data.id, SyncToken: data.sync_token };
 
     return new Promise((resolve) => {
@@ -23,3 +22,4 @@ export async function deleteQuickbooksAttachable(data: DeleteAttachableInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-attachable.handler.ts
+++ b/src/handlers/delete-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/delete-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/delete-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksBillPayment(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.deleteBillPayment(idOrEntity, (err: any, billPayment: any) => {

--- a/src/handlers/delete-quickbooks-bill.handler.ts
+++ b/src/handlers/delete-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-bill.handler.ts
+++ b/src/handlers/delete-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksBill(bill: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.deleteBill(bill, (err: any, deletedBill: any) => {

--- a/src/handlers/delete-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/delete-quickbooks-credit-memo.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/delete-quickbooks-credit-memo.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksCreditMemo(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).deleteCreditMemo(idOrEntity, (err: any, response: any) => {
@@ -20,3 +19,4 @@ export async function deleteQuickbooksCreditMemo(idOrEntity: any): Promise<ToolR
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-customer.handler.ts
+++ b/src/handlers/delete-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,7 +10,7 @@ export async function deleteQuickbooksCustomer(idOrEntity: any): Promise<ToolRes
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
-    // nodeâ€‘quickbooks v1.0.32+ exposes deleteCustomer but some older builds don't.
+    // node‑quickbooks v1.0.32+ exposes deleteCustomer but some older builds don't.
     const hasDelete = typeof (quickbooks as any).deleteCustomer === "function";
 
     return new Promise((resolve) => {

--- a/src/handlers/delete-quickbooks-customer.handler.ts
+++ b/src/handlers/delete-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,10 +8,9 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksCustomer(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
-    // node‑quickbooks v1.0.32+ exposes deleteCustomer but some older builds don't.
+    // nodeâ€‘quickbooks v1.0.32+ exposes deleteCustomer but some older builds don't.
     const hasDelete = typeof (quickbooks as any).deleteCustomer === "function";
 
     return new Promise((resolve) => {

--- a/src/handlers/delete-quickbooks-deposit.handler.ts
+++ b/src/handlers/delete-quickbooks-deposit.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-deposit.handler.ts
+++ b/src/handlers/delete-quickbooks-deposit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksDeposit(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).deleteDeposit(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
@@ -16,3 +15,4 @@ export async function deleteQuickbooksDeposit(idOrEntity: any): Promise<ToolResp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-employee.handler.ts
+++ b/src/handlers/delete-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksEmployee(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       // Helper to fetch entity when only ID supplied
@@ -51,3 +50,4 @@ export async function deleteQuickbooksEmployee(idOrEntity: any): Promise<ToolRes
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-employee.handler.ts
+++ b/src/handlers/delete-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-estimate.handler.ts
+++ b/src/handlers/delete-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksEstimate(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.deleteEstimate(idOrEntity, (err: any, response: any) => {

--- a/src/handlers/delete-quickbooks-estimate.handler.ts
+++ b/src/handlers/delete-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-invoice.handler.ts
+++ b/src/handlers/delete-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-invoice.handler.ts
+++ b/src/handlers/delete-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksInvoice(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       // Try deleteInvoice first if available
@@ -70,3 +69,4 @@ export async function deleteQuickbooksInvoice(idOrEntity: any): Promise<ToolResp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-item.handler.ts
+++ b/src/handlers/delete-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksItem(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       // Helper to fetch entity when only ID supplied
@@ -51,3 +50,4 @@ export async function deleteQuickbooksItem(idOrEntity: any): Promise<ToolRespons
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-item.handler.ts
+++ b/src/handlers/delete-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/delete-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/delete-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksJournalEntry(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.deleteJournalEntry(idOrEntity, (err: any, journalEntry: any) => {

--- a/src/handlers/delete-quickbooks-payment.handler.ts
+++ b/src/handlers/delete-quickbooks-payment.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-payment.handler.ts
+++ b/src/handlers/delete-quickbooks-payment.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksPayment(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).deletePayment(idOrEntity, (err: any, response: any) => {
@@ -20,3 +19,4 @@ export async function deleteQuickbooksPayment(idOrEntity: any): Promise<ToolResp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/delete-quickbooks-purchase-order.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/delete-quickbooks-purchase-order.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksPurchaseOrder(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).deletePurchaseOrder(idOrEntity, (err: any, response: any) => {
@@ -20,3 +19,4 @@ export async function deleteQuickbooksPurchaseOrder(idOrEntity: any): Promise<To
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-purchase.handler.ts
+++ b/src/handlers/delete-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksPurchase(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.deletePurchase(idOrEntity, (err: any, purchase: any) => {

--- a/src/handlers/delete-quickbooks-purchase.handler.ts
+++ b/src/handlers/delete-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/delete-quickbooks-refund-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksRefundReceipt(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).deleteRefundReceipt(idOrEntity, (err: any, response: any) => {
@@ -20,3 +19,4 @@ export async function deleteQuickbooksRefundReceipt(idOrEntity: any): Promise<To
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/delete-quickbooks-refund-receipt.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/delete-quickbooks-sales-receipt.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/delete-quickbooks-sales-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksSalesReceipt(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).deleteSalesReceipt(idOrEntity, (err: any, response: any) => {
@@ -20,3 +19,4 @@ export async function deleteQuickbooksSalesReceipt(idOrEntity: any): Promise<Too
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-time-activity.handler.ts
+++ b/src/handlers/delete-quickbooks-time-activity.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksTimeActivity(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).deleteTimeActivity(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
@@ -16,3 +15,4 @@ export async function deleteQuickbooksTimeActivity(idOrEntity: any): Promise<Too
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-time-activity.handler.ts
+++ b/src/handlers/delete-quickbooks-time-activity.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-transfer.handler.ts
+++ b/src/handlers/delete-quickbooks-transfer.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksTransfer(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).deleteTransfer(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
@@ -16,3 +15,4 @@ export async function deleteQuickbooksTransfer(idOrEntity: any): Promise<ToolRes
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-transfer.handler.ts
+++ b/src/handlers/delete-quickbooks-transfer.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/delete-quickbooks-vendor-credit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function deleteQuickbooksVendorCredit(idOrEntity: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).deleteVendorCredit(idOrEntity, (err: any, response: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
@@ -16,3 +15,4 @@ export async function deleteQuickbooksVendorCredit(idOrEntity: any): Promise<Too
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/delete-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/delete-quickbooks-vendor-credit.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/delete-quickbooks-vendor.handler.ts
+++ b/src/handlers/delete-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function deleteQuickbooksVendor(vendor: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.deleteVendor(vendor, (err: any, deletedVendor: any) => {

--- a/src/handlers/delete-quickbooks-vendor.handler.ts
+++ b/src/handlers/delete-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/get-quickbooks-account.handler.ts
+++ b/src/handlers/get-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksAccount(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getAccount(id, (err: any, account: any) => {

--- a/src/handlers/get-quickbooks-aged-payables.handler.ts
+++ b/src/handlers/get-quickbooks-aged-payables.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface AgedPayablesOptions {
 
 export async function getQuickbooksAgedPayables(options: AgedPayablesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.vendor) params.vendor = options.vendor;

--- a/src/handlers/get-quickbooks-aged-receivables.handler.ts
+++ b/src/handlers/get-quickbooks-aged-receivables.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface AgedReceivablesOptions {
 
 export async function getQuickbooksAgedReceivables(options: AgedReceivablesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.customer) params.customer = options.customer;

--- a/src/handlers/get-quickbooks-attachable.handler.ts
+++ b/src/handlers/get-quickbooks-attachable.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksAttachable(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getAttachable(id, (err: any, attachable: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-balance-sheet.handler.ts
+++ b/src/handlers/get-quickbooks-balance-sheet.handler.ts
@@ -15,10 +15,16 @@ export async function getQuickbooksBalanceSheet(options: BalanceSheetOptions): P
     const quickbooks = await QuickbooksClient.getInstance();
 
     // Build params — Balance Sheet is a point-in-time report.
-    // end_date is the "as of" date. start_date is not a valid QBO param
-    // for Balance Sheet and is intentionally excluded.
+    // QBO silently ignores end_date when start_date is absent. To ensure the
+    // caller's end_date is honoured, auto-supply start_date as Jan 1 of the
+    // same year when the caller omits it.
     const params: Record<string, any> = {};
-    if (options.end_date) params.end_date = options.end_date;
+    if (options.end_date) {
+      params.end_date = options.end_date;
+      params.start_date = options.start_date || `${options.end_date.substring(0, 4)}-01-01`;
+    } else if (options.start_date) {
+      params.start_date = options.start_date;
+    }
     if (options.accounting_method) params.accounting_method = options.accounting_method;
     if (options.summarize_column_by) params.summarize_column_by = options.summarize_column_by;
 

--- a/src/handlers/get-quickbooks-balance-sheet.handler.ts
+++ b/src/handlers/get-quickbooks-balance-sheet.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,11 +11,12 @@ export interface BalanceSheetOptions {
 
 export async function getQuickbooksBalanceSheet(options: BalanceSheetOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
-    // Balance Sheet is a point-in-time report — end_date is the "as of" date.
-    // start_date is not a valid QBO param for Balance Sheet and was causing
-    // end_date to be silently ignored in some configurations.
+    // Use getInstance() so token freshness is checked on every call
+    const quickbooks = await QuickbooksClient.getInstance();
+
+    // Build params — Balance Sheet is a point-in-time report.
+    // end_date is the "as of" date. start_date is not a valid QBO param
+    // for Balance Sheet and is intentionally excluded.
     const params: Record<string, any> = {};
     if (options.end_date) params.end_date = options.end_date;
     if (options.accounting_method) params.accounting_method = options.accounting_method;
@@ -23,8 +24,11 @@ export async function getQuickbooksBalanceSheet(options: BalanceSheetOptions): P
 
     return new Promise((resolve) => {
       (quickbooks as any).reportBalanceSheet(params, (err: any, report: any) => {
-        if (err) resolve({ result: null, isError: true, error: formatError(err) });
-        else resolve({ result: report, isError: false, error: null });
+        if (err) {
+          resolve({ result: null, isError: true, error: formatError(err) });
+        } else {
+          resolve({ result: report, isError: false, error: null });
+        }
       });
     });
   } catch (error) {

--- a/src/handlers/get-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/get-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksBillPayment(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.getBillPayment(id, (err: any, billPayment: any) => {

--- a/src/handlers/get-quickbooks-bill.handler.ts
+++ b/src/handlers/get-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksBill(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.getBill(id, (err: any, bill: any) => {

--- a/src/handlers/get-quickbooks-cash-flow.handler.ts
+++ b/src/handlers/get-quickbooks-cash-flow.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CashFlowOptions {
 
 export async function getQuickbooksCashFlow(options: CashFlowOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-class.handler.ts
+++ b/src/handlers/get-quickbooks-class.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksClass(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getClass(id, (err: any, cls: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-company-info.handler.ts
+++ b/src/handlers/get-quickbooks-company-info.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksCompanyInfo(companyId?: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const id = companyId || (quickbooks as any).realmId;
 
     return new Promise((resolve) => {

--- a/src/handlers/get-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/get-quickbooks-credit-memo.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksCreditMemo(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getCreditMemo(id, (err: any, creditMemo: any) => {

--- a/src/handlers/get-quickbooks-customer-balance.handler.ts
+++ b/src/handlers/get-quickbooks-customer-balance.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface CustomerBalanceOptions {
 
 export async function getQuickbooksCustomerBalance(options: CustomerBalanceOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.customer) params.customer = options.customer;

--- a/src/handlers/get-quickbooks-customer-sales.handler.ts
+++ b/src/handlers/get-quickbooks-customer-sales.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface CustomerSalesOptions {
 
 export async function getQuickbooksCustomerSales(options: CustomerSalesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-customer.handler.ts
+++ b/src/handlers/get-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksCustomer(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getCustomer(id, (err: any, customer: any) => {

--- a/src/handlers/get-quickbooks-department.handler.ts
+++ b/src/handlers/get-quickbooks-department.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksDepartment(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getDepartment(id, (err: any, dept: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-deposit.handler.ts
+++ b/src/handlers/get-quickbooks-deposit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksDeposit(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getDeposit(id, (err: any, deposit: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-employee.handler.ts
+++ b/src/handlers/get-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksEmployee(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.getEmployee(id, (err: any, employee: any) => {

--- a/src/handlers/get-quickbooks-estimate.handler.ts
+++ b/src/handlers/get-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksEstimate(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.getEstimate(id, (err: any, estimate: any) => {

--- a/src/handlers/get-quickbooks-general-ledger.handler.ts
+++ b/src/handlers/get-quickbooks-general-ledger.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface GeneralLedgerOptions {
 
 export async function getQuickbooksGeneralLedger(options: GeneralLedgerOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/get-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksJournalEntry(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.getJournalEntry(id, (err: any, journalEntry: any) => {

--- a/src/handlers/get-quickbooks-payment-method.handler.ts
+++ b/src/handlers/get-quickbooks-payment-method.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksPaymentMethod(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getPaymentMethod(id, (err: any, method: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-payment.handler.ts
+++ b/src/handlers/get-quickbooks-payment.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksPayment(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getPayment(id, (err: any, payment: any) => {

--- a/src/handlers/get-quickbooks-profit-and-loss.handler.ts
+++ b/src/handlers/get-quickbooks-profit-and-loss.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -16,8 +16,7 @@ export interface ProfitAndLossOptions {
 
 export async function getQuickbooksProfitAndLoss(options: ProfitAndLossOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/get-quickbooks-purchase-order.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksPurchaseOrder(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getPurchaseOrder(id, (err: any, po: any) => {

--- a/src/handlers/get-quickbooks-purchase.handler.ts
+++ b/src/handlers/get-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksPurchase(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.getPurchase(id, (err: any, purchase: any) => {

--- a/src/handlers/get-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/get-quickbooks-refund-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksRefundReceipt(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getRefundReceipt(id, (err: any, refundReceipt: any) => {

--- a/src/handlers/get-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/get-quickbooks-sales-receipt.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksSalesReceipt(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getSalesReceipt(id, (err: any, salesReceipt: any) => {

--- a/src/handlers/get-quickbooks-tax-agency.handler.ts
+++ b/src/handlers/get-quickbooks-tax-agency.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTaxAgency(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getTaxAgency(id, (err: any, taxAgency: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-tax-code.handler.ts
+++ b/src/handlers/get-quickbooks-tax-code.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTaxCode(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getTaxCode(id, (err: any, taxCode: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-tax-rate.handler.ts
+++ b/src/handlers/get-quickbooks-tax-rate.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTaxRate(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getTaxRate(id, (err: any, taxRate: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-term.handler.ts
+++ b/src/handlers/get-quickbooks-term.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTerm(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getTerm(id, (err: any, term: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-time-activity.handler.ts
+++ b/src/handlers/get-quickbooks-time-activity.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTimeActivity(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getTimeActivity(id, (err: any, activity: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-transfer.handler.ts
+++ b/src/handlers/get-quickbooks-transfer.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksTransfer(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getTransfer(id, (err: any, transfer: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-trial-balance.handler.ts
+++ b/src/handlers/get-quickbooks-trial-balance.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface TrialBalanceOptions {
 
 export async function getQuickbooksTrialBalance(options: TrialBalanceOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-vendor-balance.handler.ts
+++ b/src/handlers/get-quickbooks-vendor-balance.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface VendorBalanceOptions {
 
 export async function getQuickbooksVendorBalance(options: VendorBalanceOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.report_date) params.report_date = options.report_date;
     if (options.vendor) params.vendor = options.vendor;

--- a/src/handlers/get-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/get-quickbooks-vendor-credit.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function getQuickbooksVendorCredit(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getVendorCredit(id, (err: any, vc: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/get-quickbooks-vendor-expenses.handler.ts
+++ b/src/handlers/get-quickbooks-vendor-expenses.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface VendorExpensesOptions {
 
 export async function getQuickbooksVendorExpenses(options: VendorExpensesOptions): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const params: Record<string, any> = {};
     if (options.start_date) params.start_date = options.start_date;
     if (options.end_date) params.end_date = options.end_date;

--- a/src/handlers/get-quickbooks-vendor.handler.ts
+++ b/src/handlers/get-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function getQuickbooksVendor(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.getVendor(id, (err: any, vendor: any) => {

--- a/src/handlers/read-quickbooks-invoice.handler.ts
+++ b/src/handlers/read-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function readQuickbooksInvoice(invoiceId: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getInvoice(invoiceId, (err: any, invoice: any) => {

--- a/src/handlers/read-quickbooks-invoice.handler.ts
+++ b/src/handlers/read-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/read-quickbooks-item.handler.ts
+++ b/src/handlers/read-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/read-quickbooks-item.handler.ts
+++ b/src/handlers/read-quickbooks-item.handler.ts
@@ -1,11 +1,10 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 export async function readQuickbooksItem(id: string): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).getItem(id, (err: any, item: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/search-quickbooks-accounts.handler.ts
+++ b/src/handlers/search-quickbooks-accounts.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";
@@ -7,8 +7,7 @@ export type AccountSearchCriteria = QuickbooksSearchCriteriaInput;
 
 export async function searchQuickbooksAccounts(criteria: AccountSearchCriteria): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const normalizedCriteria = buildQuickbooksSearchCriteria(criteria);
 

--- a/src/handlers/search-quickbooks-accounts.handler.ts
+++ b/src/handlers/search-quickbooks-accounts.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-attachables.handler.ts
+++ b/src/handlers/search-quickbooks-attachables.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchAttachablesInput {
 
 export async function searchQuickbooksAttachables(data: SearchAttachablesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.file_name) criteria.FileName = data.file_name;
     if (data.content_type) criteria.ContentType = data.content_type;
@@ -27,3 +26,4 @@ export async function searchQuickbooksAttachables(data: SearchAttachablesInput):
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-attachables.handler.ts
+++ b/src/handlers/search-quickbooks-attachables.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-bill-payments.handler.ts
+++ b/src/handlers/search-quickbooks-bill-payments.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksBillPayments(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-bill-payments.handler.ts
+++ b/src/handlers/search-quickbooks-bill-payments.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-bills.handler.ts
+++ b/src/handlers/search-quickbooks-bills.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -6,12 +6,12 @@ import { formatError } from "../helpers/format-error.js";
  * Search bills from QuickBooks Online.
  *
  * Accepts either:
- *   â€¢ A plain criteria object (key/value pairs) â€“ passed directly to findBills
- *   â€¢ An **array** of objects in the `{ field, value, operator? }` shape â€“ this
+ *   • A plain criteria object (key/value pairs) – passed directly to findBills
+ *   • An **array** of objects in the `{ field, value, operator? }` shape – this
  *     allows use of operators such as `IN`, `LIKE`, `>`, `<`, `>=`, `<=` etc.
  *
  * Pagination / sorting options such as `limit`, `offset`, `asc`, `desc`,
- * `fetchAll`, `count` can be supplied via the topâ€‘level criteria object or as
+ * `fetchAll`, `count` can be supplied via the top‑level criteria object or as
  * dedicated entries in the array form.
  */
 export async function searchQuickbooksBills(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {

--- a/src/handlers/search-quickbooks-bills.handler.ts
+++ b/src/handlers/search-quickbooks-bills.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -6,18 +6,17 @@ import { formatError } from "../helpers/format-error.js";
  * Search bills from QuickBooks Online.
  *
  * Accepts either:
- *   • A plain criteria object (key/value pairs) – passed directly to findBills
- *   • An **array** of objects in the `{ field, value, operator? }` shape – this
+ *   â€¢ A plain criteria object (key/value pairs) â€“ passed directly to findBills
+ *   â€¢ An **array** of objects in the `{ field, value, operator? }` shape â€“ this
  *     allows use of operators such as `IN`, `LIKE`, `>`, `<`, `>=`, `<=` etc.
  *
  * Pagination / sorting options such as `limit`, `offset`, `asc`, `desc`,
- * `fetchAll`, `count` can be supplied via the top‑level criteria object or as
+ * `fetchAll`, `count` can be supplied via the topâ€‘level criteria object or as
  * dedicated entries in the array form.
  */
 export async function searchQuickbooksBills(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).findBills(criteria as any, (err: any, bills: any) => {

--- a/src/handlers/search-quickbooks-budgets.handler.ts
+++ b/src/handlers/search-quickbooks-budgets.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchBudgetsInput {
 
 export async function searchQuickbooksBudgets(data: SearchBudgetsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;
@@ -27,3 +26,4 @@ export async function searchQuickbooksBudgets(data: SearchBudgetsInput): Promise
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-budgets.handler.ts
+++ b/src/handlers/search-quickbooks-budgets.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-classes.handler.ts
+++ b/src/handlers/search-quickbooks-classes.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-classes.handler.ts
+++ b/src/handlers/search-quickbooks-classes.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchClassesInput {
 
 export async function searchQuickbooksClasses(data: SearchClassesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;
@@ -27,3 +26,4 @@ export async function searchQuickbooksClasses(data: SearchClassesInput): Promise
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-credit-memos.handler.ts
+++ b/src/handlers/search-quickbooks-credit-memos.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchCreditMemosInput {
 
 export async function searchQuickbooksCreditMemos(data: SearchCreditMemosInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria: Record<string, any> = {};
 
@@ -43,3 +42,4 @@ export async function searchQuickbooksCreditMemos(data: SearchCreditMemosInput):
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-credit-memos.handler.ts
+++ b/src/handlers/search-quickbooks-credit-memos.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-customers.handler.ts
+++ b/src/handlers/search-quickbooks-customers.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -6,12 +6,12 @@ import { formatError } from "../helpers/format-error.js";
  * Search customers from QuickBooks Online.
  *
  * Accepts either:
- *   â€¢ A plain criteria object (key/value pairs) â€“ passed directly to findCustomers
- *   â€¢ An **array** of objects in the `{ field, value, operator? }` shape â€“ this
+ *   • A plain criteria object (key/value pairs) – passed directly to findCustomers
+ *   • An **array** of objects in the `{ field, value, operator? }` shape – this
  *     allows use of operators such as `IN`, `LIKE`, `>`, `<`, `>=`, `<=` etc.
  *
  * Pagination / sorting options such as `limit`, `offset`, `asc`, `desc`,
- * `fetchAll`, `count` can be supplied via the topâ€‘level criteria object or as
+ * `fetchAll`, `count` can be supplied via the top‑level criteria object or as
  * dedicated entries in the array form (see README in user prompt).
  */
 export async function searchQuickbooksCustomers(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {

--- a/src/handlers/search-quickbooks-customers.handler.ts
+++ b/src/handlers/search-quickbooks-customers.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -6,18 +6,17 @@ import { formatError } from "../helpers/format-error.js";
  * Search customers from QuickBooks Online.
  *
  * Accepts either:
- *   • A plain criteria object (key/value pairs) – passed directly to findCustomers
- *   • An **array** of objects in the `{ field, value, operator? }` shape – this
+ *   â€¢ A plain criteria object (key/value pairs) â€“ passed directly to findCustomers
+ *   â€¢ An **array** of objects in the `{ field, value, operator? }` shape â€“ this
  *     allows use of operators such as `IN`, `LIKE`, `>`, `<`, `>=`, `<=` etc.
  *
  * Pagination / sorting options such as `limit`, `offset`, `asc`, `desc`,
- * `fetchAll`, `count` can be supplied via the top‑level criteria object or as
+ * `fetchAll`, `count` can be supplied via the topâ€‘level criteria object or as
  * dedicated entries in the array form (see README in user prompt).
  */
 export async function searchQuickbooksCustomers(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).findCustomers(criteria as any, (err: any, customers: any) => {

--- a/src/handlers/search-quickbooks-departments.handler.ts
+++ b/src/handlers/search-quickbooks-departments.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-departments.handler.ts
+++ b/src/handlers/search-quickbooks-departments.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchDepartmentsInput {
 
 export async function searchQuickbooksDepartments(data: SearchDepartmentsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;
@@ -27,3 +26,4 @@ export async function searchQuickbooksDepartments(data: SearchDepartmentsInput):
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-deposits.handler.ts
+++ b/src/handlers/search-quickbooks-deposits.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchDepositsInput {
 
 export async function searchQuickbooksDeposits(data: SearchDepositsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
     if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
@@ -27,3 +26,4 @@ export async function searchQuickbooksDeposits(data: SearchDepositsInput): Promi
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-deposits.handler.ts
+++ b/src/handlers/search-quickbooks-deposits.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-employees.handler.ts
+++ b/src/handlers/search-quickbooks-employees.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-employees.handler.ts
+++ b/src/handlers/search-quickbooks-employees.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksEmployees(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-estimates.handler.ts
+++ b/src/handlers/search-quickbooks-estimates.handler.ts
@@ -1,15 +1,14 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 /**
  * Search estimates from QuickBooks Online using the supplied criteria.
- * The criteria object is passed directly to node‑quickbooks `findEstimates`.
+ * The criteria object is passed directly to nodeâ€‘quickbooks `findEstimates`.
  */
 export async function searchQuickbooksEstimates(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).findEstimates(criteria as any, (err: any, estimates: any) => {

--- a/src/handlers/search-quickbooks-estimates.handler.ts
+++ b/src/handlers/search-quickbooks-estimates.handler.ts
@@ -1,10 +1,10 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
 /**
  * Search estimates from QuickBooks Online using the supplied criteria.
- * The criteria object is passed directly to nodeâ€‘quickbooks `findEstimates`.
+ * The criteria object is passed directly to node‑quickbooks `findEstimates`.
  */
 export async function searchQuickbooksEstimates(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {

--- a/src/handlers/search-quickbooks-invoices.handler.ts
+++ b/src/handlers/search-quickbooks-invoices.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-invoices.handler.ts
+++ b/src/handlers/search-quickbooks-invoices.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";
@@ -10,8 +10,7 @@ export type InvoiceSearchCriteria = QuickbooksSearchCriteriaInput;
  */
 export async function searchQuickbooksInvoices(criteria: InvoiceSearchCriteria): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const normalizedCriteria = buildQuickbooksSearchCriteria(criteria);
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-items.handler.ts
+++ b/src/handlers/search-quickbooks-items.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-items.handler.ts
+++ b/src/handlers/search-quickbooks-items.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria, QuickbooksSearchCriteriaInput } from "../helpers/build-quickbooks-search-criteria.js";
@@ -7,8 +7,7 @@ export type ItemSearchCriteria = QuickbooksSearchCriteriaInput;
 
 export async function searchQuickbooksItems(criteria: ItemSearchCriteria): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const normalizedCriteria = buildQuickbooksSearchCriteria(criteria);
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-journal-entries.handler.ts
+++ b/src/handlers/search-quickbooks-journal-entries.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksJournalEntries(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-journal-entries.handler.ts
+++ b/src/handlers/search-quickbooks-journal-entries.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-payment-methods.handler.ts
+++ b/src/handlers/search-quickbooks-payment-methods.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-payment-methods.handler.ts
+++ b/src/handlers/search-quickbooks-payment-methods.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchPaymentMethodsInput {
 
 export async function searchQuickbooksPaymentMethods(data: SearchPaymentMethodsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;
@@ -29,3 +28,4 @@ export async function searchQuickbooksPaymentMethods(data: SearchPaymentMethodsI
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-payments.handler.ts
+++ b/src/handlers/search-quickbooks-payments.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-payments.handler.ts
+++ b/src/handlers/search-quickbooks-payments.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -12,8 +12,7 @@ export interface SearchPaymentsInput {
 
 export async function searchQuickbooksPayments(data: SearchPaymentsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria: Record<string, any> = {};
 
@@ -44,3 +43,4 @@ export async function searchQuickbooksPayments(data: SearchPaymentsInput): Promi
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-purchase-orders.handler.ts
+++ b/src/handlers/search-quickbooks-purchase-orders.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-purchase-orders.handler.ts
+++ b/src/handlers/search-quickbooks-purchase-orders.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchPurchaseOrdersInput {
 
 export async function searchQuickbooksPurchaseOrders(data: SearchPurchaseOrdersInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria: Record<string, any> = {};
     if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;
@@ -34,3 +33,4 @@ export async function searchQuickbooksPurchaseOrders(data: SearchPurchaseOrdersI
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-purchases.handler.ts
+++ b/src/handlers/search-quickbooks-purchases.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
@@ -8,8 +8,7 @@ import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-searc
  */
 export async function searchQuickbooksPurchases(params: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria = buildQuickbooksSearchCriteria(params);
 

--- a/src/handlers/search-quickbooks-purchases.handler.ts
+++ b/src/handlers/search-quickbooks-purchases.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";

--- a/src/handlers/search-quickbooks-refund-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-refund-receipts.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchRefundReceiptsInput {
 
 export async function searchQuickbooksRefundReceipts(data: SearchRefundReceiptsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria: Record<string, any> = {};
 
@@ -43,3 +42,4 @@ export async function searchQuickbooksRefundReceipts(data: SearchRefundReceiptsI
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-refund-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-refund-receipts.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-sales-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-sales-receipts.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-sales-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-sales-receipts.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchSalesReceiptsInput {
 
 export async function searchQuickbooksSalesReceipts(data: SearchSalesReceiptsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const criteria: Record<string, any> = {};
 
@@ -43,3 +42,4 @@ export async function searchQuickbooksSalesReceipts(data: SearchSalesReceiptsInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-tax-agencies.handler.ts
+++ b/src/handlers/search-quickbooks-tax-agencies.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-tax-agencies.handler.ts
+++ b/src/handlers/search-quickbooks-tax-agencies.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface SearchTaxAgenciesInput {
 
 export async function searchQuickbooksTaxAgencies(data: SearchTaxAgenciesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.DisplayName = data.name;
     if (data.limit) criteria.limit = data.limit;
@@ -25,3 +24,4 @@ export async function searchQuickbooksTaxAgencies(data: SearchTaxAgenciesInput):
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-tax-codes.handler.ts
+++ b/src/handlers/search-quickbooks-tax-codes.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface SearchTaxCodesInput {
 
 export async function searchQuickbooksTaxCodes(data: SearchTaxCodesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;
@@ -29,3 +28,4 @@ export async function searchQuickbooksTaxCodes(data: SearchTaxCodesInput): Promi
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-tax-codes.handler.ts
+++ b/src/handlers/search-quickbooks-tax-codes.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-tax-rates.handler.ts
+++ b/src/handlers/search-quickbooks-tax-rates.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchTaxRatesInput {
 
 export async function searchQuickbooksTaxRates(data: SearchTaxRatesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;
@@ -27,3 +26,4 @@ export async function searchQuickbooksTaxRates(data: SearchTaxRatesInput): Promi
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-tax-rates.handler.ts
+++ b/src/handlers/search-quickbooks-tax-rates.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-terms.handler.ts
+++ b/src/handlers/search-quickbooks-terms.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-terms.handler.ts
+++ b/src/handlers/search-quickbooks-terms.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchTermsInput {
 
 export async function searchQuickbooksTerms(data: SearchTermsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.name) criteria.Name = data.name;
     if (data.active !== undefined) criteria.Active = data.active;
@@ -27,3 +26,4 @@ export async function searchQuickbooksTerms(data: SearchTermsInput): Promise<Too
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-time-activities.handler.ts
+++ b/src/handlers/search-quickbooks-time-activities.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface SearchTimeActivitiesInput {
 
 export async function searchQuickbooksTimeActivities(data: SearchTimeActivitiesInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.employee_ref) criteria.EmployeeRef = data.employee_ref;
     if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;
@@ -33,3 +32,4 @@ export async function searchQuickbooksTimeActivities(data: SearchTimeActivitiesI
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-time-activities.handler.ts
+++ b/src/handlers/search-quickbooks-time-activities.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-transfers.handler.ts
+++ b/src/handlers/search-quickbooks-transfers.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface SearchTransfersInput {
 
 export async function searchQuickbooksTransfers(data: SearchTransfersInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
     if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
@@ -27,3 +26,4 @@ export async function searchQuickbooksTransfers(data: SearchTransfersInput): Pro
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-transfers.handler.ts
+++ b/src/handlers/search-quickbooks-transfers.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-vendor-credits.handler.ts
+++ b/src/handlers/search-quickbooks-vendor-credits.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/search-quickbooks-vendor-credits.handler.ts
+++ b/src/handlers/search-quickbooks-vendor-credits.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface SearchVendorCreditsInput {
 
 export async function searchQuickbooksVendorCredits(data: SearchVendorCreditsInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const criteria: Record<string, any> = {};
     if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;
     if (data.limit) criteria.limit = data.limit;
@@ -25,3 +24,4 @@ export async function searchQuickbooksVendorCredits(data: SearchVendorCreditsInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/search-quickbooks-vendors.handler.ts
+++ b/src/handlers/search-quickbooks-vendors.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -6,12 +6,12 @@ import { formatError } from "../helpers/format-error.js";
  * Search vendors from QuickBooks Online.
  *
  * Accepts either:
- *   â€¢ A plain criteria object (key/value pairs) â€“ passed directly to findVendors
- *   â€¢ An **array** of objects in the `{ field, value, operator? }` shape â€“ this
+ *   • A plain criteria object (key/value pairs) – passed directly to findVendors
+ *   • An **array** of objects in the `{ field, value, operator? }` shape – this
  *     allows use of operators such as `IN`, `LIKE`, `>`, `<`, `>=`, `<=` etc.
  *
  * Pagination / sorting options such as `limit`, `offset`, `asc`, `desc`,
- * `fetchAll`, `count` can be supplied via the topâ€‘level criteria object or as
+ * `fetchAll`, `count` can be supplied via the top‑level criteria object or as
  * dedicated entries in the array form.
  */
 export async function searchQuickbooksVendors(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {

--- a/src/handlers/search-quickbooks-vendors.handler.ts
+++ b/src/handlers/search-quickbooks-vendors.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -6,18 +6,17 @@ import { formatError } from "../helpers/format-error.js";
  * Search vendors from QuickBooks Online.
  *
  * Accepts either:
- *   • A plain criteria object (key/value pairs) – passed directly to findVendors
- *   • An **array** of objects in the `{ field, value, operator? }` shape – this
+ *   â€¢ A plain criteria object (key/value pairs) â€“ passed directly to findVendors
+ *   â€¢ An **array** of objects in the `{ field, value, operator? }` shape â€“ this
  *     allows use of operators such as `IN`, `LIKE`, `>`, `<`, `>=`, `<=` etc.
  *
  * Pagination / sorting options such as `limit`, `offset`, `asc`, `desc`,
- * `fetchAll`, `count` can be supplied via the top‑level criteria object or as
+ * `fetchAll`, `count` can be supplied via the topâ€‘level criteria object or as
  * dedicated entries in the array form.
  */
 export async function searchQuickbooksVendors(criteria: object | Array<Record<string, any>> = {}): Promise<ToolResponse<any[]>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).findVendors(criteria as any, (err: any, vendors: any) => {

--- a/src/handlers/update-quickbooks-account.handler.ts
+++ b/src/handlers/update-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-account.handler.ts
+++ b/src/handlers/update-quickbooks-account.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -48,8 +48,7 @@ function normalizePatch(patch: Record<string, any>): Record<string, any> {
 
 export async function updateQuickbooksAccount({ account_id, patch }: UpdateAccountInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const existing: any = await new Promise((res, rej) => {
       (quickbooks as any).getAccount(account_id, (e: any, acc: any) => (e ? rej(e) : res(acc)));
     });

--- a/src/handlers/update-quickbooks-attachable.handler.ts
+++ b/src/handlers/update-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-attachable.handler.ts
+++ b/src/handlers/update-quickbooks-attachable.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateAttachableInput {
 
 export async function updateQuickbooksAttachable(data: UpdateAttachableInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.file_name) payload.FileName = data.file_name;
     if (data.note) payload.Note = data.note;
@@ -29,3 +28,4 @@ export async function updateQuickbooksAttachable(data: UpdateAttachableInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/update-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/update-quickbooks-bill-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksBillPayment(billPaymentData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updateBillPayment(billPaymentData, (err: any, billPayment: any) => {

--- a/src/handlers/update-quickbooks-bill.handler.ts
+++ b/src/handlers/update-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksBill(bill: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updateBill(bill, (err: any, updatedBill: any) => {

--- a/src/handlers/update-quickbooks-bill.handler.ts
+++ b/src/handlers/update-quickbooks-bill.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-class.handler.ts
+++ b/src/handlers/update-quickbooks-class.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdateClassInput {
 
 export async function updateQuickbooksClass(data: UpdateClassInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;
@@ -27,3 +26,4 @@ export async function updateQuickbooksClass(data: UpdateClassInput): Promise<Too
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-class.handler.ts
+++ b/src/handlers/update-quickbooks-class.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-company-info.handler.ts
+++ b/src/handlers/update-quickbooks-company-info.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-company-info.handler.ts
+++ b/src/handlers/update-quickbooks-company-info.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -21,8 +21,7 @@ export interface UpdateCompanyInfoInput {
 
 export async function updateQuickbooksCompanyInfo(data: UpdateCompanyInfoInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.company_name) payload.CompanyName = data.company_name;
     if (data.legal_name) payload.LegalName = data.legal_name;
@@ -48,3 +47,4 @@ export async function updateQuickbooksCompanyInfo(data: UpdateCompanyInfoInput):
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/update-quickbooks-credit-memo.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateCreditMemoInput {
 
 export async function updateQuickbooksCreditMemo(data: UpdateCreditMemoInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       Id: data.id,
@@ -44,3 +43,4 @@ export async function updateQuickbooksCreditMemo(data: UpdateCreditMemoInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/update-quickbooks-credit-memo.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-customer.handler.ts
+++ b/src/handlers/update-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksCustomer(customerData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updateCustomer(customerData, (err: any, customer: any) => {

--- a/src/handlers/update-quickbooks-customer.handler.ts
+++ b/src/handlers/update-quickbooks-customer.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-department.handler.ts
+++ b/src/handlers/update-quickbooks-department.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-department.handler.ts
+++ b/src/handlers/update-quickbooks-department.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdateDepartmentInput {
 
 export async function updateQuickbooksDepartment(data: UpdateDepartmentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;
@@ -27,3 +26,4 @@ export async function updateQuickbooksDepartment(data: UpdateDepartmentInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-deposit.handler.ts
+++ b/src/handlers/update-quickbooks-deposit.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-deposit.handler.ts
+++ b/src/handlers/update-quickbooks-deposit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -10,8 +10,7 @@ export interface UpdateDepositInput {
 
 export async function updateQuickbooksDeposit(data: UpdateDepositInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.private_note) payload.PrivateNote = data.private_note;
 
@@ -25,3 +24,4 @@ export async function updateQuickbooksDeposit(data: UpdateDepositInput): Promise
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-employee.handler.ts
+++ b/src/handlers/update-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-employee.handler.ts
+++ b/src/handlers/update-quickbooks-employee.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksEmployee(employeeData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updateEmployee(employeeData, (err: any, employee: any) => {

--- a/src/handlers/update-quickbooks-estimate.handler.ts
+++ b/src/handlers/update-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-estimate.handler.ts
+++ b/src/handlers/update-quickbooks-estimate.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksEstimate(estimateData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updateEstimate(estimateData, (err: any, estimate: any) => {

--- a/src/handlers/update-quickbooks-invoice.handler.ts
+++ b/src/handlers/update-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-invoice.handler.ts
+++ b/src/handlers/update-quickbooks-invoice.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface UpdateInvoiceInput {
 
 export async function updateQuickbooksInvoice({ invoice_id, patch }: UpdateInvoiceInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     // Need SyncToken; fetch existing invoice first
     const existing: any = await new Promise((res, rej) => {

--- a/src/handlers/update-quickbooks-item.handler.ts
+++ b/src/handlers/update-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -9,8 +9,7 @@ export interface UpdateItemInput {
 
 export async function updateQuickbooksItem({ item_id, patch }: UpdateItemInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     // Need SyncToken; fetch existing item first
     const existing: any = await new Promise((res, rej) => {

--- a/src/handlers/update-quickbooks-item.handler.ts
+++ b/src/handlers/update-quickbooks-item.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/update-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/update-quickbooks-journal-entry.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksJournalEntry(journalEntryData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updateJournalEntry(journalEntryData, (err: any, journalEntry: any) => {

--- a/src/handlers/update-quickbooks-payment-method.handler.ts
+++ b/src/handlers/update-quickbooks-payment-method.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdatePaymentMethodInput {
 
 export async function updateQuickbooksPaymentMethod(data: UpdatePaymentMethodInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;
@@ -27,3 +26,4 @@ export async function updateQuickbooksPaymentMethod(data: UpdatePaymentMethodInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-payment-method.handler.ts
+++ b/src/handlers/update-quickbooks-payment-method.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-payment.handler.ts
+++ b/src/handlers/update-quickbooks-payment.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-payment.handler.ts
+++ b/src/handlers/update-quickbooks-payment.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface UpdatePaymentInput {
 
 export async function updateQuickbooksPayment(data: UpdatePaymentInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const paymentPayload: any = {
       Id: data.id,
@@ -48,3 +47,4 @@ export async function updateQuickbooksPayment(data: UpdatePaymentInput): Promise
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/update-quickbooks-purchase-order.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdatePurchaseOrderInput {
 
 export async function updateQuickbooksPurchaseOrder(data: UpdatePurchaseOrderInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       Id: data.id,
@@ -38,3 +37,4 @@ export async function updateQuickbooksPurchaseOrder(data: UpdatePurchaseOrderInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/update-quickbooks-purchase-order.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-purchase.handler.ts
+++ b/src/handlers/update-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -8,8 +8,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksPurchase(purchaseData: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updatePurchase(purchaseData, (err: any, purchase: any) => {

--- a/src/handlers/update-quickbooks-purchase.handler.ts
+++ b/src/handlers/update-quickbooks-purchase.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-refund-receipt.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-refund-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateRefundReceiptInput {
 
 export async function updateQuickbooksRefundReceipt(data: UpdateRefundReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       Id: data.id,
@@ -44,3 +43,4 @@ export async function updateQuickbooksRefundReceipt(data: UpdateRefundReceiptInp
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-sales-receipt.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -12,8 +12,7 @@ export interface UpdateSalesReceiptInput {
 
 export async function updateQuickbooksSalesReceipt(data: UpdateSalesReceiptInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     const payload: any = {
       Id: data.id,
@@ -44,3 +43,4 @@ export async function updateQuickbooksSalesReceipt(data: UpdateSalesReceiptInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-sales-receipt.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-term.handler.ts
+++ b/src/handlers/update-quickbooks-term.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -14,8 +14,7 @@ export interface UpdateTermInput {
 
 export async function updateQuickbooksTerm(data: UpdateTermInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;
@@ -33,3 +32,4 @@ export async function updateQuickbooksTerm(data: UpdateTermInput): Promise<ToolR
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-term.handler.ts
+++ b/src/handlers/update-quickbooks-term.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-time-activity.handler.ts
+++ b/src/handlers/update-quickbooks-time-activity.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-time-activity.handler.ts
+++ b/src/handlers/update-quickbooks-time-activity.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -14,8 +14,7 @@ export interface UpdateTimeActivityInput {
 
 export async function updateQuickbooksTimeActivity(data: UpdateTimeActivityInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.hours !== undefined) payload.Hours = data.hours;
     if (data.minutes !== undefined) payload.Minutes = data.minutes;
@@ -33,3 +32,4 @@ export async function updateQuickbooksTimeActivity(data: UpdateTimeActivityInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-transfer.handler.ts
+++ b/src/handlers/update-quickbooks-transfer.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-transfer.handler.ts
+++ b/src/handlers/update-quickbooks-transfer.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -13,8 +13,7 @@ export interface UpdateTransferInput {
 
 export async function updateQuickbooksTransfer(data: UpdateTransferInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.from_account_ref) payload.FromAccountRef = { value: data.from_account_ref };
     if (data.to_account_ref) payload.ToAccountRef = { value: data.to_account_ref };
@@ -31,3 +30,4 @@ export async function updateQuickbooksTransfer(data: UpdateTransferInput): Promi
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/update-quickbooks-vendor-credit.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/update-quickbooks-vendor-credit.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -11,8 +11,7 @@ export interface UpdateVendorCreditInput {
 
 export async function updateQuickbooksVendorCredit(data: UpdateVendorCreditInput): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.vendor_ref) payload.VendorRef = { value: data.vendor_ref };
     if (data.private_note) payload.PrivateNote = data.private_note;
@@ -27,3 +26,4 @@ export async function updateQuickbooksVendorCredit(data: UpdateVendorCreditInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
+

--- a/src/handlers/update-quickbooks-vendor.handler.ts
+++ b/src/handlers/update-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 

--- a/src/handlers/update-quickbooks-vendor.handler.ts
+++ b/src/handlers/update-quickbooks-vendor.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+﻿import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -7,8 +7,7 @@ import { formatError } from "../helpers/format-error.js";
  */
 export async function updateQuickbooksVendor(vendor: any): Promise<ToolResponse<any>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       quickbooks.updateVendor(vendor, (err: any, updatedVendor: any) => {

--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -214,11 +214,16 @@ export const mockQuickBooksInstance = {
   reportSalesTaxLiability: jest.fn(),
 };
 
-// Mock QuickBooks client
+// Mock QuickBooks client (instance)
 export const mockQuickbooksClient = {
   authenticate: jest.fn<() => Promise<typeof mockQuickBooksInstance>>().mockResolvedValue(mockQuickBooksInstance),
   getQuickbooks: jest.fn<() => typeof mockQuickBooksInstance>().mockReturnValue(mockQuickBooksInstance),
   refreshAccessToken: jest.fn<() => Promise<{ access_token: string; expires_in: number }>>().mockResolvedValue({ access_token: 'mock-token', expires_in: 3600 }),
+};
+
+// Mock QuickbooksClient class (for handlers using QuickbooksClient.getInstance())
+export const mockQuickbooksClientClass = {
+  getInstance: jest.fn<() => Promise<typeof mockQuickBooksInstance>>().mockResolvedValue(mockQuickBooksInstance),
 };
 
 // Helper to create a successful callback mock
@@ -256,4 +261,6 @@ export function resetAllMocks() {
   mockQuickbooksClient.getQuickbooks.mockReset();
   (mockQuickbooksClient.getQuickbooks as any).mockReturnValue(mockQuickBooksInstance);
   (mockQuickbooksClient.authenticate as any).mockResolvedValue(mockQuickBooksInstance);
+  mockQuickbooksClientClass.getInstance.mockReset();
+  (mockQuickbooksClientClass.getInstance as any).mockResolvedValue(mockQuickBooksInstance);
 }

--- a/tests/unit/handlers/bill.handlers.test.ts
+++ b/tests/unit/handlers/bill.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -35,6 +36,26 @@ describe('Bill Handlers', () => {
       expect(result.result).toEqual(mockBill);
     });
 
+    it('should preserve already-structured line items and pass through bare lines', async () => {
+      const mockBill = { Id: '2', TotalAmt: 200 };
+      mockQuickBooksInstance.createBill.mockImplementation((_payload: any, cb: any) => cb(null, mockBill));
+
+      const result = await createQuickbooksBill({
+        Line: [
+          // already has AccountBasedExpenseLineDetail — must be returned as-is (line 18)
+          { Amount: 100, AccountBasedExpenseLineDetail: { AccountRef: { value: '1' } } },
+          // already has ItemBasedExpenseLineDetail — must be returned as-is (line 18)
+          { Amount: 50, ItemBasedExpenseLineDetail: { ItemRef: { value: '2' } } },
+          // no AccountRef and no detail key — bare pass-through (line 27)
+          { Amount: 0, DetailType: 'SubTotalLineDetail' },
+        ],
+        VendorRef: { value: '56' },
+      });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(mockBill);
+    });
+
     it('should handle API errors', async () => {
       mockQuickBooksInstance.createBill.mockImplementation((_payload: any, cb: any) =>
         cb(new Error('SAXParseException: Premature end of file'), null)
@@ -46,7 +67,7 @@ describe('Bill Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksBill({});
 
@@ -77,7 +98,7 @@ describe('Bill Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksBill('1');
 
@@ -108,7 +129,7 @@ describe('Bill Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksBill({ Id: '1', SyncToken: '0' });
 
@@ -139,7 +160,7 @@ describe('Bill Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksBill({ Id: '1', SyncToken: '0' });
 
@@ -218,7 +239,7 @@ describe('Bill Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksBills({});
 
@@ -227,3 +248,5 @@ describe('Bill Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/bill.handlers.test.ts
+++ b/tests/unit/handlers/bill.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/budget.handlers.test.ts
+++ b/tests/unit/handlers/budget.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({

--- a/tests/unit/handlers/budget.handlers.test.ts
+++ b/tests/unit/handlers/budget.handlers.test.ts
@@ -1,8 +1,9 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 const { searchQuickbooksBudgets } = await import('../../../src/handlers/search-quickbooks-budgets.handler');
@@ -70,7 +71,7 @@ describe('Budget Handlers', () => {
     });
 
     it('should propagate authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksBudgets({});
 
@@ -79,3 +80,5 @@ describe('Budget Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/budget.prototype-shape.test.ts
+++ b/tests/unit/handlers/budget.prototype-shape.test.ts
@@ -9,13 +9,20 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import QuickBooks from 'node-quickbooks';
 
-const mockQuickbooksClient = {
-  authenticate: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
-  getQuickbooks: jest.fn<() => QuickBooks>(),
+// Inline mocks for this test — uses a real QuickBooks prototype instance
+// so that prototype-shape drift is caught without network or credentials.
+let mockQbInstance: QuickBooks;
+
+const mockQuickbooksClientClass = {
+  getInstance: jest.fn<() => Promise<QuickBooks>>(),
 };
 
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
-  quickbooksClient: mockQuickbooksClient,
+  quickbooksClient: {
+    authenticate: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    getQuickbooks: jest.fn<() => QuickBooks>(),
+  },
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 const { searchQuickbooksBudgets } = await import('../../../src/handlers/search-quickbooks-budgets.handler');
@@ -23,7 +30,8 @@ const { searchQuickbooksBudgets } = await import('../../../src/handlers/search-q
 describe('search_budgets prototype-shape contract', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
-    mockQuickbooksClient.authenticate.mockResolvedValue(undefined);
+    mockQbInstance = Object.create(QuickBooks.prototype) as QuickBooks;
+    (mockQuickbooksClientClass.getInstance as any).mockResolvedValue(mockQbInstance);
   });
 
   it('node-quickbooks exposes findBudgets on its prototype', () => {
@@ -31,9 +39,6 @@ describe('search_budgets prototype-shape contract', () => {
   });
 
   it('handler invokes a method that exists on the real QuickBooks prototype', async () => {
-    const qb = Object.create(QuickBooks.prototype) as QuickBooks;
-    mockQuickbooksClient.getQuickbooks.mockReturnValue(qb);
-
     const spy = jest
       .spyOn(QuickBooks.prototype as any, 'findBudgets')
       .mockImplementation(function (this: unknown, _criteria: any, cb: any) {

--- a/tests/unit/handlers/class.handlers.test.ts
+++ b/tests/unit/handlers/class.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -70,7 +71,7 @@ describe('Class Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksClass('123');
 
@@ -109,7 +110,7 @@ describe('Class Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksClass({ id: '123', sync_token: '0', name: 'Test' });
 
@@ -163,7 +164,7 @@ describe('Class Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksClasses({});
 
@@ -174,7 +175,7 @@ describe('Class Handlers', () => {
 
   describe('createQuickbooksClass', () => {
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksClass({ name: 'Test' });
 
@@ -183,3 +184,5 @@ describe('Class Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/class.handlers.test.ts
+++ b/tests/unit/handlers/class.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/company-attachable.handlers.test.ts
+++ b/tests/unit/handlers/company-attachable.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -128,7 +129,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksCompanyInfo({ id: '1', sync_token: '0' });
 
@@ -139,7 +140,7 @@ describe('Company and Attachable Handlers', () => {
 
   describe('getQuickbooksCompanyInfo auth errors', () => {
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCompanyInfo();
 
@@ -184,7 +185,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksAttachable({ file_name: 'test.pdf' });
 
@@ -214,7 +215,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksAttachable('1');
 
@@ -249,7 +250,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksAttachable({ id: '1', sync_token: '0' });
 
@@ -278,7 +279,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksAttachable({ id: '1', sync_token: '0' });
 
@@ -325,7 +326,7 @@ describe('Company and Attachable Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksAttachables({});
 
@@ -345,3 +346,5 @@ describe('Company and Attachable Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/company-attachable.handlers.test.ts
+++ b/tests/unit/handlers/company-attachable.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/credit-memo.handlers.test.ts
+++ b/tests/unit/handlers/credit-memo.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -43,7 +44,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksCreditMemo({ customer_ref: 'cust-1', line_items: [] });
 
@@ -92,7 +93,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCreditMemo('123');
 
@@ -122,7 +123,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksCreditMemo({ id: '123', sync_token: '0' });
 
@@ -167,7 +168,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksCreditMemo({ id: '123', sync_token: '0' });
 
@@ -215,7 +216,7 @@ describe('CreditMemo Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksCreditMemos({});
 
@@ -235,3 +236,5 @@ describe('CreditMemo Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/credit-memo.handlers.test.ts
+++ b/tests/unit/handlers/credit-memo.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/department-term-paymentmethod.handlers.test.ts
+++ b/tests/unit/handlers/department-term-paymentmethod.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -91,7 +92,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
       });
 
       it('should handle authentication errors', async () => {
-        (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+        (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
         const result = await searchQuickbooksDepartments({});
 
@@ -112,7 +113,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should create department - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksDepartment({ name: 'Test' });
 
@@ -131,7 +132,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should get department - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksDepartment('1');
 
@@ -150,7 +151,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should update department - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksDepartment({ id: '1', sync_token: '0' });
 
@@ -260,7 +261,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
       });
 
       it('should handle authentication errors', async () => {
-        (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+        (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
         const result = await searchQuickbooksTerms({});
 
@@ -281,7 +282,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should create term - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksTerm({ name: 'Test', due_days: 30 });
 
@@ -300,7 +301,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should get term - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTerm('1');
 
@@ -319,7 +320,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should update term - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksTerm({ id: '1', sync_token: '0' });
 
@@ -403,7 +404,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
       });
 
       it('should handle authentication errors', async () => {
-        (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+        (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
         const result = await searchQuickbooksPaymentMethods({});
 
@@ -424,7 +425,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should create payment method - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksPaymentMethod({ name: 'Test', type: 'NON_CREDIT_CARD' });
 
@@ -443,7 +444,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should get payment method - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksPaymentMethod('1');
 
@@ -462,7 +463,7 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
 
     it('should update payment method - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksPaymentMethod({ id: '1', sync_token: '0' });
 
@@ -481,3 +482,5 @@ describe('Department, Term, PaymentMethod Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/department-term-paymentmethod.handlers.test.ts
+++ b/tests/unit/handlers/department-term-paymentmethod.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/deposit-transfer.handlers.test.ts
+++ b/tests/unit/handlers/deposit-transfer.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -77,7 +78,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should create a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksDeposit({
         deposit_to_account_ref: 'account-1',
@@ -97,7 +98,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should get a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksDeposit('1');
 
@@ -136,7 +137,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should update a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksDeposit({ id: '1', sync_token: '0' });
 
@@ -163,7 +164,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should delete a deposit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksDeposit({ id: '1', sync_token: '0' });
 
@@ -202,7 +203,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should search deposits - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksDeposits({});
 
@@ -274,7 +275,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should get a transfer - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTransfer('1');
 
@@ -319,7 +320,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should update a transfer - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksTransfer({ id: '1', sync_token: '0' });
 
@@ -346,7 +347,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should delete a transfer - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksTransfer({ id: '1', sync_token: '0' });
 
@@ -375,7 +376,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should search transfers - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTransfers({});
 
@@ -419,7 +420,7 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Token expired'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Token expired'));
 
       const result = await createQuickbooksTransfer({
         from_account_ref: 'account-1',
@@ -446,3 +447,5 @@ describe('Deposit and Transfer Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/deposit-transfer.handlers.test.ts
+++ b/tests/unit/handlers/deposit-transfer.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/payment.handlers.test.ts
+++ b/tests/unit/handlers/payment.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -42,7 +43,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksPayment({ customer_ref: 'cust-1', total_amt: 100 });
 
@@ -95,7 +96,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksPayment('123');
 
@@ -161,7 +162,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksPayment({ id: '123', sync_token: '0', total_amt: 150 });
 
@@ -193,7 +194,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksPayment({ id: '123', sync_token: '0' });
 
@@ -237,7 +238,7 @@ describe('Payment Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksPayments({ limit: 10 });
 
@@ -261,3 +262,5 @@ describe('Payment Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/payment.handlers.test.ts
+++ b/tests/unit/handlers/payment.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/purchase-employee-search.handlers.test.ts
+++ b/tests/unit/handlers/purchase-employee-search.handlers.test.ts
@@ -1,16 +1,17 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
 const { searchQuickbooksPurchases } = await import('../../../src/handlers/search-quickbooks-purchases.handler');
 const { searchQuickbooksEmployees } = await import('../../../src/handlers/search-quickbooks-employees.handler');
 
-describe('search_purchases – Fixes #14', () => {
+describe('search_purchases â€“ Fixes #14', () => {
   beforeEach(() => {
     resetAllMocks();
   });
@@ -51,7 +52,7 @@ describe('search_purchases – Fixes #14', () => {
   });
 
   it('should handle authentication errors', async () => {
-    (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+    (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
     const result = await searchQuickbooksPurchases({});
 
@@ -60,7 +61,7 @@ describe('search_purchases – Fixes #14', () => {
   });
 });
 
-describe('search_employees – Fixes #15', () => {
+describe('search_employees â€“ Fixes #15', () => {
   beforeEach(() => {
     resetAllMocks();
   });
@@ -101,7 +102,7 @@ describe('search_employees – Fixes #15', () => {
   });
 
   it('should handle authentication errors', async () => {
-    (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+    (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
     const result = await searchQuickbooksEmployees({});
 
@@ -109,3 +110,5 @@ describe('search_employees – Fixes #15', () => {
     expect(result.error).toContain('Auth failed');
   });
 });
+
+

--- a/tests/unit/handlers/purchase-employee-search.handlers.test.ts
+++ b/tests/unit/handlers/purchase-employee-search.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
@@ -11,7 +11,7 @@ jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
 const { searchQuickbooksPurchases } = await import('../../../src/handlers/search-quickbooks-purchases.handler');
 const { searchQuickbooksEmployees } = await import('../../../src/handlers/search-quickbooks-employees.handler');
 
-describe('search_purchases â€“ Fixes #14', () => {
+describe('search_purchases – Fixes #14', () => {
   beforeEach(() => {
     resetAllMocks();
   });
@@ -61,7 +61,7 @@ describe('search_purchases â€“ Fixes #14', () => {
   });
 });
 
-describe('search_employees â€“ Fixes #15', () => {
+describe('search_employees – Fixes #15', () => {
   beforeEach(() => {
     resetAllMocks();
   });

--- a/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
+++ b/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -57,7 +58,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should create a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksRefundReceipt({
         customer_ref: 'cust-1',
@@ -90,7 +91,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should get a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksRefundReceipt('1');
 
@@ -131,7 +132,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should update a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksRefundReceipt({ id: '1', sync_token: '0' });
 
@@ -158,7 +159,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should delete a refund receipt - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksRefundReceipt({ id: '1', sync_token: '0' });
 
@@ -187,7 +188,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should search refund receipts - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksRefundReceipts({});
 
@@ -267,7 +268,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should create a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksPurchaseOrder({
         vendor_ref: 'vendor-1',
@@ -300,7 +301,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should get a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksPurchaseOrder('1');
 
@@ -341,7 +342,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should update a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksPurchaseOrder({ id: '1', sync_token: '0' });
 
@@ -368,7 +369,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should delete a purchase order - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksPurchaseOrder({ id: '1', sync_token: '0' });
 
@@ -397,7 +398,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should search purchase orders - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksPurchaseOrders({});
 
@@ -469,7 +470,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should create a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksVendorCredit({
         vendor_ref: 'vendor-1',
@@ -502,7 +503,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should get a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksVendorCredit('1');
 
@@ -542,7 +543,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should update a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksVendorCredit({ id: '1', sync_token: '0' });
 
@@ -569,7 +570,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should delete a vendor credit - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksVendorCredit({ id: '1', sync_token: '0' });
 
@@ -598,7 +599,7 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
 
     it('should search vendor credits - authentication error', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksVendorCredits({});
 
@@ -641,3 +642,5 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
+++ b/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/reports.handlers.test.ts
+++ b/tests/unit/handlers/reports.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -59,8 +60,17 @@ describe('Report Handlers', () => {
       expect(result.isError).toBe(true);
     });
 
+    it('should handle start_date only (no end_date)', async () => {
+      const mockReport = { Header: { ReportName: 'BalanceSheet' } };
+      mockQuickBooksInstance.reportBalanceSheet.mockImplementation((params: any, cb: any) => cb(null, mockReport));
+
+      const result = await getQuickbooksBalanceSheet({ start_date: '2024-01-01' });
+
+      expect(result.isError).toBe(false);
+    });
+
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksBalanceSheet({});
 
@@ -115,7 +125,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksProfitAndLoss({});
 
@@ -158,7 +168,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCashFlow({});
 
@@ -201,7 +211,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTrialBalance({});
 
@@ -247,7 +257,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksGeneralLedger({});
 
@@ -291,7 +301,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCustomerSales({});
 
@@ -337,7 +347,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksAgedReceivables({});
 
@@ -380,7 +390,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksCustomerBalance({});
 
@@ -425,7 +435,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksAgedPayables({});
 
@@ -470,7 +480,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksVendorExpenses({});
 
@@ -513,7 +523,7 @@ describe('Report Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksVendorBalance({});
 
@@ -522,3 +532,5 @@ describe('Report Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/reports.handlers.test.ts
+++ b/tests/unit/handlers/reports.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/sales-receipt.handlers.test.ts
+++ b/tests/unit/handlers/sales-receipt.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -43,7 +44,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksSalesReceipt({ customer_ref: 'cust-1', line_items: [] });
 
@@ -94,7 +95,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksSalesReceipt('123');
 
@@ -139,7 +140,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksSalesReceipt({ id: '123', sync_token: '0' });
 
@@ -168,7 +169,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksSalesReceipt({ id: '123', sync_token: '0' });
 
@@ -201,7 +202,7 @@ describe('SalesReceipt Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksSalesReceipts({});
 
@@ -236,3 +237,5 @@ describe('SalesReceipt Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/sales-receipt.handlers.test.ts
+++ b/tests/unit/handlers/sales-receipt.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/tax-entities.handlers.test.ts
+++ b/tests/unit/handlers/tax-entities.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -75,7 +76,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTaxCodes({});
 
@@ -97,7 +98,7 @@ describe('Tax Entity Handlers', () => {
 
   describe('getQuickbooksTaxCode auth tests', () => {
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTaxCode('1');
 
@@ -128,7 +129,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTaxRate('1');
 
@@ -171,7 +172,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTaxRates({});
 
@@ -213,7 +214,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTaxAgency('1');
 
@@ -267,7 +268,7 @@ describe('Tax Entity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTaxAgencies({});
 
@@ -276,3 +277,5 @@ describe('Tax Entity Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/tax-entities.handlers.test.ts
+++ b/tests/unit/handlers/tax-entities.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/time-activity.handlers.test.ts
+++ b/tests/unit/handlers/time-activity.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -58,7 +59,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksTimeActivity({ name_of: 'Vendor' });
 
@@ -112,7 +113,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksTimeActivity('123');
 
@@ -141,7 +142,8 @@ describe('TimeActivity Handlers', () => {
         hours: 8,
         minutes: 30,
         description: 'Updated task',
-        billable_status: 'Billable'
+        billable_status: 'Billable',
+        item_ref: 'item-1'
       });
 
       expect(result.isError).toBe(false);
@@ -158,7 +160,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksTimeActivity({ id: '123', sync_token: '0' });
 
@@ -187,7 +189,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksTimeActivity({ id: '123', sync_token: '0' });
 
@@ -220,7 +222,7 @@ describe('TimeActivity Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksTimeActivities({});
 
@@ -257,3 +259,5 @@ describe('TimeActivity Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/time-activity.handlers.test.ts
+++ b/tests/unit/handlers/time-activity.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking

--- a/tests/unit/handlers/vendor.handlers.test.ts
+++ b/tests/unit/handlers/vendor.handlers.test.ts
@@ -1,9 +1,10 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic imports after mock setup
@@ -43,7 +44,7 @@ describe('Vendor Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await createQuickbooksVendor({});
 
@@ -74,7 +75,7 @@ describe('Vendor Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await getQuickbooksVendor('56');
 
@@ -105,7 +106,7 @@ describe('Vendor Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await updateQuickbooksVendor({ Id: '56', SyncToken: '0' });
 
@@ -136,7 +137,7 @@ describe('Vendor Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await deleteQuickbooksVendor({ Id: '56', SyncToken: '0' });
 
@@ -215,7 +216,7 @@ describe('Vendor Handlers', () => {
     });
 
     it('should handle authentication errors', async () => {
-      (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+      (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
       const result = await searchQuickbooksVendors({});
 
@@ -224,3 +225,5 @@ describe('Vendor Handlers', () => {
     });
   });
 });
+
+

--- a/tests/unit/handlers/vendor.handlers.test.ts
+++ b/tests/unit/handlers/vendor.handlers.test.ts
@@ -1,4 +1,4 @@
-﻿import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking


### PR DESCRIPTION
## Summary

This PR fixes three distinct issues in the QuickBooks Online MCP server.

### 1. Balance Sheet `end_date` ignored — root cause correctly identified

**What actually happened:** The original handler (`86afee2`) conditionally passed `start_date` and `end_date` to the QBO API only when the caller supplied them. This worked correctly when both were provided. However, the QBO BalanceSheet endpoint has an undocumented behavior: **it silently ignores `end_date` when `start_date` is absent**, always returning the year-to-date balance sheet regardless of the end date specified.

Callers passing only `end_date` (the common case for "give me the 2024 year-end balance sheet") got today's data. A prior fix attempt (commit `f48147f`, cherry-picked onto `main` from an intermediate state of this PR) removed `start_date` entirely, citing the **opposite** hypothesis — that `start_date` was causing `end_date` to be ignored. That hypothesis is incorrect; that commit made the behavior worse for all callers.

**The actual fix:** when `end_date` is supplied without `start_date`, the handler now auto-supplies `start_date` as January 1st of the same year. This ensures both parameters are always sent together, which QBO honors correctly.

Verified against the live production QBO API: `end_date: "2024-12-31"` returns `EndPeriod: "2024-12-31"` with historically accurate data (Total Assets $210,628), different from today's live balance ($186,456).

### 2. Access token not refreshed on every tool call

All 143 handlers previously relied on `quickbooksClient.authenticate()` being called once at server startup. The QBO access token expires after 60 minutes; any handler call after expiry would fail silently or error. Every handler now calls `QuickbooksClient.getInstance()` instead, which checks token freshness on every invocation and silently refreshes before the 60-minute boundary. `QuickbooksClient` is now a named export so handlers can import the static method directly.

### 3. OAuth browser flow triggered on every tool call

Claude Desktop (and similar MCP host apps) can inject explicit empty-string values for `QUICKBOOKS_REFRESH_TOKEN` and `QUICKBOOKS_REALM_ID` in their MCP server `env` config. The previous `dotenv.config()` call (no options) silently skipped loading those keys from `.env` because `dotenv`'s default behavior does not overwrite keys that already exist in `process.env` — even when they are set to `""`. The server therefore started with blank tokens on every launch and triggered a full browser OAuth flow on the very first tool call of every session.

Fix: pass `{ override: true }` to `dotenv.config()` so values from the `.env` file always win over whatever empty-string placeholders the host app injected.

## Test plan

- [ ] All 337 tests pass (`npm test`) — 100% statement/branch/function/line coverage maintained
- [ ] `get_balance_sheet({ end_date: "2024-12-31" })` returns `EndPeriod: "2024-12-31"` (not today's date)
- [ ] Back-to-back tool calls within a running server session do not trigger an OAuth browser flow
- [ ] Server restart with a valid `.env` does not trigger OAuth
