### PR TITLE
fix(journal-entry): replace z.any() schemas with structural Zod validation

### DIFF
--- a/src/tools/create-journal-entry.tool.ts
+++ b/src/tools/create-journal-entry.tool.ts
@@ -4,17 +4,41 @@ import { z } from "zod";
 
 // Define the tool metadata
 const toolName = "create_journal_entry";
-const toolDescription = "Create a journal entry in QuickBooks Online.";
+const toolDescription = "Create a journal entry in QuickBooks Online. Description goes on the Line level, not inside JournalEntryLineDetail.";
 
 // Define the expected input schema for creating a journal entry
 const toolSchema = z.object({
-  journalEntry: z.any(),
+  journalEntry: z.object({
+    TxnDate: z.string().describe("Transaction date in YYYY-MM-DD format"),
+    PrivateNote: z.string().optional().describe("Private memo for the journal entry"),
+    DocNumber: z.string().optional().describe("Journal number"),
+    Line: z.array(z.object({
+      Amount: z.number(),
+      DetailType: z.literal("JournalEntryLineDetail"),
+      Description: z.string().optional().describe("Line description (must be at Line level, NOT inside JournalEntryLineDetail)"),
+      JournalEntryLineDetail: z.object({
+        PostingType: z.enum(["Debit", "Credit"]),
+        AccountRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }),
+        ClassRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }).optional(),
+        DepartmentRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }).optional(),
+      }),
+    })),
+  }),
 });
 
 type ToolParams = z.infer<typeof toolSchema>;
 
 // Define the tool handler
-const toolHandler = async (args: any) => {
+const toolHandler = async (args: { [x: string]: any }) => {
   const response = await createQuickbooksJournalEntry(args.params.journalEntry);
 
   if (response.isError) {

--- a/src/tools/update-journal-entry.tool.ts
+++ b/src/tools/update-journal-entry.tool.ts
@@ -8,13 +8,41 @@ const toolDescription = "Update a journal entry in QuickBooks Online.";
 
 // Define the expected input schema for updating a journal entry
 const toolSchema = z.object({
-  journalEntry: z.any(),
+  journalEntry: z.object({
+    Id: z.string().describe("The journal entry ID to update"),
+    SyncToken: z.string().describe("Current SyncToken (required for concurrency control)"),
+    sparse: z.boolean().optional().describe("If true, only update provided fields"),
+    TxnDate: z.string().optional().describe("Transaction date in YYYY-MM-DD format"),
+    PrivateNote: z.string().optional().describe("Private memo"),
+    DocNumber: z.string().optional().describe("Journal number"),
+    Line: z.array(z.object({
+      Id: z.string().optional(),
+      Amount: z.number(),
+      DetailType: z.literal("JournalEntryLineDetail"),
+      Description: z.string().optional().describe("Line description (must be at Line level, NOT inside JournalEntryLineDetail)"),
+      JournalEntryLineDetail: z.object({
+        PostingType: z.enum(["Debit", "Credit"]),
+        AccountRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }),
+        ClassRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }).optional(),
+        DepartmentRef: z.object({
+          value: z.string(),
+          name: z.string().optional(),
+        }).optional(),
+      }),
+    })).optional(),
+  }),
 });
 
 type ToolParams = z.infer<typeof toolSchema>;
 
 // Define the tool handler
-const toolHandler = async (args: any) => {
+const toolHandler = async (args: { [x: string]: any }) => {
   const response = await updateQuickbooksJournalEntry(args.params.journalEntry);
 
   if (response.isError) {


### PR DESCRIPTION
## Summary

Replaces `journalEntry: z.any()` in `create_journal_entry` and `update_journal_entry` tools with a proper Zod schema that mirrors the QBO API's `JournalEntry` shape. Fields are documented inline, including the easy-to-miss rule that `Description` belongs at the `Line` level — **not** nested inside `JournalEntryLineDetail`.

## Why

`z.any()` provides no input validation, so structurally-wrong payloads round-trip to the QBO API and come back as opaque `failed to parse json object` errors. The most common LLM/agent failure I hit was placing `Description` inside `JournalEntryLineDetail`. With a proper schema, the MCP layer rejects the payload up front with a useful error, and the LLM gets the corrected shape from the schema description on the next attempt.

## Scope

- 2 files: `src/tools/create-journal-entry.tool.ts`, `src/tools/update-journal-entry.tool.ts`
- No handler changes, no API changes — purely tightening the input schema
- Mirrors the same structural-Zod pattern used for `create-bill`, `update-bill`, and other already-merged tools

## Context — branch off the consolidated PR #42

I previously opened the consolidated #42 to surface a batch of community fixes. The initial consolidation was well received and was substantively accepted as its component PRs (#18, #22, #26, #30 merged; #31, #32, #35, and #40's content folded in via direct commits — thank you!) — but **this journal-entry Zod fix was missed in that absorption**, which is why I'm re-filing it as a focused, single-concern PR off a fresh `main`.

This branch (`johntrandall:slim`) is upstream `main` + this one commit, no other drift.

## Test plan

- [x] `npm run build` succeeds
- [ ] `create_journal_entry` with `Description` correctly placed on `Line` → still works (no behavior change)
- [ ] `create_journal_entry` with `Description` placed inside `JournalEntryLineDetail` → schema validation rejects with a clear error, instead of opaque QBO 400
- [ ] `update_journal_entry` accepts a structurally valid update payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)