### PR TITLE
Persist rotated refresh_token after each refresh

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -172,10 +172,38 @@ class QuickbooksClient {
     fs.writeFileSync(tokenPath, envLines.join('\n'));
   }
 
+  private reloadRefreshTokenFromEnv(): void {
+    // Multiple processes (e.g. one MCP host per client) can each hold a
+    // QuickbooksClient and refresh independently. Because QBO rotates the
+    // refresh_token on every refresh, the in-memory copy in process A goes
+    // stale the moment process B refreshes and persists the rotated value.
+    // Re-reading .env right before we attempt a refresh lets process A pick
+    // up the value process B just persisted, instead of failing with 400/401.
+    try {
+      const tokenPath = path.join(__dirname, '..', '..', '.env');
+      const envContent = fs.readFileSync(tokenPath, 'utf-8');
+      for (const rawLine of envContent.split('\n')) {
+        const line = rawLine.trim();
+        if (!line.startsWith('QUICKBOOKS_REFRESH_TOKEN=')) continue;
+        const value = line.slice('QUICKBOOKS_REFRESH_TOKEN='.length).trim();
+        if (value && value !== this.refreshToken) {
+          this.refreshToken = value;
+        }
+        return;
+      }
+    } catch {
+      // Best-effort. If .env can't be read, fall through and try with whatever
+      // is already in memory; refreshUsingToken will surface the error.
+    }
+  }
+
   async refreshAccessToken() {
+    // Pick up any refresh_token rotation persisted by a sibling process.
+    this.reloadRefreshTokenFromEnv();
+
     if (!this.refreshToken) {
       await this.startOAuthFlow();
-      
+
       // Verify we have a refresh token after OAuth flow
       if (!this.refreshToken) {
         throw new Error('Failed to obtain refresh token from OAuth flow');
@@ -185,13 +213,31 @@ class QuickbooksClient {
     try {
       // At this point we know refreshToken is not undefined
       const authResponse = await this.oauthClient.refreshUsingToken(this.refreshToken);
-      
+
       this.accessToken = authResponse.token.access_token;
-      
+
+      // QuickBooks rotates the refresh_token on refresh (approximately every
+      // 24 hours a new value is returned). If the rotated value isn't
+      // captured and persisted, the next refresh will fail with
+      // "Failed to refresh Quickbooks token: Request failed with status code
+      // 400" because the stored refresh_token is now invalid. Capture and
+      // persist whenever QBO returns a new value.
+      const rotatedRefreshToken = (authResponse.token as { refresh_token?: string }).refresh_token;
+      if (rotatedRefreshToken && rotatedRefreshToken !== this.refreshToken) {
+        this.refreshToken = rotatedRefreshToken;
+        try {
+          this.saveTokensToEnv();
+        } catch (persistError: any) {
+          console.error(
+            `[quickbooks-client] failed to persist rotated refresh token: ${persistError?.message ?? persistError}`,
+          );
+        }
+      }
+
       // Calculate expiry time
       const expiresIn = authResponse.token.expires_in || 3600; // Default to 1 hour
       this.accessTokenExpiry = new Date(Date.now() + expiresIn * 1000);
-      
+
       return {
         access_token: this.accessToken,
         expires_in: expiresIn,


### PR DESCRIPTION
## Summary

`refreshAccessToken()` had two related bugs that combined to force a manual re-OAuth roughly every other day in any deployment with more than one client process (the common MCP-server pattern, where each client host spawns its own server instance):

1. **Persistence:** only the new `access_token` was captured. The rotated `refresh_token` that QBO returns alongside it was discarded, so `.env` still held the previous value and the next refresh failed with `Failed to refresh Quickbooks token: Request failed with status code 400`.
2. **Concurrency:** when a second process refreshed and persisted the rotated value, the first process still held the now-invalidated value in memory. Its next refresh failed with 400/401 even though `.env` on disk was correct.

## Change

Two narrow additions to `src/clients/quickbooks-client.ts`:

- **Capture and persist** the rotated `refresh_token` from the refresh response, update `this.refreshToken`, and call the existing `saveTokensToEnv()` helper. Persistence failures are logged via `console.error` but do not block the in-flight request.
- **`reloadRefreshTokenFromEnv()`** — called at the top of `refreshAccessToken()` so a process that has been idle picks up whatever a sibling process most recently persisted before attempting its own refresh.

Cast through `{ refresh_token?: string }` because the `intuit-oauth` `Token` type only declares `access_token` + `expires_in`, but the API response includes `refresh_token`.

## Why

QBO refresh tokens are valid for ~100 days, but a new one is issued on each refresh ([Intuit docs](https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0#refresh-the-access-token)). Without rotation capture, this server forces re-auth after one rotation cycle. Without the disk re-read, multi-process deployments fail even when capture works because in-memory state diverges from `.env`.

## Test plan

- [x] TypeScript builds (`npm run build`) with no errors
- [x] Initial OAuth flow still works (unchanged path — `startOAuthFlow` already calls `saveTokensToEnv`)
- [x] `refreshAccessToken()` now persists the rotated token to `.env` when QBO returns one
- [x] Sibling process picks up the persisted token via `reloadRefreshTokenFromEnv()` before its own refresh attempt
- [ ] Multi-process deployment runs through full token lifetime without re-auth (validating in our own deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)