### PR TITLE
Add 'Classes' to P&L summarize_column_by enum

### DIFF
--- a/src/handlers/get-quickbooks-profit-and-loss.handler.ts
+++ b/src/handlers/get-quickbooks-profit-and-loss.handler.ts
@@ -6,7 +6,7 @@ export interface ProfitAndLossOptions {
   start_date?: string;
   end_date?: string;
   accounting_method?: "Cash" | "Accrual";
-  summarize_column_by?: "Total" | "Month" | "Week" | "Days";
+  summarize_column_by?: "Total" | "Month" | "Week" | "Days" | "Classes";
   customer?: string;
   vendor?: string;
   item?: string;

--- a/src/tools/get-profit-and-loss.tool.ts
+++ b/src/tools/get-profit-and-loss.tool.ts
@@ -8,7 +8,7 @@ const toolSchema = z.object({
   start_date: z.string().optional().describe("Start date (YYYY-MM-DD)"),
   end_date: z.string().optional().describe("End date (YYYY-MM-DD)"),
   accounting_method: z.enum(["Cash", "Accrual"]).optional().describe("Accounting method"),
-  summarize_column_by: z.enum(["Total", "Month", "Week", "Days"]).optional().describe("How to summarize columns"),
+  summarize_column_by: z.enum(["Total", "Month", "Week", "Days", "Classes"]).optional().describe("How to summarize columns"),
   customer: z.string().optional().describe("Filter by customer ID"),
   vendor: z.string().optional().describe("Filter by vendor ID"),
   item: z.string().optional().describe("Filter by item ID"),


### PR DESCRIPTION
## Summary

Adds `"Classes"` as a valid value for `summarize_column_by` in the `get_profit_and_loss` tool, enabling P&L reports broken down by QuickBooks class.

**Changes:**
- `src/tools/get-profit-and-loss.tool.ts` — adds `"Classes"` to the Zod enum
- `src/handlers/get-quickbooks-profit-and-loss.handler.ts` — adds `"Classes"` to the TypeScript type

The QuickBooks Online API already supports `summarize_column_by=Classes` — this change simply exposes it through the MCP tool schema.

## Usage

```json
{
  "start_date": "2026-01-01",
  "end_date": "2026-04-30",
  "accounting_method": "Cash",
  "summarize_column_by": "Classes"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)