### PR TITLE
test: add prototype-shape contract test for get_general_ledger

### DIFF
--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -200,7 +200,6 @@ export const mockQuickBooksInstance = {
   reportProfitAndLoss: jest.fn(),
   reportCashFlow: jest.fn(),
   reportTrialBalance: jest.fn(),
-  reportGeneralLedger: jest.fn(),
   reportGeneralLedgerDetail: jest.fn(),
   reportCustomerSales: jest.fn(),
   reportItemSales: jest.fn(),

--- a/tests/unit/handlers/general-ledger.prototype-shape.test.ts
+++ b/tests/unit/handlers/general-ledger.prototype-shape.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Prototype-shape contract test for get_general_ledger.
+ *
+ * Exercises the handler against the real node-quickbooks prototype (not the
+ * hand-rolled mock) so any future drift between the handler's method name and
+ * the library's prototype method name fails loudly in CI without needing
+ * network or credentials.
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import QuickBooks from 'node-quickbooks';
+
+const mockQuickbooksClient = {
+  authenticate: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  getQuickbooks: jest.fn<() => QuickBooks>(),
+};
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+}));
+
+const { getQuickbooksGeneralLedger } = await import('../../../src/handlers/get-quickbooks-general-ledger.handler');
+
+describe('get_general_ledger prototype-shape contract', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockQuickbooksClient.authenticate.mockResolvedValue(undefined);
+  });
+
+  it('node-quickbooks exposes reportGeneralLedgerDetail on its prototype', () => {
+    expect(typeof (QuickBooks.prototype as any).reportGeneralLedgerDetail).toBe('function');
+  });
+
+  it('handler invokes a method that exists on the real QuickBooks prototype', async () => {
+    const qb = Object.create(QuickBooks.prototype) as QuickBooks;
+    mockQuickbooksClient.getQuickbooks.mockReturnValue(qb);
+
+    const spy = jest
+      .spyOn(QuickBooks.prototype as any, 'reportGeneralLedgerDetail')
+      .mockImplementation(function (this: unknown, _params: any, cb: any) {
+        cb(null, { Header: { ReportName: 'GeneralLedger' } });
+      });
+
+    const result = await getQuickbooksGeneralLedger({ start_date: '2024-01-01', end_date: '2024-01-31' });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(false);
+    expect(result.result).toMatchObject({ Header: { ReportName: 'GeneralLedger' } });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing CI guard that would have caught issue #34 (`get_general_ledger` calling a non-existent `node-quickbooks` method) before it shipped, plus a small dead-code cleanup in the test mock.

This is a follow-up to:
- #35 / commit 36f18be — the handler fix (`reportGeneralLedger` → `reportGeneralLedgerDetail`)
- commit c59c20f — the test/mock rename

Both of those landed the production fix. What was still missing was a test that exercises the handler against the real `node-quickbooks` library shape, so that the next time a handler calls `(quickbooks as any).someMethod(...)` with a method name that doesn't exist on the library, CI fails loudly instead of agreeing with the typo via the hand-rolled mock.

## Why the original bug slipped past CI

`tests/mocks/quickbooks.mock.ts` stubs whatever method name the handler happens to call:

```ts
// Before the fix, the handler called reportGeneralLedger,
// and the mock dutifully stubbed reportGeneralLedger:
reportGeneralLedger: jest.fn(),  // typo'd name, mock agrees with handler
```

So the existing unit test in `reports.handlers.test.ts` passed — the handler called `reportGeneralLedger`, the mock returned a mock report, the assertion fired green. CI saw nothing wrong, because nothing in the test path ever touched the real `node-quickbooks` library.

This pattern silently masks any handler-vs-library method-name drift.

## What this PR adds

### `tests/unit/handlers/general-ledger.prototype-shape.test.ts`

Two assertions:

1. **`node-quickbooks` actually exposes `reportGeneralLedgerDetail` on its prototype.** This pins the contract: if a future `node-quickbooks` upgrade renames or removes the method, the test fails immediately and points at the right place.

2. **The handler invokes a method that exists on the real `QuickBooks.prototype`.** Instead of the hand-rolled `mockQuickBooksInstance` mock, this test spies on the real prototype method (`jest.spyOn(QuickBooks.prototype, 'reportGeneralLedgerDetail')`) and points the client at a real-prototype-backed instance. If the handler ever calls a name that isn't on the prototype, the spy never fires, the response object reflects the failure, and the test fails loudly. No network or credentials needed.

The test follows the exact same pattern already used in [`tests/unit/handlers/budget.prototype-shape.test.ts`](https://github.com/intuit/quickbooks-online-mcp-server/blob/main/tests/unit/handlers/budget.prototype-shape.test.ts) (added in #39), so it should be familiar.

### `tests/mocks/quickbooks.mock.ts` — remove orphaned entry

After the test rename in c59c20f, the mock has both `reportGeneralLedger: jest.fn()` (the original typo) and `reportGeneralLedgerDetail: jest.fn()` (the correct name). The typo'd entry isn't referenced anywhere in the codebase anymore. Removing it.

Diff:
```diff
   reportTrialBalance: jest.fn(),
-  reportGeneralLedger: jest.fn(),
   reportGeneralLedgerDetail: jest.fn(),
```

## Verification

- `npm test` — 398 tests pass (was 396 on main; +2 new prototype-shape assertions).
- `npm run build` — clean.
- Coverage thresholds: same numbers as `main` baseline (99.79% / 99.59% / 99.83%) — pre-existing on main, not introduced or regressed by this PR.

## Why this is worth landing

Same class of bug is possible anywhere a handler calls `(quickbooks as any).someMethod(...)` — and that pattern is used throughout this server. This PR doesn't try to retrofit prototype-shape tests across every handler, but it adds the proven pattern next to the bug that motivated it, so the same trap can't catch `get_general_ledger` again. If maintainers find the pattern useful, extending it to other report/find handlers is mechanical.

Closes the loop on #34.