### PR TITLE
Add binary file upload support to `create_attachable`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
+                "@jest/globals": "^30.3.0",
                 "@types/jest": "^30.0.0",
                 "@types/node": "^22.13.10",
                 "eslint": "^9.22.0",
@@ -1172,19 +1173,397 @@
             }
         },
         "node_modules/@jest/globals": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+            "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.2.0",
-                "@jest/expect": "30.2.0",
-                "@jest/types": "30.2.0",
-                "jest-mock": "30.2.0"
+                "@jest/environment": "30.3.0",
+                "@jest/expect": "30.3.0",
+                "@jest/types": "30.3.0",
+                "jest-mock": "30.3.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/diff-sequences": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+            "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/environment": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+            "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.3.0",
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-mock": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/expect": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+            "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "30.3.0",
+                "jest-snapshot": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/expect-utils": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+            "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/fake-timers": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+            "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@sinonjs/fake-timers": "^15.0.0",
+                "@types/node": "*",
+                "jest-message-util": "30.3.0",
+                "jest-mock": "30.3.0",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/snapshot-utils": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+            "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "natural-compare": "^1.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/transform": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+            "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/types": "30.3.0",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "babel-plugin-istanbul": "^7.0.1",
+                "chalk": "^4.1.2",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.3.0",
+                "jest-regex-util": "30.0.1",
+                "jest-util": "30.3.0",
+                "pirates": "^4.0.7",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^5.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/types": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+            "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.0.1",
+                "@jest/schemas": "30.0.5",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@sinonjs/fake-timers": {
+            "version": "15.3.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+            "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/expect": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+            "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/expect-utils": "30.3.0",
+                "@jest/get-type": "30.1.0",
+                "jest-matcher-utils": "30.3.0",
+                "jest-message-util": "30.3.0",
+                "jest-mock": "30.3.0",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-diff": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+            "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/diff-sequences": "30.3.0",
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "pretty-format": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-haste-map": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+            "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "anymatch": "^3.1.3",
+                "fb-watchman": "^2.0.2",
+                "graceful-fs": "^4.2.11",
+                "jest-regex-util": "30.0.1",
+                "jest-util": "30.3.0",
+                "jest-worker": "30.3.0",
+                "picomatch": "^4.0.3",
+                "walker": "^1.0.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.3"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-matcher-utils": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+            "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "jest-diff": "30.3.0",
+                "pretty-format": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-message-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+            "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.3.0",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3",
+                "pretty-format": "30.3.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-mock": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+            "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-snapshot": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+            "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@babel/generator": "^7.27.5",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1",
+                "@babel/types": "^7.27.3",
+                "@jest/expect-utils": "30.3.0",
+                "@jest/get-type": "30.1.0",
+                "@jest/snapshot-utils": "30.3.0",
+                "@jest/transform": "30.3.0",
+                "@jest/types": "30.3.0",
+                "babel-preset-current-node-syntax": "^1.2.0",
+                "chalk": "^4.1.2",
+                "expect": "30.3.0",
+                "graceful-fs": "^4.2.11",
+                "jest-diff": "30.3.0",
+                "jest-matcher-utils": "30.3.0",
+                "jest-message-util": "30.3.0",
+                "jest-util": "30.3.0",
+                "pretty-format": "30.3.0",
+                "semver": "^7.7.2",
+                "synckit": "^0.11.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+            "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-worker": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+            "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@ungap/structured-clone": "^1.3.0",
+                "jest-util": "30.3.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/pretty-format": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+            "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.0.5",
+                "ansi-styles": "^5.2.0",
+                "react-is": "^18.3.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/@jest/pattern": {
@@ -5223,6 +5602,22 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
+        "node_modules/jest-runtime/node_modules/@jest/globals": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.2.0",
+                "@jest/expect": "30.2.0",
+                "@jest/types": "30.2.0",
+                "jest-mock": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -8835,15 +9230,299 @@
             "dev": true
         },
         "@jest/globals": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+            "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "30.2.0",
-                "@jest/expect": "30.2.0",
-                "@jest/types": "30.2.0",
-                "jest-mock": "30.2.0"
+                "@jest/environment": "30.3.0",
+                "@jest/expect": "30.3.0",
+                "@jest/types": "30.3.0",
+                "jest-mock": "30.3.0"
+            },
+            "dependencies": {
+                "@jest/diff-sequences": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+                    "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+                    "dev": true
+                },
+                "@jest/environment": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+                    "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/fake-timers": "30.3.0",
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "jest-mock": "30.3.0"
+                    }
+                },
+                "@jest/expect": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+                    "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+                    "dev": true,
+                    "requires": {
+                        "expect": "30.3.0",
+                        "jest-snapshot": "30.3.0"
+                    }
+                },
+                "@jest/expect-utils": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+                    "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/get-type": "30.1.0"
+                    }
+                },
+                "@jest/fake-timers": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+                    "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@sinonjs/fake-timers": "^15.0.0",
+                        "@types/node": "*",
+                        "jest-message-util": "30.3.0",
+                        "jest-mock": "30.3.0",
+                        "jest-util": "30.3.0"
+                    }
+                },
+                "@jest/snapshot-utils": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+                    "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "chalk": "^4.1.2",
+                        "graceful-fs": "^4.2.11",
+                        "natural-compare": "^1.4.0"
+                    }
+                },
+                "@jest/transform": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+                    "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.27.4",
+                        "@jest/types": "30.3.0",
+                        "@jridgewell/trace-mapping": "^0.3.25",
+                        "babel-plugin-istanbul": "^7.0.1",
+                        "chalk": "^4.1.2",
+                        "convert-source-map": "^2.0.0",
+                        "fast-json-stable-stringify": "^2.1.0",
+                        "graceful-fs": "^4.2.11",
+                        "jest-haste-map": "30.3.0",
+                        "jest-regex-util": "30.0.1",
+                        "jest-util": "30.3.0",
+                        "pirates": "^4.0.7",
+                        "slash": "^3.0.0",
+                        "write-file-atomic": "^5.0.1"
+                    }
+                },
+                "@jest/types": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+                    "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/pattern": "30.0.1",
+                        "@jest/schemas": "30.0.5",
+                        "@types/istanbul-lib-coverage": "^2.0.6",
+                        "@types/istanbul-reports": "^3.0.4",
+                        "@types/node": "*",
+                        "@types/yargs": "^17.0.33",
+                        "chalk": "^4.1.2"
+                    }
+                },
+                "@sinonjs/fake-timers": {
+                    "version": "15.3.2",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+                    "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^3.0.1"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                    "dev": true
+                },
+                "expect": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+                    "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/expect-utils": "30.3.0",
+                        "@jest/get-type": "30.1.0",
+                        "jest-matcher-utils": "30.3.0",
+                        "jest-message-util": "30.3.0",
+                        "jest-mock": "30.3.0",
+                        "jest-util": "30.3.0"
+                    }
+                },
+                "jest-diff": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+                    "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/diff-sequences": "30.3.0",
+                        "@jest/get-type": "30.1.0",
+                        "chalk": "^4.1.2",
+                        "pretty-format": "30.3.0"
+                    }
+                },
+                "jest-haste-map": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+                    "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "anymatch": "^3.1.3",
+                        "fb-watchman": "^2.0.2",
+                        "fsevents": "^2.3.3",
+                        "graceful-fs": "^4.2.11",
+                        "jest-regex-util": "30.0.1",
+                        "jest-util": "30.3.0",
+                        "jest-worker": "30.3.0",
+                        "picomatch": "^4.0.3",
+                        "walker": "^1.0.8"
+                    }
+                },
+                "jest-matcher-utils": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+                    "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/get-type": "30.1.0",
+                        "chalk": "^4.1.2",
+                        "jest-diff": "30.3.0",
+                        "pretty-format": "30.3.0"
+                    }
+                },
+                "jest-message-util": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+                    "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.27.1",
+                        "@jest/types": "30.3.0",
+                        "@types/stack-utils": "^2.0.3",
+                        "chalk": "^4.1.2",
+                        "graceful-fs": "^4.2.11",
+                        "picomatch": "^4.0.3",
+                        "pretty-format": "30.3.0",
+                        "slash": "^3.0.0",
+                        "stack-utils": "^2.0.6"
+                    }
+                },
+                "jest-mock": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+                    "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "jest-util": "30.3.0"
+                    }
+                },
+                "jest-snapshot": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+                    "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.27.4",
+                        "@babel/generator": "^7.27.5",
+                        "@babel/plugin-syntax-jsx": "^7.27.1",
+                        "@babel/plugin-syntax-typescript": "^7.27.1",
+                        "@babel/types": "^7.27.3",
+                        "@jest/expect-utils": "30.3.0",
+                        "@jest/get-type": "30.1.0",
+                        "@jest/snapshot-utils": "30.3.0",
+                        "@jest/transform": "30.3.0",
+                        "@jest/types": "30.3.0",
+                        "babel-preset-current-node-syntax": "^1.2.0",
+                        "chalk": "^4.1.2",
+                        "expect": "30.3.0",
+                        "graceful-fs": "^4.2.11",
+                        "jest-diff": "30.3.0",
+                        "jest-matcher-utils": "30.3.0",
+                        "jest-message-util": "30.3.0",
+                        "jest-util": "30.3.0",
+                        "pretty-format": "30.3.0",
+                        "semver": "^7.7.2",
+                        "synckit": "^0.11.8"
+                    }
+                },
+                "jest-util": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+                    "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "chalk": "^4.1.2",
+                        "ci-info": "^4.2.0",
+                        "graceful-fs": "^4.2.11",
+                        "picomatch": "^4.0.3"
+                    }
+                },
+                "jest-worker": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+                    "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "@ungap/structured-clone": "^1.3.0",
+                        "jest-util": "30.3.0",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^8.1.1"
+                    }
+                },
+                "picomatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+                    "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+                    "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/schemas": "30.0.5",
+                        "ansi-styles": "^5.2.0",
+                        "react-is": "^18.3.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "@jest/pattern": {
@@ -11626,6 +12305,18 @@
                 "strip-bom": "^4.0.0"
             },
             "dependencies": {
+                "@jest/globals": {
+                    "version": "30.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+                    "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/environment": "30.2.0",
+                        "@jest/expect": "30.2.0",
+                        "@jest/types": "30.2.0",
+                        "jest-mock": "30.2.0"
+                    }
+                },
                 "brace-expansion": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@modelcontextprotocol/sdk": "^1.6.0",
                 "dotenv": "^16.4.7",
                 "intuit-oauth": "^4.0.0",
+                "ioredis": "^5.10.1",
                 "node-quickbooks": "^2.0.43",
                 "open": "^9.1.0",
                 "zod": "^3.24.2"
@@ -804,6 +805,12 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
             }
+        },
+        "node_modules/@ioredis/commands": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+            "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+            "license": "MIT"
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
@@ -3221,6 +3228,15 @@
                 "node": ">=12"
             }
         },
+        "node_modules/cluster-key-slot": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3539,6 +3555,15 @@
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/depd": {
@@ -4758,6 +4783,30 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/ioredis": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+            "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@ioredis/commands": "1.5.1",
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.4",
+                "denque": "^2.1.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.isarguments": "^3.1.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
             }
         },
         "node_modules/ipaddr.js": {
@@ -6010,10 +6059,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+            "license": "MIT"
+        },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+        },
+        "node_modules/lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+            "license": "MIT"
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
@@ -6950,6 +7011,27 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "license": "MIT",
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/request": {
             "version": "2.88.0",
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -7562,6 +7644,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+            "license": "MIT"
         },
         "node_modules/statuses": {
             "version": "2.0.2",
@@ -8973,6 +9061,11 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true
+        },
+        "@ioredis/commands": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+            "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="
         },
         "@isaacs/cliui": {
             "version": "8.0.2",
@@ -10657,6 +10750,11 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
+        "cluster-key-slot": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10877,6 +10975,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
         },
         "depd": {
             "version": "2.0.0",
@@ -11723,6 +11826,22 @@
                 "query-string": "^6.12.1",
                 "rsa-pem-from-mod-exp": "^0.8.4",
                 "winston": "^3.1.0"
+            }
+        },
+        "ioredis": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+            "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+            "requires": {
+                "@ioredis/commands": "1.5.1",
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.4",
+                "denque": "^2.1.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.isarguments": "^3.1.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
             }
         },
         "ipaddr.js": {
@@ -12621,10 +12740,20 @@
                 "p-locate": "^5.0.0"
             }
         },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+        },
         "lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
         },
         "lodash.isboolean": {
             "version": "3.0.3",
@@ -13273,6 +13402,19 @@
                 "resolve": "^1.1.6"
             }
         },
+        "redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+        },
+        "redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "requires": {
+                "redis-errors": "^1.0.0"
+            }
+        },
         "request": {
             "version": "2.88.0",
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -13689,6 +13831,11 @@
                     "dev": true
                 }
             }
+        },
+        "standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
         },
         "statuses": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@modelcontextprotocol/sdk": "^1.6.0",
         "dotenv": "^16.4.7",
         "intuit-oauth": "^4.0.0",
+        "ioredis": "^5.10.1",
         "node-quickbooks": "^2.0.43",
         "open": "^9.1.0",
         "zod": "^3.24.2"

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -51,6 +51,7 @@ class QuickbooksClient {
   private isAuthenticating: boolean = false;
   private redirectUri: string;
   private redisTokenLoaded: boolean = false;
+  private needsReauth: boolean = false;
 
   constructor(config: {
     clientId: string;
@@ -290,6 +291,14 @@ class QuickbooksClient {
         };
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
+        // invalid_grant means the refresh token is expired or revoked.
+        // Set the flag so the HTTP layer can return 401 and trigger Claude's re-auth UI.
+        if (message.toLowerCase().includes('invalid_grant') || message.includes('400')) {
+          this.needsReauth = true;
+          this.refreshToken = undefined;
+          this.accessToken = undefined;
+          this.accessTokenExpiry = undefined;
+        }
         throw new Error(`Failed to refresh Quickbooks token: ${message}`);
       } finally {
         this.refreshInFlight = undefined;
@@ -300,15 +309,27 @@ class QuickbooksClient {
   }
 
   async authenticate() {
-    // On the first call, try to load the latest rotated token from Redis.
-    // This ensures pod restarts pick up the most recent token rather than the
-    // bootstrap value baked into the GCP Secret Manager secret.
+    // On the first call, load the latest rotated token from Redis.
+    // Redis is the sole source of truth for the refresh token — it is no longer
+    // stored in GCP Secret Manager. Seed it once with:
+    //   kubectl exec -n redis redis-0 -c redis -- \
+    //     redis-cli SET qbo:refresh_token <token>
     if (!this.redisTokenLoaded) {
       this.redisTokenLoaded = true;
       const redisToken = await redisGetRefreshToken();
       if (redisToken) {
         this.refreshToken = redisToken;
       }
+    }
+
+    if (!this.refreshToken && this.realmId) {
+      // We have a realmId (server context) but no refresh token — Redis is empty.
+      // Starting a browser OAuth flow in a headless pod would hang forever.
+      throw new Error(
+        'QuickBooks refresh token not found in Redis. ' +
+        'Seed it once with: kubectl exec -n redis redis-0 -c redis -- ' +
+        'redis-cli SET qbo:refresh_token <your_refresh_token>'
+      );
     }
 
     if (!this.refreshToken || !this.realmId) {
@@ -360,6 +381,17 @@ class QuickbooksClient {
       realmId: this.realmId,
       isSandbox: this.environment === 'sandbox',
     };
+  }
+
+  /** True when the refresh token is expired/revoked and the user must re-authorize. */
+  isReauthNeeded(): boolean {
+    return this.needsReauth;
+  }
+
+  /** Called by the /token handler after a successful OAuth re-authorization. */
+  clearReauthFlag(): void {
+    this.needsReauth = false;
+    this.redisTokenLoaded = false; // force re-read of fresh token from Redis on next call
   }
 }
 

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -5,8 +5,44 @@ import http from 'http';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { AsyncLocalStorage } from 'async_hooks';
+import { createHash } from 'crypto';
 import open from 'open';
-import { getRefreshToken as redisGetRefreshToken, setRefreshToken as redisSetRefreshToken } from './redis-token-store.js';
+import { UserSession, getSession, setSession, setRtIndex } from './redis-token-store.js';
+
+// ── Per-user session context ─────────────────────────────────────────────────
+// Each MCP request runs inside AsyncLocalStorage carrying the authenticated
+// user's session so the singleton quickbooksClient uses the right credentials.
+
+interface RequestContext extends UserSession {
+  sessionKey: string;  // Redis key: qbo:user:<sha256(bearer_token)>
+}
+
+const requestALS = new AsyncLocalStorage<RequestContext>();
+
+/** In-memory access-token cache per session (single-replica safe). */
+const accessTokenCache = new Map<string, { accessToken: string; expiry: Date }>();
+
+/**
+ * Hash a token for use as a Redis key fragment.
+ * We only need the first 32 hex chars — collision probability is negligible.
+ */
+export function tokenHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex').slice(0, 32);
+}
+
+/**
+ * Run `fn` within a per-user session context.
+ * All tool handlers that call quickbooksClient.authenticate() will use the
+ * credentials from this context automatically.
+ */
+export function runWithUserSession<T>(
+  sessionKey: string,
+  session: UserSession,
+  fn: () => Promise<T>
+): Promise<T> {
+  return requestALS.run({ sessionKey, ...session }, fn);
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -50,6 +86,7 @@ class QuickbooksClient {
   private oauthClient: OAuthClient;
   private isAuthenticating: boolean = false;
   private redirectUri: string;
+  // Legacy single-user fields (used when no per-user ALS context is present)
   private redisTokenLoaded: boolean = false;
   private needsReauth: boolean = false;
 
@@ -266,14 +303,19 @@ class QuickbooksClient {
         // stale and will eventually stop working, silently breaking refresh.
         const newRefreshToken = token.refresh_token;
         if (newRefreshToken && newRefreshToken !== this.refreshToken) {
-          this.refreshToken = newRefreshToken;
-          // Persist to Redis (survives pod restarts) and .env (local dev fallback).
-          redisSetRefreshToken(newRefreshToken).catch(() => { /* logged inside */ });
-          try {
-            this.saveTokensToEnv();
-            console.error('[qbo-client] Refresh token rotated and persisted');
-          } catch (persistErr) {
-            console.error('[qbo-client] Failed to persist rotated refresh token to .env:', persistErr);
+          const ctx = requestALS.getStore();
+          if (ctx) {
+            // Per-user mode: update the session in ALS and Redis.
+            ctx.refreshToken = newRefreshToken;
+            const newRtHash = tokenHash(newRefreshToken);
+            setSession(ctx.sessionKey, { refreshToken: newRefreshToken, realmId: ctx.realmId }).catch(() => {});
+            setRtIndex(newRtHash, ctx.sessionKey).catch(() => {});
+            console.error(`[qbo-client] Refresh token rotated for session ${ctx.sessionKey.slice(-8)}`);
+          } else {
+            // Legacy single-user fallback
+            this.refreshToken = newRefreshToken;
+            try { this.saveTokensToEnv(); } catch { /* best effort */ }
+            console.error('[qbo-client] Refresh token rotated (single-user mode)');
           }
         }
 
@@ -309,46 +351,71 @@ class QuickbooksClient {
   }
 
   async authenticate() {
-    // On the first call, load the latest rotated token from Redis.
-    // Redis is the sole source of truth for the refresh token — it is no longer
-    // stored in GCP Secret Manager. Seed it once with:
-    //   kubectl exec -n redis redis-0 -c redis -- \
-    //     redis-cli SET qbo:refresh_token <token>
-    if (!this.redisTokenLoaded) {
-      this.redisTokenLoaded = true;
-      const redisToken = await redisGetRefreshToken();
-      if (redisToken) {
-        this.refreshToken = redisToken;
+    const ctx = requestALS.getStore();
+
+    if (ctx) {
+      // ── Per-user mode ────────────────────────────────────────────────────
+      // Check in-memory access token cache for this session.
+      const cached = accessTokenCache.get(ctx.sessionKey);
+      const now = new Date();
+      let accessToken: string;
+
+      if (cached && cached.expiry > now) {
+        accessToken = cached.accessToken;
+      } else {
+        // Temporarily set instance fields so refreshAccessToken() can use them.
+        this.refreshToken = ctx.refreshToken;
+        this.realmId = ctx.realmId;
+        const result = await this.refreshAccessToken();
+        accessToken = result.access_token;
+        accessTokenCache.set(ctx.sessionKey, {
+          accessToken,
+          expiry: new Date(now.getTime() + result.expires_in * 1000 - 60_000), // 1 min early
+        });
       }
+
+      this.quickbooksInstance = new QuickBooks(
+        this.clientId,
+        this.clientSecret,
+        accessToken,
+        false,
+        ctx.realmId,
+        this.environment === 'sandbox',
+        false,
+        null,
+        '2.0',
+        ctx.refreshToken
+      );
+      // Keep instance fields in sync for getAuthCredentials()
+      this.accessToken = accessToken;
+      this.realmId = ctx.realmId;
+      return this.quickbooksInstance;
     }
 
+    // ── Legacy single-user fallback (no ALS context) ─────────────────────
     if (!this.refreshToken) {
-      // No token in Redis or env — signal a 401 so Claude triggers its OAuth UI.
       this.needsReauth = true;
       throw new Error('QuickBooks refresh token not found — re-authorization required');
     }
 
-    // Check if token exists and is still valid
     const now = new Date();
     if (!this.accessToken || !this.accessTokenExpiry || this.accessTokenExpiry <= now) {
       const tokenResponse = await this.refreshAccessToken();
       this.accessToken = tokenResponse.access_token;
     }
-    
-    // At this point we know all tokens are available
+
     this.quickbooksInstance = new QuickBooks(
       this.clientId,
       this.clientSecret,
       this.accessToken,
-      false, // no token secret for OAuth 2.0
-      this.realmId!, // Safe to use ! here as we checked above
-      this.environment === 'sandbox', // use the sandbox?
-      false, // debug?
-      null, // minor version
-      '2.0', // oauth version
+      false,
+      this.realmId!,
+      this.environment === 'sandbox',
+      false,
+      null,
+      '2.0',
       this.refreshToken
     );
-    
     return this.quickbooksInstance;
   }
   
@@ -381,24 +448,6 @@ class QuickbooksClient {
     this.redisTokenLoaded = false; // force re-read of fresh token from Redis on next call
   }
 
-  /**
-   * Eagerly load the refresh token from Redis at startup.
-   * If Redis is empty and there is no real token in the environment, set
-   * needsReauth = true immediately so the very first incoming request returns
-   * 401 and Claude shows the "Connect to QuickBooks" button — rather than
-   * letting the error bubble up through the tool handler as text.
-   */
-  async initialize(): Promise<void> {
-    if (this.redisTokenLoaded) return;
-    this.redisTokenLoaded = true;
-    const redisToken = await redisGetRefreshToken();
-    if (redisToken) {
-      this.refreshToken = redisToken;
-    } else if (!this.refreshToken || this.refreshToken.startsWith('placeholder')) {
-      this.needsReauth = true;
-      console.error('[qbo-client] No refresh token in Redis or env — marking reauth required');
-    }
-  }
 }
 
 export const quickbooksClient = new QuickbooksClient({

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -322,23 +322,10 @@ class QuickbooksClient {
       }
     }
 
-    if (!this.refreshToken && this.realmId) {
-      // We have a realmId (server context) but no refresh token — Redis is empty.
-      // Starting a browser OAuth flow in a headless pod would hang forever.
-      throw new Error(
-        'QuickBooks refresh token not found in Redis. ' +
-        'Seed it once with: kubectl exec -n redis redis-0 -c redis -- ' +
-        'redis-cli SET qbo:refresh_token <your_refresh_token>'
-      );
-    }
-
-    if (!this.refreshToken || !this.realmId) {
-      await this.startOAuthFlow();
-      
-      // Verify we have both tokens after OAuth flow
-      if (!this.refreshToken || !this.realmId) {
-        throw new Error('Failed to obtain required tokens from OAuth flow');
-      }
+    if (!this.refreshToken) {
+      // No token in Redis or env — signal a 401 so Claude triggers its OAuth UI.
+      this.needsReauth = true;
+      throw new Error('QuickBooks refresh token not found — re-authorization required');
     }
 
     // Check if token exists and is still valid

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import open from 'open';
+import { getRefreshToken as redisGetRefreshToken, setRefreshToken as redisSetRefreshToken } from './redis-token-store.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -49,6 +50,7 @@ class QuickbooksClient {
   private oauthClient: OAuthClient;
   private isAuthenticating: boolean = false;
   private redirectUri: string;
+  private redisTokenLoaded: boolean = false;
 
   constructor(config: {
     clientId: string;
@@ -264,13 +266,13 @@ class QuickbooksClient {
         const newRefreshToken = token.refresh_token;
         if (newRefreshToken && newRefreshToken !== this.refreshToken) {
           this.refreshToken = newRefreshToken;
+          // Persist to Redis (survives pod restarts) and .env (local dev fallback).
+          redisSetRefreshToken(newRefreshToken).catch(() => { /* logged inside */ });
           try {
             this.saveTokensToEnv();
-            console.error('[qbo-client] Refresh token rotated and persisted to .env');
+            console.error('[qbo-client] Refresh token rotated and persisted');
           } catch (persistErr) {
-            // Don't fail the whole refresh just because we couldn't write to
-            // disk; the in-memory token is still valid for this process.
-            console.error('[qbo-client] Failed to persist rotated refresh token:', persistErr);
+            console.error('[qbo-client] Failed to persist rotated refresh token to .env:', persistErr);
           }
         }
 
@@ -298,6 +300,17 @@ class QuickbooksClient {
   }
 
   async authenticate() {
+    // On the first call, try to load the latest rotated token from Redis.
+    // This ensures pod restarts pick up the most recent token rather than the
+    // bootstrap value baked into the GCP Secret Manager secret.
+    if (!this.redisTokenLoaded) {
+      this.redisTokenLoaded = true;
+      const redisToken = await redisGetRefreshToken();
+      if (redisToken) {
+        this.refreshToken = redisToken;
+      }
+    }
+
     if (!this.refreshToken || !this.realmId) {
       await this.startOAuthFlow();
       

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -337,6 +337,17 @@ class QuickbooksClient {
     }
     return this.quickbooksInstance;
   }
+
+  getAuthCredentials(): { accessToken: string; realmId: string; isSandbox: boolean } {
+    if (!this.accessToken || !this.realmId) {
+      throw new Error('Quickbooks not authenticated. Call authenticate() first');
+    }
+    return {
+      accessToken: this.accessToken,
+      realmId: this.realmId,
+      isSandbox: this.environment === 'sandbox',
+    };
+  }
 }
 
 export const quickbooksClient = new QuickbooksClient({

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -380,6 +380,25 @@ class QuickbooksClient {
     this.needsReauth = false;
     this.redisTokenLoaded = false; // force re-read of fresh token from Redis on next call
   }
+
+  /**
+   * Eagerly load the refresh token from Redis at startup.
+   * If Redis is empty and there is no real token in the environment, set
+   * needsReauth = true immediately so the very first incoming request returns
+   * 401 and Claude shows the "Connect to QuickBooks" button — rather than
+   * letting the error bubble up through the tool handler as text.
+   */
+  async initialize(): Promise<void> {
+    if (this.redisTokenLoaded) return;
+    this.redisTokenLoaded = true;
+    const redisToken = await redisGetRefreshToken();
+    if (redisToken) {
+      this.refreshToken = redisToken;
+    } else if (!this.refreshToken || this.refreshToken.startsWith('placeholder')) {
+      this.needsReauth = true;
+      console.error('[qbo-client] No refresh token in Redis or env — marking reauth required');
+    }
+  }
 }
 
 export const quickbooksClient = new QuickbooksClient({

--- a/src/clients/redis-token-store.ts
+++ b/src/clients/redis-token-store.ts
@@ -1,0 +1,85 @@
+/**
+ * Thin Redis wrapper for persisting the QBO refresh token across pod restarts.
+ *
+ * The refresh token is rotated by Intuit on every use. Writing it to a flat
+ * .env file is unsafe in Kubernetes because the file is ephemeral — it is lost
+ * on every pod restart, causing a 400 "invalid_grant" error until the original
+ * (stale) token from GCP Secret Manager is manually replaced.
+ *
+ * Instead, the latest rotated token is stored in Redis under the key
+ * `qbo:refresh_token`. On startup the client reads from Redis first and falls
+ * back to the env var (bootstrap / first deploy). When the token rotates it is
+ * written back to Redis so the next pod start picks it up.
+ *
+ * If REDIS_URL is not set (local dev / CI) the module is a no-op and the
+ * existing env-var / .env fallback continues to work unchanged.
+ */
+
+import IORedis from "ioredis";
+const { default: Redis } = IORedis as any;
+type RedisClient = InstanceType<typeof Redis>;
+
+const REDIS_KEY = "qbo:refresh_token";
+const CONNECT_TIMEOUT_MS = 3_000;
+
+let client: RedisClient | null = null;
+let clientInitialized = false;
+
+function getClient(): RedisClient | null {
+  if (clientInitialized) return client;
+  clientInitialized = true;
+
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    console.error("[redis-token-store] REDIS_URL not set — token persistence via Redis disabled");
+    return null;
+  }
+
+  client = new Redis(url, {
+    connectTimeout: CONNECT_TIMEOUT_MS,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+  });
+
+  client.on("error", (err: Error) => {
+    // Log but never throw — Redis being down must not break QBO calls.
+    console.error("[redis-token-store] Redis error:", err.message);
+  });
+
+  return client;
+}
+
+/**
+ * Returns the refresh token stored in Redis, or null if not found / unavailable.
+ * Call this on startup before falling back to the QUICKBOOKS_REFRESH_TOKEN env var.
+ */
+export async function getRefreshToken(): Promise<string | null> {
+  try {
+    const redis = getClient();
+    if (!redis) return null;
+    const value = await redis.get(REDIS_KEY);
+    if (value) {
+      console.error("[redis-token-store] Loaded refresh token from Redis");
+    }
+    return value;
+  } catch (err) {
+    console.error("[redis-token-store] Failed to read refresh token:", err);
+    return null;
+  }
+}
+
+/**
+ * Persists the rotated refresh token to Redis.
+ * Errors are swallowed — the in-memory token remains valid even if Redis is down.
+ */
+export async function setRefreshToken(token: string): Promise<void> {
+  try {
+    const redis = getClient();
+    if (!redis) return;
+    await redis.set(REDIS_KEY, token);
+    console.error("[redis-token-store] Refresh token persisted to Redis");
+  } catch (err) {
+    console.error("[redis-token-store] Failed to persist refresh token:", err);
+  }
+}

--- a/src/clients/redis-token-store.ts
+++ b/src/clients/redis-token-store.ts
@@ -1,26 +1,27 @@
 /**
- * Thin Redis wrapper for persisting the QBO refresh token across pod restarts.
+ * Redis wrapper for persisting QBO OAuth tokens across pod restarts.
  *
- * The refresh token is rotated by Intuit on every use. Writing it to a flat
- * .env file is unsafe in Kubernetes because the file is ephemeral — it is lost
- * on every pod restart, causing a 400 "invalid_grant" error until the original
- * (stale) token from GCP Secret Manager is manually replaced.
+ * Per-user sessions are stored under:
+ *   qbo:user:<sha256(access_token)>  → UserSession JSON   (TTL 101 days)
+ *   qbo:rt:<sha256(refresh_token)>   → session key string (TTL 101 days)
  *
- * Instead, the latest rotated token is stored in Redis under the key
- * `qbo:refresh_token`. On startup the client reads from Redis first and falls
- * back to the env var (bootstrap / first deploy). When the token rotates it is
- * written back to Redis so the next pod start picks it up.
+ * The access_token sent by Claude as a Bearer on every MCP request is used as
+ * the session discriminator so each person gets their own isolated QBO auth state.
  *
- * If REDIS_URL is not set (local dev / CI) the module is a no-op and the
- * existing env-var / .env fallback continues to work unchanged.
+ * If REDIS_URL is not set (local dev / CI) the module is a no-op.
  */
 
 import IORedis from "ioredis";
 const { default: Redis } = IORedis as any;
 type RedisClient = InstanceType<typeof Redis>;
 
-const REDIS_KEY = "qbo:refresh_token";
 const CONNECT_TIMEOUT_MS = 3_000;
+const SESSION_TTL = 101 * 24 * 3600; // 101 days — slightly longer than Intuit's 100-day refresh token
+
+export interface UserSession {
+  refreshToken: string;
+  realmId: string;
+}
 
 let client: RedisClient | null = null;
 let clientInitialized = false;
@@ -50,36 +51,56 @@ function getClient(): RedisClient | null {
   return client;
 }
 
-/**
- * Returns the refresh token stored in Redis, or null if not found / unavailable.
- * Call this on startup before falling back to the QUICKBOOKS_REFRESH_TOKEN env var.
- */
-export async function getRefreshToken(): Promise<string | null> {
+// ── Per-user session API ──────────────────────────────────────────────────────
+
+/** Read a user session. Returns null when not found or Redis is unavailable. */
+export async function getSession(sessionKey: string): Promise<UserSession | null> {
   try {
     const redis = getClient();
     if (!redis) return null;
-    const value = await redis.get(REDIS_KEY);
-    if (value) {
-      console.error("[redis-token-store] Loaded refresh token from Redis");
-    }
-    return value;
+    const value = await redis.get(sessionKey);
+    return value ? (JSON.parse(value) as UserSession) : null;
   } catch (err) {
-    console.error("[redis-token-store] Failed to read refresh token:", err);
+    console.error("[redis-token-store] Failed to read session:", err);
     return null;
   }
 }
 
-/**
- * Persists the rotated refresh token to Redis.
- * Errors are swallowed — the in-memory token remains valid even if Redis is down.
- */
-export async function setRefreshToken(token: string): Promise<void> {
+/** Write (or overwrite) a user session with a rolling TTL. */
+export async function setSession(sessionKey: string, session: UserSession): Promise<void> {
   try {
     const redis = getClient();
     if (!redis) return;
-    await redis.set(REDIS_KEY, token);
-    console.error("[redis-token-store] Refresh token persisted to Redis");
+    await redis.set(sessionKey, JSON.stringify(session), "EX", SESSION_TTL);
   } catch (err) {
-    console.error("[redis-token-store] Failed to persist refresh token:", err);
+    console.error("[redis-token-store] Failed to write session:", err);
+  }
+}
+
+/**
+ * Store a reverse index from refresh-token hash → session key.
+ * Used when Claude calls POST /token with grant_type=refresh_token so we can
+ * find the existing session (and inherit its realmId) even though the Bearer
+ * token has changed.
+ */
+export async function setRtIndex(rtHash: string, sessionKey: string): Promise<void> {
+  try {
+    const redis = getClient();
+    if (!redis) return;
+    await redis.set(`qbo:rt:${rtHash}`, sessionKey, "EX", SESSION_TTL);
+  } catch (err) {
+    console.error("[redis-token-store] Failed to write rt index:", err);
+  }
+}
+
+/** Look up a session key by refresh-token hash. */
+export async function getSessionKeyByRt(rtHash: string): Promise<string | null> {
+  try {
+    const redis = getClient();
+    if (!redis) return null;
+    return await redis.get(`qbo:rt:${rtHash}`);
+  } catch (err) {
+    console.error("[redis-token-store] Failed to read rt index:", err);
+    return null;
   }
 }

--- a/src/clients/redis-token-store.ts
+++ b/src/clients/redis-token-store.ts
@@ -37,9 +37,9 @@ function getClient(): RedisClient | null {
 
   client = new Redis(url, {
     connectTimeout: CONNECT_TIMEOUT_MS,
-    lazyConnect: true,
-    maxRetriesPerRequest: 1,
-    enableOfflineQueue: false,
+    maxRetriesPerRequest: 2,
+    enableOfflineQueue: true,
+    retryStrategy: (times: number) => (times <= 3 ? Math.min(times * 200, 1000) : null),
   });
 
   client.on("error", (err: Error) => {

--- a/src/clients/redis-token-store.ts
+++ b/src/clients/redis-token-store.ts
@@ -38,9 +38,10 @@ function getClient(): RedisClient | null {
 
   client = new Redis(url, {
     connectTimeout: CONNECT_TIMEOUT_MS,
-    maxRetriesPerRequest: 2,
+    maxRetriesPerRequest: null,  // retry indefinitely per command
     enableOfflineQueue: true,
-    retryStrategy: (times: number) => (times <= 3 ? Math.min(times * 200, 1000) : null),
+    // Reconnect with exponential backoff capped at 5s, no give-up limit.
+    retryStrategy: (times: number) => Math.min(times * 200, 5000),
   });
 
   client.on("error", (err: Error) => {

--- a/src/handlers/create-quickbooks-attachable.handler.ts
+++ b/src/handlers/create-quickbooks-attachable.handler.ts
@@ -1,35 +1,152 @@
+import https from "https";
 import { quickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+
+const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+]);
 
 export interface CreateAttachableInput {
   file_name: string;
   note?: string;
   category?: string;
   content_type?: string;
+  base64_content?: string;
   attachable_ref?: {
     entity_ref_type: string;
     entity_ref_value: string;
   };
 }
 
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\r\n"\\]/g, "_");
+}
+
+async function uploadAttachableFile(
+  fileBuffer: Buffer,
+  metadata: Record<string, unknown>,
+  accessToken: string,
+  realmId: string,
+  isSandbox: boolean
+): Promise<unknown> {
+  const boundary = `----QBOBoundary${Date.now()}`;
+  const metadataJson = JSON.stringify(metadata);
+  const fileName = sanitizeFilename(metadata.FileName as string);
+  const contentType = metadata.ContentType as string;
+
+  const bodyParts: Buffer[] = [
+    Buffer.from(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file_metadata_01"\r\n` +
+        `Content-Type: application/json\r\n` +
+        `\r\n` +
+        `${metadataJson}\r\n`
+    ),
+    Buffer.from(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file_content_01"; filename="${fileName}"\r\n` +
+        `Content-Type: ${contentType}\r\n` +
+        `\r\n`
+    ),
+    fileBuffer,
+    Buffer.from(`\r\n--${boundary}--\r\n`),
+  ];
+
+  const body = Buffer.concat(bodyParts);
+  const host = isSandbox
+    ? "sandbox-quickbooks.api.intuit.com"
+    : "quickbooks.api.intuit.com";
+  const path = `/v3/company/${realmId}/upload`;
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: host,
+        path,
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+          "Content-Length": body.length,
+          Accept: "application/json",
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const responseText = Buffer.concat(chunks).toString("utf-8");
+          try {
+            const json: unknown = JSON.parse(responseText);
+            if (res.statusCode && res.statusCode >= 400) {
+              reject(
+                new Error(
+                  `QBO upload failed (${res.statusCode}): ${responseText}`
+                )
+              );
+            } else {
+              resolve(json);
+            }
+          } catch {
+            reject(
+              new Error(
+                `QBO upload: unexpected response (${res.statusCode}): ${responseText}`
+              )
+            );
+          }
+        });
+      }
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
 export async function createQuickbooksAttachable(data: CreateAttachableInput): Promise<ToolResponse<any>> {
   try {
     await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
-    const payload: any = { FileName: data.file_name };
+
+    const payload: Record<string, unknown> = { FileName: data.file_name };
     if (data.note) payload.Note = data.note;
     if (data.category) payload.Category = data.category;
     if (data.content_type) payload.ContentType = data.content_type;
     if (data.attachable_ref) {
-      payload.AttachableRef = [{
-        EntityRef: {
-          type: data.attachable_ref.entity_ref_type,
-          value: data.attachable_ref.entity_ref_value
-        }
-      }];
+      payload.AttachableRef = [
+        {
+          EntityRef: {
+            type: data.attachable_ref.entity_ref_type,
+            value: data.attachable_ref.entity_ref_value,
+          },
+        },
+      ];
     }
 
+    if (data.base64_content) {
+      const effectiveContentType = data.content_type ?? "application/octet-stream";
+      if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(effectiveContentType)) {
+        return {
+          result: null,
+          isError: true,
+          error: `Error: Unsupported content_type "${effectiveContentType}" for upload. Allowed types: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].join(", ")}`,
+        };
+      }
+      const { accessToken, realmId, isSandbox } = quickbooksClient.getAuthCredentials();
+      const fileBuffer = Buffer.from(data.base64_content, "base64");
+      const uploadResult = await uploadAttachableFile(
+        fileBuffer,
+        payload,
+        accessToken,
+        realmId,
+        isSandbox
+      );
+      return { result: uploadResult, isError: false, error: null };
+    }
+
+    const quickbooks = quickbooksClient.getQuickbooks();
     return new Promise((resolve) => {
       (quickbooks as any).createAttachable(payload, (err: any, created: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });

--- a/src/handlers/upload-attachment-from-url.handler.ts
+++ b/src/handlers/upload-attachment-from-url.handler.ts
@@ -19,6 +19,7 @@ const MAX_REDIRECTS = 5;
 export interface UploadAttachmentFromUrlInput {
   file_url: string;
   file_name?: string;
+  content_type?: string;
   note?: string;
   category?: string;
   attachable_ref?: {
@@ -188,13 +189,20 @@ export async function uploadAttachmentFromUrl(
 ): Promise<ToolResponse<any>> {
   try {
     // Download the file first (before authenticating to fail fast on bad URLs)
-    const { buffer, contentType } = await downloadUrl(data.file_url, MAX_REDIRECTS);
+    const { buffer, contentType: detectedContentType } = await downloadUrl(data.file_url, MAX_REDIRECTS);
+
+    // Allow explicit override — S3/GCS presigned URLs often return application/octet-stream
+    // regardless of the actual file type.
+    const contentType = data.content_type
+      ? data.content_type.split(";")[0].trim().toLowerCase()
+      : detectedContentType;
 
     if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(contentType)) {
       return {
         result: null,
         isError: true,
-        error: `Unsupported content type "${contentType}" from URL. QuickBooks only accepts: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].join(", ")}`,
+        error: `Unsupported content type "${contentType}". QuickBooks only accepts: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].join(", ")}. ` +
+          `The URL returned "${detectedContentType}" — if the file is a PDF/PNG/JPEG, pass the correct content_type explicitly.`,
       };
     }
 

--- a/src/handlers/upload-attachment-from-url.handler.ts
+++ b/src/handlers/upload-attachment-from-url.handler.ts
@@ -1,0 +1,231 @@
+import https from "https";
+import http from "http";
+import { URL } from "url";
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { ToolResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+
+const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+]);
+
+// 20 MB hard cap to prevent memory exhaustion
+const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+const MAX_REDIRECTS = 5;
+
+export interface UploadAttachmentFromUrlInput {
+  file_url: string;
+  file_name?: string;
+  note?: string;
+  category?: string;
+  attachable_ref?: {
+    entity_ref_type: string;
+    entity_ref_value: string;
+  };
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\r\n"\\]/g, "_");
+}
+
+function deriveFilenameFromUrl(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const last = segments[segments.length - 1];
+    return last ? decodeURIComponent(last) : "attachment";
+  } catch {
+    return "attachment";
+  }
+}
+
+function downloadUrl(
+  rawUrl: string,
+  redirectsLeft: number
+): Promise<{ buffer: Buffer; contentType: string }> {
+  return new Promise((resolve, reject) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      return reject(new Error(`Invalid URL: ${rawUrl}`));
+    }
+
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return reject(new Error(`URL must use http or https, got: ${parsed.protocol}`));
+    }
+
+    const transport = parsed.protocol === "https:" ? https : http;
+    const req = transport.get(rawUrl, { timeout: DOWNLOAD_TIMEOUT_MS }, (res) => {
+      // Follow redirects (3xx) safely
+      if (
+        res.statusCode &&
+        res.statusCode >= 300 &&
+        res.statusCode < 400 &&
+        res.headers.location
+      ) {
+        if (redirectsLeft <= 0) {
+          return reject(new Error("Too many redirects while downloading file"));
+        }
+        res.resume(); // discard body
+        const nextUrl = new URL(res.headers.location, rawUrl).toString();
+        return resolve(downloadUrl(nextUrl, redirectsLeft - 1));
+      }
+
+      if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        return reject(new Error(`Failed to download file: HTTP ${res.statusCode}`));
+      }
+
+      const rawContentType = res.headers["content-type"] ?? "application/octet-stream";
+      // Strip parameters (e.g. "image/jpeg; charset=utf-8" → "image/jpeg")
+      const contentType = rawContentType.split(";")[0].trim().toLowerCase();
+
+      const chunks: Buffer[] = [];
+      let totalBytes = 0;
+
+      res.on("data", (chunk: Buffer) => {
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_FILE_SIZE_BYTES) {
+          req.destroy();
+          reject(new Error(`File exceeds maximum allowed size of ${MAX_FILE_SIZE_BYTES / 1024 / 1024} MB`));
+        } else {
+          chunks.push(chunk);
+        }
+      });
+
+      res.on("end", () => resolve({ buffer: Buffer.concat(chunks), contentType }));
+      res.on("error", reject);
+    });
+
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Timed out while downloading file"));
+    });
+    req.on("error", reject);
+  });
+}
+
+async function uploadToQuickbooks(
+  fileBuffer: Buffer,
+  metadata: Record<string, unknown>,
+  accessToken: string,
+  realmId: string,
+  isSandbox: boolean
+): Promise<unknown> {
+  const boundary = `----QBOBoundary${Date.now()}`;
+  const metadataJson = JSON.stringify(metadata);
+  const fileName = sanitizeFilename(metadata.FileName as string);
+  const contentType = metadata.ContentType as string;
+
+  const bodyParts: Buffer[] = [
+    Buffer.from(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file_metadata_01"\r\n` +
+        `Content-Type: application/json\r\n` +
+        `\r\n` +
+        `${metadataJson}\r\n`
+    ),
+    Buffer.from(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file_content_01"; filename="${fileName}"\r\n` +
+        `Content-Type: ${contentType}\r\n` +
+        `\r\n`
+    ),
+    fileBuffer,
+    Buffer.from(`\r\n--${boundary}--\r\n`),
+  ];
+
+  const body = Buffer.concat(bodyParts);
+  const host = isSandbox
+    ? "sandbox-quickbooks.api.intuit.com"
+    : "quickbooks.api.intuit.com";
+  const path = `/v3/company/${realmId}/upload`;
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: host,
+        path,
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+          "Content-Length": body.length,
+          Accept: "application/json",
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const responseText = Buffer.concat(chunks).toString("utf-8");
+          try {
+            const json: unknown = JSON.parse(responseText);
+            if (res.statusCode && res.statusCode >= 400) {
+              reject(new Error(`QBO upload failed (${res.statusCode}): ${responseText}`));
+            } else {
+              resolve(json);
+            }
+          } catch {
+            reject(new Error(`QBO upload: unexpected response (${res.statusCode}): ${responseText}`));
+          }
+        });
+        res.on("error", reject);
+      }
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function uploadAttachmentFromUrl(
+  data: UploadAttachmentFromUrlInput
+): Promise<ToolResponse<any>> {
+  try {
+    // Download the file first (before authenticating to fail fast on bad URLs)
+    const { buffer, contentType } = await downloadUrl(data.file_url, MAX_REDIRECTS);
+
+    if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(contentType)) {
+      return {
+        result: null,
+        isError: true,
+        error: `Unsupported content type "${contentType}" from URL. QuickBooks only accepts: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].join(", ")}`,
+      };
+    }
+
+    await quickbooksClient.authenticate();
+
+    const fileName = sanitizeFilename(
+      data.file_name ?? deriveFilenameFromUrl(data.file_url)
+    );
+
+    const metadata: Record<string, unknown> = {
+      FileName: fileName,
+      ContentType: contentType,
+    };
+    if (data.note) metadata.Note = data.note;
+    if (data.category) metadata.Category = data.category;
+    if (data.attachable_ref) {
+      metadata.AttachableRef = [
+        {
+          EntityRef: {
+            type: data.attachable_ref.entity_ref_type,
+            value: data.attachable_ref.entity_ref_value,
+          },
+        },
+      ];
+    }
+
+    const { accessToken, realmId, isSandbox } = quickbooksClient.getAuthCredentials();
+    const uploadResult = await uploadToQuickbooks(buffer, metadata, accessToken, realmId, isSandbox);
+
+    return { result: uploadResult, isError: false, error: null };
+  } catch (error) {
+    return { result: null, isError: true, error: formatError(error) };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ import { GetAttachableTool } from "./tools/get-attachable.tool.js";
 import { UpdateAttachableTool } from "./tools/update-attachable.tool.js";
 import { DeleteAttachableTool } from "./tools/delete-attachable.tool.js";
 import { SearchAttachablesTool } from "./tools/search-attachables.tool.js";
+import { UploadAttachmentFromUrlTool } from "./tools/upload-attachment-from-url.tool.js";
 
 // Financial Report tools
 import { GetBalanceSheetTool } from "./tools/get-balance-sheet.tool.js";
@@ -406,6 +407,7 @@ const main = async () => {
   RegisterTool(server, UpdateAttachableTool);
   RegisterTool(server, DeleteAttachableTool);
   RegisterTool(server, SearchAttachablesTool);
+  RegisterTool(server, UploadAttachmentFromUrlTool);
 
   // Add financial report tools
   RegisterTool(server, GetBalanceSheetTool);

--- a/src/tools/create-attachable.tool.ts
+++ b/src/tools/create-attachable.tool.ts
@@ -8,7 +8,8 @@ const toolSchema = z.object({
   file_name: z.string().min(1).describe("File name"),
   note: z.string().optional().describe("Note about the attachment"),
   category: z.string().optional().describe("Attachment category"),
-  content_type: z.string().optional().describe("MIME content type"),
+  content_type: z.string().optional().describe("MIME content type (e.g., 'application/pdf', 'image/png', 'image/jpeg'). Required when base64_content is provided."),
+  base64_content: z.string().optional().describe("Base64-encoded file bytes to upload. When provided, the file is POSTed to the QBO upload endpoint as multipart/form-data. Supported content types: application/pdf, image/png, image/jpeg."),
   attachable_ref: z.object({
     entity_ref_type: z.string().describe("Entity type (e.g., 'Invoice', 'Bill')"),
     entity_ref_value: z.string().describe("Entity ID to attach to"),

--- a/src/tools/search-bill-payments.tool.ts
+++ b/src/tools/search-bill-payments.tool.ts
@@ -8,7 +8,11 @@ const toolDescription = "Search bill payments in QuickBooks Online that match gi
 
 // Define the expected input schema for searching bill payments
 const toolSchema = z.object({
-  criteria: z.array(z.any()).optional(),
+  criteria: z.array(z.object({
+    field: z.string(),
+    value: z.union([z.string(), z.number(), z.boolean()]),
+    operator: z.enum(["=", "IN", "<", ">", "<=", ">=", "LIKE"]).optional(),
+  })).optional(),
   asc: z.string().optional(),
   desc: z.string().optional(),
   limit: z.number().optional(),

--- a/src/tools/search-employees.tool.ts
+++ b/src/tools/search-employees.tool.ts
@@ -8,7 +8,11 @@ const toolDescription = "Search employees in QuickBooks Online that match given 
 
 // Define the expected input schema for searching employees
 const toolSchema = z.object({
-  criteria: z.array(z.any()).optional(),
+  criteria: z.array(z.object({
+    field: z.string(),
+    value: z.union([z.string(), z.number(), z.boolean()]),
+    operator: z.enum(["=", "IN", "<", ">", "<=", ">=", "LIKE"]).optional(),
+  })).optional(),
   asc: z.string().optional(),
   desc: z.string().optional(),
   limit: z.number().optional(),

--- a/src/tools/search-journal-entries.tool.ts
+++ b/src/tools/search-journal-entries.tool.ts
@@ -8,7 +8,11 @@ const toolDescription = "Search journal entries in QuickBooks Online that match 
 
 // Define the expected input schema for searching journal entries
 const toolSchema = z.object({
-  criteria: z.array(z.any()).optional(),
+  criteria: z.array(z.object({
+    field: z.string(),
+    value: z.union([z.string(), z.number(), z.boolean()]),
+    operator: z.enum(["=", "IN", "<", ">", "<=", ">=", "LIKE"]).optional(),
+  })).optional(),
   asc: z.string().optional(),
   desc: z.string().optional(),
   limit: z.number().optional(),

--- a/src/tools/search-purchases.tool.ts
+++ b/src/tools/search-purchases.tool.ts
@@ -8,7 +8,11 @@ const toolDescription = "Search purchases in QuickBooks Online that match given 
 
 // Define the expected input schema for searching purchases
 const toolSchema = z.object({
-  criteria: z.array(z.any()).optional(),
+  criteria: z.array(z.object({
+    field: z.string(),
+    value: z.union([z.string(), z.number(), z.boolean()]),
+    operator: z.enum(["=", "IN", "<", ">", "<=", ">=", "LIKE"]).optional(),
+  })).optional(),
   asc: z.string().optional(),
   desc: z.string().optional(),
   limit: z.number().optional(),

--- a/src/tools/upload-attachment-from-url.tool.ts
+++ b/src/tools/upload-attachment-from-url.tool.ts
@@ -22,6 +22,12 @@ const toolSchema = z.object({
     .describe(
       "Override the file name stored in QuickBooks. Defaults to the last path segment of the URL."
     ),
+  content_type: z
+    .enum(["application/pdf", "image/png", "image/jpeg"])
+    .optional()
+    .describe(
+      "Override the MIME type. Required when the URL serves the file as application/octet-stream (common with S3/GCS presigned URLs). Inferred from the HTTP Content-Type header otherwise."
+    ),
   note: z.string().optional().describe("Optional note about the attachment"),
   category: z.string().optional().describe("Optional attachment category"),
   attachable_ref: z

--- a/src/tools/upload-attachment-from-url.tool.ts
+++ b/src/tools/upload-attachment-from-url.tool.ts
@@ -1,0 +1,60 @@
+import { uploadAttachmentFromUrl } from "../handlers/upload-attachment-from-url.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+
+const toolName = "upload_attachment_from_url";
+const toolDescription =
+  "Download a file from a public URL and upload it as an attachment to QuickBooks Online. " +
+  "Supported file types: PDF, PNG, JPEG (detected automatically from the response Content-Type). " +
+  "Optionally attach the uploaded file to a QuickBooks entity (e.g. Bill, Invoice, Purchase) by providing attachable_ref. " +
+  "Returns the QuickBooks Attachable object including its Id, which can be used with update_attachable to link it to additional entities.";
+
+const toolSchema = z.object({
+  file_url: z
+    .string()
+    .url()
+    .describe(
+      "Public URL of the file to download and upload. Must be accessible without authentication. Only http and https URLs are supported."
+    ),
+  file_name: z
+    .string()
+    .optional()
+    .describe(
+      "Override the file name stored in QuickBooks. Defaults to the last path segment of the URL."
+    ),
+  note: z.string().optional().describe("Optional note about the attachment"),
+  category: z.string().optional().describe("Optional attachment category"),
+  attachable_ref: z
+    .object({
+      entity_ref_type: z
+        .string()
+        .describe("QuickBooks entity type to attach to (e.g. 'Bill', 'Invoice', 'Purchase')"),
+      entity_ref_value: z
+        .string()
+        .describe("Id of the QuickBooks entity to attach to"),
+    })
+    .optional()
+    .describe(
+      "Optionally link the uploaded attachment to a QuickBooks entity immediately after upload"
+    ),
+});
+
+const toolHandler = async ({ params }: any) => {
+  const response = await uploadAttachmentFromUrl(params);
+  if (response.isError) {
+    return { content: [{ type: "text" as const, text: `Error: ${response.error}` }] };
+  }
+  return {
+    content: [
+      { type: "text" as const, text: "Attachment uploaded successfully:" },
+      { type: "text" as const, text: JSON.stringify(response.result, null, 2) },
+    ],
+  };
+};
+
+export const UploadAttachmentFromUrlTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -219,6 +219,7 @@ export const mockQuickbooksClient = {
   authenticate: jest.fn<() => Promise<typeof mockQuickBooksInstance>>().mockResolvedValue(mockQuickBooksInstance),
   getQuickbooks: jest.fn<() => typeof mockQuickBooksInstance>().mockReturnValue(mockQuickBooksInstance),
   refreshAccessToken: jest.fn<() => Promise<{ access_token: string; expires_in: number }>>().mockResolvedValue({ access_token: 'mock-token', expires_in: 3600 }),
+  getAuthCredentials: jest.fn<() => { accessToken: string; realmId: string; isSandbox: boolean }>().mockReturnValue({ accessToken: 'mock-token', realmId: 'mock-realm-id', isSandbox: true }),
 };
 
 // Helper to create a successful callback mock
@@ -254,6 +255,8 @@ export function resetAllMocks() {
   });
   mockQuickbooksClient.authenticate.mockReset();
   mockQuickbooksClient.getQuickbooks.mockReset();
+  mockQuickbooksClient.getAuthCredentials.mockReset();
   (mockQuickbooksClient.getQuickbooks as any).mockReturnValue(mockQuickBooksInstance);
   (mockQuickbooksClient.authenticate as any).mockResolvedValue(mockQuickBooksInstance);
+  (mockQuickbooksClient.getAuthCredentials as any).mockReturnValue({ accessToken: 'mock-token', realmId: 'mock-realm-id', isSandbox: true });
 }

--- a/tests/unit/handlers/company-attachable.handlers.test.ts
+++ b/tests/unit/handlers/company-attachable.handlers.test.ts
@@ -6,6 +6,39 @@ jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
 }));
 
+// Mock https for upload tests
+const mockHttpsRequest = jest.fn();
+jest.unstable_mockModule('https', () => ({
+  default: { request: mockHttpsRequest },
+  request: mockHttpsRequest,
+}));
+
+function mockHttpsUploadSuccess(statusCode: number, responseBody: unknown) {
+  const mockReq = { write: jest.fn(), end: jest.fn(), on: jest.fn() };
+  (mockHttpsRequest as any).mockImplementation((_options: unknown, callback: (res: unknown) => void) => {
+    const mockRes = {
+      statusCode,
+      on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'data') handler(Buffer.from(JSON.stringify(responseBody)));
+        else if (event === 'end') handler();
+      }),
+    };
+    callback(mockRes);
+    return mockReq;
+  });
+}
+
+function mockHttpsUploadNetworkError(err: Error) {
+  const mockReq = {
+    write: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === 'error') handler(err);
+    }),
+  };
+  (mockHttpsRequest as any).mockImplementation((_options: unknown, _callback: unknown) => mockReq);
+}
+
 // Dynamic imports after mock setup
 const { getQuickbooksCompanyInfo } = await import('../../../src/handlers/get-quickbooks-company-info.handler');
 const { updateQuickbooksCompanyInfo } = await import('../../../src/handlers/update-quickbooks-company-info.handler');
@@ -190,6 +223,144 @@ describe('Company and Attachable Handlers', () => {
 
       expect(result.isError).toBe(true);
       expect(result.error).toContain('Auth failed');
+    });
+
+    it('should upload file when base64_content is provided', async () => {
+      const uploadResponse = {
+        AttachableResponse: [{ Attachable: { Id: '99', FileName: 'invoice.pdf', FileAccessUri: 'https://example.com/file' }, responseStatus: '200' }]
+      };
+      mockHttpsUploadSuccess(200, uploadResponse);
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'invoice.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('fake-pdf-bytes').toString('base64'),
+        note: 'Supplier invoice',
+        attachable_ref: { entity_ref_type: 'Bill', entity_ref_value: '123' },
+      });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(uploadResponse);
+      expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+      const [[reqOptions]] = (mockHttpsRequest as jest.Mock).mock.calls as any[][];
+      expect(reqOptions.method).toBe('POST');
+      expect(reqOptions.path).toBe('/v3/company/mock-realm-id/upload');
+      expect(reqOptions.hostname).toBe('sandbox-quickbooks.api.intuit.com');
+    });
+
+    it('should upload image/png file', async () => {
+      const uploadResponse = { AttachableResponse: [{ Attachable: { Id: '100', FileName: 'photo.png' }, responseStatus: '200' }] };
+      mockHttpsUploadSuccess(200, uploadResponse);
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'photo.png',
+        content_type: 'image/png',
+        base64_content: Buffer.from('fake-png-bytes').toString('base64'),
+      });
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should upload image/jpeg file', async () => {
+      const uploadResponse = { AttachableResponse: [{ Attachable: { Id: '101', FileName: 'photo.jpg' }, responseStatus: '200' }] };
+      mockHttpsUploadSuccess(200, uploadResponse);
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'photo.jpg',
+        content_type: 'image/jpeg',
+        base64_content: Buffer.from('fake-jpeg-bytes').toString('base64'),
+      });
+
+      expect(result.isError).toBe(false);
+    });
+
+    it('should return error for unsupported content_type on upload', async () => {
+      const result = await createQuickbooksAttachable({
+        file_name: 'archive.zip',
+        content_type: 'application/zip',
+        base64_content: Buffer.from('fake-bytes').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Unsupported content_type');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should return error when base64_content is provided without content_type', async () => {
+      const result = await createQuickbooksAttachable({
+        file_name: 'document.pdf',
+        base64_content: Buffer.from('fake-bytes').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Unsupported content_type');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should return error when QBO upload endpoint returns 4xx', async () => {
+      mockHttpsUploadSuccess(400, { fault: { error: [{ message: 'Bad Request' }] } });
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'invoice.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('fake-pdf-bytes').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('QBO upload failed');
+    });
+
+    it('should return error on upload network failure', async () => {
+      mockHttpsUploadNetworkError(new Error('ECONNREFUSED'));
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'invoice.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('fake-pdf-bytes').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('ECONNREFUSED');
+    });
+
+    it('should return error when QBO returns non-JSON response', async () => {
+      const mockReq = { write: jest.fn(), end: jest.fn(), on: jest.fn() };
+      (mockHttpsRequest as any).mockImplementation((_options: unknown, callback: (res: unknown) => void) => {
+        const mockRes = {
+          statusCode: 200,
+          on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+            if (event === 'data') handler(Buffer.from('not-valid-json'));
+            else if (event === 'end') handler();
+          }),
+        };
+        callback(mockRes);
+        return mockReq;
+      });
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'invoice.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('fake-pdf-bytes').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('unexpected response');
+    });
+
+    it('should use production host when not sandbox', async () => {
+      (mockQuickbooksClient.getAuthCredentials as any).mockReturnValue({ accessToken: 'mock-token', realmId: 'prod-realm', isSandbox: false });
+      const uploadResponse = { AttachableResponse: [{ Attachable: { Id: '102' }, responseStatus: '200' }] };
+      mockHttpsUploadSuccess(200, uploadResponse);
+
+      await createQuickbooksAttachable({
+        file_name: 'invoice.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('fake-pdf-bytes').toString('base64'),
+      });
+
+      const [[reqOptions]] = (mockHttpsRequest as jest.Mock).mock.calls as any[][];
+      expect(reqOptions.hostname).toBe('quickbooks.api.intuit.com');
+      expect(reqOptions.path).toBe('/v3/company/prod-realm/upload');
     });
   });
 


### PR DESCRIPTION
# Add binary file upload support to `create_attachable`

Implements #47.

## Summary

The `create_attachable` tool previously only created attachment metadata records in QBO, with no way to transfer actual file bytes. This PR extends it to accept an optional `base64_content` field and POST the decoded bytes to the QBO upload endpoint (`POST /v3/company/{realmId}/upload`) as `multipart/form-data`.

## Changes

- **`src/handlers/create-quickbooks-attachable.handler.ts`** — Added `base64_content` to `CreateAttachableInput`. When present, validates the `content_type`, decodes the base64 payload, and sends it directly to the QBO upload endpoint via a raw HTTPS `multipart/form-data` request. The original metadata-only path (no `base64_content`) is fully preserved.

- **`src/clients/quickbooks-client.ts`** — Added `getAuthCredentials()` to expose the `accessToken`, `realmId`, and `isSandbox` flag needed to construct the upload request (the `node-quickbooks` SDK does not provide a file-upload method).

- **`src/tools/create-attachable.tool.ts`** — Added `base64_content` to the Zod schema with documentation; updated the `content_type` description to reflect supported MIME types.

- **`tests/mocks/quickbooks.mock.ts`** — Added `getAuthCredentials` mock.

- **`tests/unit/handlers/company-attachable.handlers.test.ts`** — Added 9 new tests covering: PDF/PNG/JPEG upload, sandbox vs production host selection, missing `content_type`, unsupported `content_type`, HTTP 4xx response, network error, and non-JSON response body.