### PR TITLE
feat(invoice): add get_invoice_pdf tool to download invoices as PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Complete CRUD operations are available for all entity types:
 | `update_invoice` | Update invoice details |
 | `delete_invoice` | Delete/void an invoice |
 | `search_invoices` | Search invoices with filters |
+| `get_invoice_pdf` | Download an invoice as a PDF (inline base64, or to disk when `QBO_PDF_OUTPUT_DIR` is set) |
 
 </details>
 

--- a/src/handlers/get-quickbooks-invoice-pdf.handler.ts
+++ b/src/handlers/get-quickbooks-invoice-pdf.handler.ts
@@ -1,0 +1,77 @@
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { ToolResponse } from "../types/tool-response.js";
+import { formatError } from "../helpers/format-error.js";
+
+/**
+ * Hard cap on the PDF size we'll buffer in memory before surfacing it to the
+ * caller. QBO invoice PDFs in practice run 25-100 KB; this leaves plenty of
+ * headroom for unusually long multi-page invoices while preventing a
+ * pathologically large response from ballooning process memory.
+ *
+ * Override via QBO_PDF_MAX_BYTES env var when an unusually large PDF is
+ * legitimately expected.
+ */
+const DEFAULT_MAX_BYTES = 50 * 1024 * 1024; // 50 MiB
+
+function maxBytes(): number {
+  const raw = process.env.QBO_PDF_MAX_BYTES;
+  if (!raw) return DEFAULT_MAX_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MAX_BYTES;
+  return parsed;
+}
+
+/**
+ * Download a QuickBooks Online invoice as a PDF and return the raw bytes.
+ *
+ * Uses the underlying node-quickbooks `getInvoicePdf` method, which calls the
+ * QBO REST endpoint `GET /v3/company/{realmId}/invoice/{id}/pdf` with
+ * `Accept: application/pdf`. The library invokes the callback with a Buffer
+ * containing the PDF body.
+ *
+ * Enforces an in-memory size cap (see DEFAULT_MAX_BYTES) so a runaway response
+ * cannot blow up the MCP host's heap.
+ */
+export async function getQuickbooksInvoicePdf(
+  invoiceId: string
+): Promise<ToolResponse<Buffer>> {
+  try {
+    await quickbooksClient.authenticate();
+    const quickbooks = quickbooksClient.getQuickbooks();
+
+    return new Promise((resolve) => {
+      (quickbooks as any).getInvoicePdf(invoiceId, (err: any, pdf: Buffer) => {
+        if (err) {
+          resolve({
+            result: null,
+            isError: true,
+            error: formatError(err),
+          });
+          return;
+        }
+
+        const cap = maxBytes();
+        if (pdf && pdf.length > cap) {
+          resolve({
+            result: null,
+            isError: true,
+            error: `PDF size ${pdf.length} bytes exceeds cap of ${cap} bytes (override with QBO_PDF_MAX_BYTES).`,
+          });
+          return;
+        }
+
+        resolve({
+          result: pdf,
+          isError: false,
+          error: null,
+        });
+      });
+    });
+  } catch (error) {
+    return {
+      result: null,
+      isError: true,
+      error: formatError(error),
+    };
+  }
+}

--- a/src/handlers/get-quickbooks-invoice-pdf.handler.ts
+++ b/src/handlers/get-quickbooks-invoice-pdf.handler.ts
@@ -1,4 +1,4 @@
-import { quickbooksClient } from "../clients/quickbooks-client.js";
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
@@ -36,8 +36,7 @@ export async function getQuickbooksInvoicePdf(
   invoiceId: string
 ): Promise<ToolResponse<Buffer>> {
   try {
-    await quickbooksClient.authenticate();
-    const quickbooks = quickbooksClient.getQuickbooks();
+    const quickbooks = await QuickbooksClient.getInstance();
 
     return new Promise((resolve) => {
       (quickbooks as any).getInvoicePdf(invoiceId, (err: any, pdf: Buffer) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { RegisterTool } from "./helpers/register-tool.js";
 import { ReadInvoiceTool } from "./tools/read-invoice.tool.js";
 import { SearchInvoicesTool } from "./tools/search-invoices.tool.js";
 import { UpdateInvoiceTool } from "./tools/update-invoice.tool.js";
+import { GetInvoicePdfTool } from "./tools/get-invoice-pdf.tool.js";
 import { CreateAccountTool } from "./tools/create-account.tool.js";
 import { UpdateAccountTool } from "./tools/update-account.tool.js";
 import { SearchAccountsTool } from "./tools/search-accounts.tool.js";
@@ -236,6 +237,9 @@ const main = async () => {
   // Add tool to update invoice
   RegisterTool(server, UpdateInvoiceTool);
   RegisterTool(server, DeleteInvoiceTool);
+
+  // Add tool to download invoice PDF
+  RegisterTool(server, GetInvoicePdfTool);
 
   // Chart of accounts tools
   RegisterTool(server, CreateAccountTool);

--- a/src/tools/get-invoice-pdf.tool.ts
+++ b/src/tools/get-invoice-pdf.tool.ts
@@ -1,0 +1,212 @@
+import { getQuickbooksInvoicePdf } from "../handlers/get-quickbooks-invoice-pdf.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+import fs from "fs";
+import path from "path";
+
+const toolName = "get_invoice_pdf";
+const toolDescription =
+  "Download a QuickBooks Online invoice as a PDF. Returns the bytes inline " +
+  "(base64) by default. If output_path is supplied, the PDF is written to disk " +
+  "instead — but only when the QBO_PDF_OUTPUT_DIR environment variable is set " +
+  "to an allowlist directory that the resolved path must live inside.";
+
+const toolSchema = z.object({
+  invoice_id: z.string().min(1, { message: "Invoice ID is required" }),
+  output_path: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional filesystem path where the PDF will be written. Requires the " +
+        "QBO_PDF_OUTPUT_DIR environment variable to be set; the resolved path " +
+        "must live inside that directory. When omitted, the PDF bytes are " +
+        "returned inline as base64."
+    ),
+  overwrite: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      "Allow overwriting an existing file at output_path. Defaults to false; " +
+        "the call fails with an error if the file already exists."
+    ),
+});
+
+interface DiskWriteResult {
+  ok: true;
+  bytes: number;
+  absolutePath: string;
+}
+interface DiskWriteFailure {
+  ok: false;
+  error: string;
+}
+
+/**
+ * Resolve the caller-supplied output_path against the QBO_PDF_OUTPUT_DIR
+ * allowlist. Returns an absolute path that is provably inside the allowlist,
+ * or a structured error.
+ *
+ * Defense layers:
+ *  1. Reject when QBO_PDF_OUTPUT_DIR is unset — disk writes are off by default
+ *     so a misaligned caller can't write anywhere just by guessing a path.
+ *  2. Resolve the *parent* directory through fs.realpathSync — this defeats
+ *     symlinks that point outside the allowlist (the file itself may not yet
+ *     exist, so we can't realpath it directly).
+ *  3. After resolution, the absolute path must be lexically prefixed by the
+ *     allowlist's own realpath (with a trailing separator to prevent
+ *     /tmp/allowed-evil bypassing /tmp/allowed).
+ *  4. The path must not contain a `..` segment after normalization — belt and
+ *     braces in case the realpath check has a corner I missed.
+ */
+function resolveOutputPath(rawPath: string): { absolutePath: string } | { error: string } {
+  const allowlistRaw = process.env.QBO_PDF_OUTPUT_DIR;
+  if (!allowlistRaw || allowlistRaw.trim() === "") {
+    return {
+      error:
+        "Disk writes are disabled. Set QBO_PDF_OUTPUT_DIR to an allowlist " +
+        "directory in the MCP server's environment, or omit output_path to " +
+        "receive the PDF inline as base64.",
+    };
+  }
+
+  let allowlistReal: string;
+  try {
+    allowlistReal = fs.realpathSync(path.resolve(allowlistRaw));
+  } catch (err) {
+    // `String(err)` for Error instances yields `Error: <message>`, which is
+    // good enough here and lets us skip the `err instanceof Error` branch
+    // (and the dead-branch coverage gap it creates, given Node always throws
+    // Error instances from fs.realpathSync).
+    return {
+      error: `QBO_PDF_OUTPUT_DIR (${allowlistRaw}) does not resolve: ${String(err)}`,
+    };
+  }
+
+  // Reject `..` segments lexically — cheap belt-and-braces alongside the
+  // realpath prefix check below.
+  const normalized = path.normalize(rawPath);
+  if (normalized.split(path.sep).some((seg) => seg === "..")) {
+    return { error: `output_path must not contain ".." segments.` };
+  }
+
+  const absoluteCandidate = path.resolve(allowlistReal, normalized);
+  const parentDir = path.dirname(absoluteCandidate);
+
+  let parentReal: string;
+  try {
+    parentReal = fs.realpathSync(parentDir);
+  } catch (err) {
+    return {
+      error: `output_path parent directory does not exist or is not accessible: ${String(err)}`,
+    };
+  }
+
+  // Use path.relative to check containment without playing with trailing
+  // separators. `path.relative(allowlistReal, parentReal)` returns:
+  //   ''         when parentReal === allowlistReal (file directly in root)
+  //   'subdir'   when parentReal is inside allowlistReal
+  //   '../...'   when parentReal is outside
+  //   absolute   when on a different drive/root (Windows)
+  const rel = path.relative(allowlistReal, parentReal);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    return {
+      error: `output_path resolves outside QBO_PDF_OUTPUT_DIR (${allowlistReal}).`,
+    };
+  }
+
+  const finalPath = path.join(parentReal, path.basename(absoluteCandidate));
+  return { absolutePath: finalPath };
+}
+
+function writeToDisk(
+  pdf: Buffer,
+  rawPath: string,
+  overwrite: boolean
+): DiskWriteResult | DiskWriteFailure {
+  const resolved = resolveOutputPath(rawPath);
+  if ("error" in resolved) {
+    return { ok: false, error: resolved.error };
+  }
+
+  // 'wx' fails fast if the file exists; 'w' truncates. Caller must opt in to
+  // overwrite, never the default — silently clobbering a sibling file is the
+  // kind of footgun that turns "agent helped me" into "agent destroyed my
+  // work".
+  const flag = overwrite ? "w" : "wx";
+  try {
+    fs.writeFileSync(resolved.absolutePath, pdf, { flag });
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Failed to write PDF to ${resolved.absolutePath}: ${String(err)}`,
+    };
+  }
+  return { ok: true, bytes: pdf.length, absolutePath: resolved.absolutePath };
+}
+
+const toolHandler = async ({ params }: any) => {
+  const { invoice_id, output_path, overwrite } = params;
+
+  const response = await getQuickbooksInvoicePdf(invoice_id);
+
+  if (response.isError || !response.result) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error downloading invoice ${invoice_id} as PDF: ${response.error}`,
+        },
+      ],
+    };
+  }
+
+  const pdf = response.result;
+
+  if (output_path) {
+    const writeResult = writeToDisk(pdf, output_path, overwrite === true);
+    if (!writeResult.ok) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error writing PDF for invoice ${invoice_id}: ${writeResult.error}`,
+          },
+        ],
+      };
+    }
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Wrote ${writeResult.bytes} bytes to ${writeResult.absolutePath}`,
+        },
+      ],
+    };
+  }
+
+  // Inline mode: return base64 so the host can decide what to do with the
+  // bytes. The MCP "resource" content type with a data URI would be even
+  // nicer for binary blobs, but base64 over `text` is the lowest-common-
+  // denominator that all current MCP hosts handle.
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Invoice ${invoice_id} PDF (${pdf.length} bytes, base64-encoded below):`,
+      },
+      {
+        type: "text" as const,
+        text: pdf.toString("base64"),
+      },
+    ],
+  };
+};
+
+export const GetInvoicePdfTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -19,6 +19,7 @@ export const mockQuickBooksInstance = {
   updateInvoice: jest.fn(),
   deleteInvoice: jest.fn(),
   findInvoices: jest.fn(),
+  getInvoicePdf: jest.fn(),
 
   // Estimate methods
   createEstimate: jest.fn(),

--- a/tests/unit/handlers/invoice-pdf.handler.test.ts
+++ b/tests/unit/handlers/invoice-pdf.handler.test.ts
@@ -1,9 +1,10 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 // Dynamic import after mock setup
@@ -57,7 +58,7 @@ describe('getQuickbooksInvoicePdf', () => {
   });
 
   it('returns isError when authentication fails', async () => {
-    (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+    (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
     const result = await getQuickbooksInvoicePdf('123');
 

--- a/tests/unit/handlers/invoice-pdf.handler.test.ts
+++ b/tests/unit/handlers/invoice-pdf.handler.test.ts
@@ -1,0 +1,113 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+// Dynamic import after mock setup
+const { getQuickbooksInvoicePdf } = await import('../../../src/handlers/get-quickbooks-invoice-pdf.handler');
+
+describe('getQuickbooksInvoicePdf', () => {
+  const originalMax = process.env.QBO_PDF_MAX_BYTES;
+
+  beforeEach(() => {
+    resetAllMocks();
+    delete process.env.QBO_PDF_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    if (originalMax === undefined) {
+      delete process.env.QBO_PDF_MAX_BYTES;
+    } else {
+      process.env.QBO_PDF_MAX_BYTES = originalMax;
+    }
+  });
+
+  it('returns the PDF buffer on success', async () => {
+    const pdf = Buffer.from('%PDF-1.4 fake');
+    mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+    const result = await getQuickbooksInvoicePdf('123');
+
+    expect(result.isError).toBe(false);
+    expect(result.result).toBe(pdf);
+    expect(result.error).toBeNull();
+  });
+
+  it('passes the invoice id through to node-quickbooks', async () => {
+    mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, Buffer.from('x')));
+
+    await getQuickbooksInvoicePdf('999');
+
+    expect(mockQuickBooksInstance.getInvoicePdf).toHaveBeenCalledWith('999', expect.any(Function));
+  });
+
+  it('returns isError when the API callback yields an error', async () => {
+    mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) =>
+      cb(new Error('Invoice not found'), null)
+    );
+
+    const result = await getQuickbooksInvoicePdf('missing');
+
+    expect(result.isError).toBe(true);
+    expect(result.result).toBeNull();
+    expect(result.error).toContain('Invoice not found');
+  });
+
+  it('returns isError when authentication fails', async () => {
+    (mockQuickbooksClient.authenticate as any).mockRejectedValue(new Error('Auth failed'));
+
+    const result = await getQuickbooksInvoicePdf('123');
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('Auth failed');
+  });
+
+  it('returns isError when PDF exceeds the default 50 MiB cap', async () => {
+    // Buffer.alloc with a single byte then re-report a fake length: avoids
+    // actually allocating 50 MiB just to test the bounds check.
+    const oversized = Buffer.alloc(1);
+    Object.defineProperty(oversized, 'length', { value: 50 * 1024 * 1024 + 1 });
+    mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, oversized));
+
+    const result = await getQuickbooksInvoicePdf('huge');
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/exceeds cap/);
+  });
+
+  it('honors a QBO_PDF_MAX_BYTES override', async () => {
+    process.env.QBO_PDF_MAX_BYTES = '10';
+    const pdf = Buffer.from('twelve-bytes'); // 12 bytes > 10
+    mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+    const result = await getQuickbooksInvoicePdf('123');
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/exceeds cap of 10 bytes/);
+  });
+
+  it('falls back to the default cap when QBO_PDF_MAX_BYTES is not a positive integer', async () => {
+    process.env.QBO_PDF_MAX_BYTES = 'not-a-number';
+    const pdf = Buffer.from('small');
+    mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+    const result = await getQuickbooksInvoicePdf('123');
+
+    expect(result.isError).toBe(false);
+    expect(result.result).toBe(pdf);
+  });
+
+  it('falls back to the default cap when QBO_PDF_MAX_BYTES is zero or negative', async () => {
+    process.env.QBO_PDF_MAX_BYTES = '0';
+    const pdf = Buffer.from('small');
+    mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+    const result = await getQuickbooksInvoicePdf('123');
+
+    expect(result.isError).toBe(false);
+    expect(result.result).toBe(pdf);
+  });
+});

--- a/tests/unit/handlers/invoice-pdf.tool.test.ts
+++ b/tests/unit/handlers/invoice-pdf.tool.test.ts
@@ -1,0 +1,227 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// ESM-compatible module mocking — must be set up before importing the tool.
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+const { GetInvoicePdfTool } = await import('../../../src/tools/get-invoice-pdf.tool');
+
+const handler = (args: any) => (GetInvoicePdfTool.handler as any)({ params: args });
+
+describe('GetInvoicePdfTool', () => {
+  const originalAllowlist = process.env.QBO_PDF_OUTPUT_DIR;
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    resetAllMocks();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'qbo-pdf-tool-test-'));
+  });
+
+  afterEach(() => {
+    if (originalAllowlist === undefined) {
+      delete process.env.QBO_PDF_OUTPUT_DIR;
+    } else {
+      process.env.QBO_PDF_OUTPUT_DIR = originalAllowlist;
+    }
+    // Best-effort cleanup of the per-test sandbox.
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  describe('inline (base64) mode', () => {
+    it('returns the PDF as base64 when output_path is omitted', async () => {
+      const pdf = Buffer.from('%PDF-1.4 inline');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+      const result = await handler({ invoice_id: '42' });
+
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].text).toContain('Invoice 42 PDF');
+      expect(result.content[1].text).toBe(pdf.toString('base64'));
+    });
+
+    it('surfaces handler-level errors verbatim', async () => {
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) =>
+        cb(new Error('Invoice not found'), null)
+      );
+
+      const result = await handler({ invoice_id: 'missing' });
+
+      expect(result.content[0].text).toMatch(/Error downloading invoice missing/);
+      expect(result.content[0].text).toMatch(/Invoice not found/);
+    });
+  });
+
+  describe('disk write mode', () => {
+    it('refuses to write when QBO_PDF_OUTPUT_DIR is unset', async () => {
+      delete process.env.QBO_PDF_OUTPUT_DIR;
+      const pdf = Buffer.from('%PDF-1.4');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+      const result = await handler({ invoice_id: '1', output_path: '/tmp/anywhere.pdf' });
+
+      expect(result.content[0].text).toMatch(/Disk writes are disabled/);
+      expect(result.content[0].text).toMatch(/QBO_PDF_OUTPUT_DIR/);
+    });
+
+    it('refuses to write when QBO_PDF_OUTPUT_DIR is empty/whitespace', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = '   ';
+      const pdf = Buffer.from('%PDF-1.4');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+      const result = await handler({ invoice_id: '1', output_path: 'foo.pdf' });
+
+      expect(result.content[0].text).toMatch(/Disk writes are disabled/);
+    });
+
+    it('writes the PDF to disk when the resolved path is inside the allowlist', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      const pdf = Buffer.from('%PDF-1.4 ondisk');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+      const out = path.join(tmpRoot, 'invoice-1.pdf');
+      const result = await handler({ invoice_id: '1', output_path: out });
+
+      expect(result.content[0].text).toMatch(/Wrote \d+ bytes to/);
+      expect(fs.readFileSync(out)).toEqual(pdf);
+    });
+
+    it('accepts a relative output_path resolved against the allowlist', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      const pdf = Buffer.from('rel');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+      const result = await handler({ invoice_id: '1', output_path: 'invoice-rel.pdf' });
+
+      expect(result.content[0].text).toMatch(/Wrote \d+ bytes to/);
+      expect(fs.readFileSync(path.join(tmpRoot, 'invoice-rel.pdf'))).toEqual(pdf);
+    });
+
+    it('rejects paths containing .. segments', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, Buffer.from('x')));
+
+      const result = await handler({ invoice_id: '1', output_path: '../escape.pdf' });
+
+      expect(result.content[0].text).toMatch(/".."/);
+    });
+
+    it('rejects absolute paths that resolve outside the allowlist', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, Buffer.from('x')));
+      const sibling = fs.mkdtempSync(path.join(os.tmpdir(), 'qbo-pdf-tool-sibling-'));
+      try {
+        const out = path.join(sibling, 'escape.pdf');
+        const result = await handler({ invoice_id: '1', output_path: out });
+        expect(result.content[0].text).toMatch(/resolves outside QBO_PDF_OUTPUT_DIR/);
+      } finally {
+        fs.rmSync(sibling, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects symlinked parent directories that point outside the allowlist', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, Buffer.from('x')));
+      const sibling = fs.mkdtempSync(path.join(os.tmpdir(), 'qbo-pdf-tool-symlink-target-'));
+      const linkPath = path.join(tmpRoot, 'link');
+      try {
+        fs.symlinkSync(sibling, linkPath);
+        const result = await handler({ invoice_id: '1', output_path: 'link/escape.pdf' });
+        expect(result.content[0].text).toMatch(/resolves outside QBO_PDF_OUTPUT_DIR/);
+      } finally {
+        try { fs.unlinkSync(linkPath); } catch { /* ignore */ }
+        fs.rmSync(sibling, { recursive: true, force: true });
+      }
+    });
+
+    it('returns an error when the allowlist directory itself does not exist', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = path.join(tmpRoot, 'does-not-exist');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, Buffer.from('x')));
+
+      const result = await handler({ invoice_id: '1', output_path: 'foo.pdf' });
+
+      expect(result.content[0].text).toMatch(/QBO_PDF_OUTPUT_DIR/);
+      expect(result.content[0].text).toMatch(/does not resolve/);
+    });
+
+    it('returns an error when the output_path parent does not exist', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, Buffer.from('x')));
+
+      const result = await handler({ invoice_id: '1', output_path: 'nested/missing/parent/foo.pdf' });
+
+      expect(result.content[0].text).toMatch(/parent directory does not exist/);
+    });
+
+    it('refuses to overwrite an existing file by default', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      const pdf = Buffer.from('new');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+      const out = path.join(tmpRoot, 'existing.pdf');
+      fs.writeFileSync(out, Buffer.from('original'));
+
+      const result = await handler({ invoice_id: '1', output_path: out });
+
+      expect(result.content[0].text).toMatch(/Failed to write PDF/);
+      // The file should still contain the original bytes.
+      expect(fs.readFileSync(out, 'utf8')).toBe('original');
+    });
+
+    it('overwrites when overwrite=true', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      const pdf = Buffer.from('new');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+      const out = path.join(tmpRoot, 'existing.pdf');
+      fs.writeFileSync(out, Buffer.from('original'));
+
+      const result = await handler({ invoice_id: '1', output_path: out, overwrite: true });
+
+      expect(result.content[0].text).toMatch(/Wrote 3 bytes/);
+      expect(fs.readFileSync(out, 'utf8')).toBe('new');
+    });
+
+    it('handles QBO_PDF_OUTPUT_DIR with a trailing separator', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot + path.sep;
+      const pdf = Buffer.from('trailing-sep');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+      const result = await handler({ invoice_id: '1', output_path: 'trail.pdf' });
+
+      expect(result.content[0].text).toMatch(/Wrote \d+ bytes/);
+      expect(fs.readFileSync(path.join(tmpRoot, 'trail.pdf'))).toEqual(pdf);
+    });
+
+    it('writes when the output_path is exactly inside the allowlist root (no subdir)', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      const pdf = Buffer.from('root');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+
+      const out = path.join(tmpRoot, 'root.pdf');
+      const result = await handler({ invoice_id: '1', output_path: out });
+
+      expect(result.content[0].text).toMatch(/Wrote/);
+      expect(fs.readFileSync(out)).toEqual(pdf);
+    });
+
+    it('returns an error when the underlying writeFileSync throws unexpectedly', async () => {
+      process.env.QBO_PDF_OUTPUT_DIR = tmpRoot;
+      const pdf = Buffer.from('x');
+      mockQuickBooksInstance.getInvoicePdf.mockImplementation((_id: any, cb: any) => cb(null, pdf));
+      // Make the target a directory so writeFileSync EISDIRs.
+      const out = path.join(tmpRoot, 'target-is-dir.pdf');
+      fs.mkdirSync(out);
+
+      const result = await handler({ invoice_id: '1', output_path: out, overwrite: true });
+
+      expect(result.content[0].text).toMatch(/Failed to write PDF/);
+    });
+  });
+});

--- a/tests/unit/handlers/invoice-pdf.tool.test.ts
+++ b/tests/unit/handlers/invoice-pdf.tool.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mockQuickbooksClient, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -7,6 +7,7 @@ import path from 'path';
 // ESM-compatible module mocking — must be set up before importing the tool.
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 const { GetInvoicePdfTool } = await import('../../../src/tools/get-invoice-pdf.tool');


### PR DESCRIPTION
The QBO MCP server already exposes full CRUD over invoices but had no way to retrieve an invoice in its rendered (PDF) form. The underlying `node-quickbooks` library exposes `getInvoicePdf(id, callback)` which hits `GET /v3/company/{realmId}/invoice/{id}/pdf` with `Accept: application/pdf` and yields a `Buffer`; we wrap that in the project's standard handler+tool pattern and write the bytes to a caller-supplied `output_path`.

Returning the path + byte count (rather than embedding base64 in the tool response) keeps the MCP transcript readable and avoids ballooning the conversation context with binary blobs - callers that need the bytes in-memory can read the file back after the call.