### PR TITLE
fix: use array criteria format for date filters in search handlers

### DIFF
--- a/src/handlers/search-quickbooks-credit-memos.handler.ts
+++ b/src/handlers/search-quickbooks-credit-memos.handler.ts
@@ -13,19 +13,19 @@ export async function searchQuickbooksCreditMemos(data: SearchCreditMemosInput):
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
-    const criteria: Record<string, any> = {};
+    const criteria: Array<Record<string, any>> = [];
 
     if (data.customer_ref) {
-      criteria.CustomerRef = data.customer_ref;
+      criteria.push({ field: "CustomerRef", value: data.customer_ref, operator: "=" });
     }
     if (data.txn_date_from) {
-      criteria.TxnDate = { $gte: data.txn_date_from };
+      criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
     }
     if (data.txn_date_to) {
-      criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
+      criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
     }
     if (data.limit) {
-      criteria.limit = data.limit;
+      criteria.push({ field: "limit", value: data.limit });
     }
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-deposits.handler.ts
+++ b/src/handlers/search-quickbooks-deposits.handler.ts
@@ -11,10 +11,10 @@ export interface SearchDepositsInput {
 export async function searchQuickbooksDeposits(data: SearchDepositsInput): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
-    const criteria: Record<string, any> = {};
-    if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
-    if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
-    if (data.limit) criteria.limit = data.limit;
+    const criteria: Array<Record<string, any>> = [];
+    if (data.txn_date_from) criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
+    if (data.txn_date_to) criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
+    if (data.limit) criteria.push({ field: "limit", value: data.limit });
 
     return new Promise((resolve) => {
       (quickbooks as any).findDeposits(criteria, (err: any, result: any) => {

--- a/src/handlers/search-quickbooks-payments.handler.ts
+++ b/src/handlers/search-quickbooks-payments.handler.ts
@@ -1,7 +1,6 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
-import { buildQuickbooksSearchCriteria } from "../helpers/build-quickbooks-search-criteria.js";
 
 export interface SearchPaymentsInput {
   customer_ref?: string;
@@ -14,19 +13,19 @@ export async function searchQuickbooksPayments(data: SearchPaymentsInput): Promi
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
-    const criteria: Record<string, any> = {};
+    const criteria: Array<Record<string, any>> = [];
 
     if (data.customer_ref) {
-      criteria.CustomerRef = data.customer_ref;
+      criteria.push({ field: "CustomerRef", value: data.customer_ref, operator: "=" });
     }
     if (data.txn_date_from) {
-      criteria.TxnDate = { $gte: data.txn_date_from };
+      criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
     }
     if (data.txn_date_to) {
-      criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
+      criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
     }
     if (data.limit) {
-      criteria.limit = data.limit;
+      criteria.push({ field: "limit", value: data.limit });
     }
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-purchase-orders.handler.ts
+++ b/src/handlers/search-quickbooks-purchase-orders.handler.ts
@@ -13,11 +13,11 @@ export async function searchQuickbooksPurchaseOrders(data: SearchPurchaseOrdersI
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
-    const criteria: Record<string, any> = {};
-    if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;
-    if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
-    if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
-    if (data.limit) criteria.limit = data.limit;
+    const criteria: Array<Record<string, any>> = [];
+    if (data.vendor_ref) criteria.push({ field: "VendorRef", value: data.vendor_ref, operator: "=" });
+    if (data.txn_date_from) criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
+    if (data.txn_date_to) criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
+    if (data.limit) criteria.push({ field: "limit", value: data.limit });
 
     return new Promise((resolve) => {
       (quickbooks as any).findPurchaseOrders(criteria, (err: any, result: any) => {

--- a/src/handlers/search-quickbooks-refund-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-refund-receipts.handler.ts
@@ -13,19 +13,19 @@ export async function searchQuickbooksRefundReceipts(data: SearchRefundReceiptsI
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
-    const criteria: Record<string, any> = {};
+    const criteria: Array<Record<string, any>> = [];
 
     if (data.customer_ref) {
-      criteria.CustomerRef = data.customer_ref;
+      criteria.push({ field: "CustomerRef", value: data.customer_ref, operator: "=" });
     }
     if (data.txn_date_from) {
-      criteria.TxnDate = { $gte: data.txn_date_from };
+      criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
     }
     if (data.txn_date_to) {
-      criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
+      criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
     }
     if (data.limit) {
-      criteria.limit = data.limit;
+      criteria.push({ field: "limit", value: data.limit });
     }
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-sales-receipts.handler.ts
+++ b/src/handlers/search-quickbooks-sales-receipts.handler.ts
@@ -13,19 +13,19 @@ export async function searchQuickbooksSalesReceipts(data: SearchSalesReceiptsInp
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
-    const criteria: Record<string, any> = {};
+    const criteria: Array<Record<string, any>> = [];
 
     if (data.customer_ref) {
-      criteria.CustomerRef = data.customer_ref;
+      criteria.push({ field: "CustomerRef", value: data.customer_ref, operator: "=" });
     }
     if (data.txn_date_from) {
-      criteria.TxnDate = { $gte: data.txn_date_from };
+      criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
     }
     if (data.txn_date_to) {
-      criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
+      criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
     }
     if (data.limit) {
-      criteria.limit = data.limit;
+      criteria.push({ field: "limit", value: data.limit });
     }
 
     return new Promise((resolve) => {

--- a/src/handlers/search-quickbooks-time-activities.handler.ts
+++ b/src/handlers/search-quickbooks-time-activities.handler.ts
@@ -14,13 +14,13 @@ export interface SearchTimeActivitiesInput {
 export async function searchQuickbooksTimeActivities(data: SearchTimeActivitiesInput): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
-    const criteria: Record<string, any> = {};
-    if (data.employee_ref) criteria.EmployeeRef = data.employee_ref;
-    if (data.vendor_ref) criteria.VendorRef = data.vendor_ref;
-    if (data.customer_ref) criteria.CustomerRef = data.customer_ref;
-    if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
-    if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
-    if (data.limit) criteria.limit = data.limit;
+    const criteria: Array<Record<string, any>> = [];
+    if (data.employee_ref) criteria.push({ field: "EmployeeRef", value: data.employee_ref, operator: "=" });
+    if (data.vendor_ref) criteria.push({ field: "VendorRef", value: data.vendor_ref, operator: "=" });
+    if (data.customer_ref) criteria.push({ field: "CustomerRef", value: data.customer_ref, operator: "=" });
+    if (data.txn_date_from) criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
+    if (data.txn_date_to) criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
+    if (data.limit) criteria.push({ field: "limit", value: data.limit });
 
     return new Promise((resolve) => {
       (quickbooks as any).findTimeActivities(criteria, (err: any, result: any) => {

--- a/src/handlers/search-quickbooks-transfers.handler.ts
+++ b/src/handlers/search-quickbooks-transfers.handler.ts
@@ -11,10 +11,10 @@ export interface SearchTransfersInput {
 export async function searchQuickbooksTransfers(data: SearchTransfersInput): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
-    const criteria: Record<string, any> = {};
-    if (data.txn_date_from) criteria.TxnDate = { $gte: data.txn_date_from };
-    if (data.txn_date_to) criteria.TxnDate = { ...criteria.TxnDate, $lte: data.txn_date_to };
-    if (data.limit) criteria.limit = data.limit;
+    const criteria: Array<Record<string, any>> = [];
+    if (data.txn_date_from) criteria.push({ field: "TxnDate", value: data.txn_date_from, operator: ">=" });
+    if (data.txn_date_to) criteria.push({ field: "TxnDate", value: data.txn_date_to, operator: "<=" });
+    if (data.limit) criteria.push({ field: "limit", value: data.limit });
 
     return new Promise((resolve) => {
       (quickbooks as any).findTransfers(criteria, (err: any, result: any) => {

--- a/tests/unit/handlers/deposit-transfer.handlers.test.ts
+++ b/tests/unit/handlers/deposit-transfer.handlers.test.ts
@@ -225,6 +225,30 @@ describe('Deposit and Transfer Handlers', () => {
       expect(result.isError).toBe(false);
     });
 
+    it('should pass date filters in the array/operator format node-quickbooks parses', async () => {
+      // Regression guard for the silently-ignored date filter bug: node-quickbooks
+      // builds its WHERE clause from an array of { field, value, operator } objects
+      // (module.criteriaToString -> `field operator value`). The old MongoDB-style
+      // { TxnDate: { $gte } } had no `field`/`operator` keys and was dropped, so
+      // date ranges were ignored. Assert the exact criteria shape reaching the lib.
+      let captured: any;
+      mockQuickBooksInstance.findDeposits.mockImplementation((criteria: any, cb: any) => {
+        captured = criteria;
+        cb(null, { QueryResponse: { Deposit: [] } });
+      });
+
+      await searchQuickbooksDeposits({ txn_date_from: '2024-01-01', txn_date_to: '2024-12-31', limit: 50 });
+
+      expect(Array.isArray(captured)).toBe(true);
+      expect(captured).toEqual(expect.arrayContaining([
+        { field: 'TxnDate', value: '2024-01-01', operator: '>=' },
+        { field: 'TxnDate', value: '2024-12-31', operator: '<=' },
+        { field: 'limit', value: 50 },
+      ]));
+      // No MongoDB-style operators should survive.
+      expect(JSON.stringify(captured)).not.toMatch(/\$gte|\$lte/);
+    });
+
     it('should handle empty QueryResponse', async () => {
       mockQuickBooksInstance.findDeposits.mockImplementation((criteria: any, cb: any) =>
         cb(null, { QueryResponse: {} })
@@ -406,6 +430,24 @@ describe('Deposit and Transfer Handlers', () => {
       });
 
       expect(result.isError).toBe(false);
+    });
+
+    it('should pass date filters in the array/operator format node-quickbooks parses', async () => {
+      let captured: any;
+      mockQuickBooksInstance.findTransfers.mockImplementation((criteria: any, cb: any) => {
+        captured = criteria;
+        cb(null, { QueryResponse: { Transfer: [] } });
+      });
+
+      await searchQuickbooksTransfers({ txn_date_from: '2024-01-01', txn_date_to: '2024-12-31', limit: 50 });
+
+      expect(Array.isArray(captured)).toBe(true);
+      expect(captured).toEqual(expect.arrayContaining([
+        { field: 'TxnDate', value: '2024-01-01', operator: '>=' },
+        { field: 'TxnDate', value: '2024-12-31', operator: '<=' },
+        { field: 'limit', value: 50 },
+      ]));
+      expect(JSON.stringify(captured)).not.toMatch(/\$gte|\$lte/);
     });
 
     it('should handle empty QueryResponse', async () => {


### PR DESCRIPTION
The 8 search handlers that support txn_date_from/txn_date_to were building date filter criteria using MongoDB-style operators ({ $gte: value }), which node-quickbooks does not understand. The library's toCriterion() function treats the nested object as a plain value, producing invalid QBO query syntax like
`WHERE TxnDate = [object Object]`, causing a QueryParserError from the QuickBooks API.

Switch all affected handlers from `Record<string, any>` with $gte/$lte to `Array<Record<string, any>>` with `{ field, value, operator }` — the format that node-quickbooks' criteriaToString() expects, producing correct SQL like `WHERE TxnDate >= '2024-01-01' AND TxnDate <= '2024-12-31'`.

Affected handlers:
- search-quickbooks-payments
- search-quickbooks-credit-memos
- search-quickbooks-deposits
- search-quickbooks-transfers
- search-quickbooks-purchase-orders
- search-quickbooks-time-activities
- search-quickbooks-sales-receipts
- search-quickbooks-refund-receipts