### PR TITLE
Feature: Restriction Mode for CRUD tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,6 @@ QUICKBOOKS_REDIRECT_URI=http://localhost:8000/callback
 QUICKBOOKS_ENVIRONMENT=sandbox
 
 # Restriction Mode — omit or set to false to register all tools (default: all tools registered)
-# DISABLE_WRITE=true    # suppress create_* and create-* tools
-# DISABLE_UPDATE=true   # suppress update_* and update-* tools
-# DISABLE_DELETE=true   # suppress delete_* and delete-* tools
+# QUICKBOOKS_DISABLE_WRITE=true    # suppress create_* and create-* tools
+# QUICKBOOKS_DISABLE_UPDATE=true   # suppress update_* and update-* tools
+# QUICKBOOKS_DISABLE_DELETE=true   # suppress delete_* and delete-* tools

--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ QUICKBOOKS_REFRESH_TOKEN=your_refresh_token_here
 QUICKBOOKS_REALM_ID=your_company_id_here
 QUICKBOOKS_REDIRECT_URI=http://localhost:8000/callback
 QUICKBOOKS_ENVIRONMENT=sandbox
+# Restriction Mode — omit or set to false to register all tools (default: all tools registered)
+# DISABLE_WRITE=false    # suppress create_* and create-* tools
+# DISABLE_UPDATE=false   # suppress update_* and update-* tools
+# DISABLE_DELETE=false   # suppress delete_* and delete-* tools

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ QUICKBOOKS_REFRESH_TOKEN=your_refresh_token_here
 QUICKBOOKS_REALM_ID=your_company_id_here
 QUICKBOOKS_REDIRECT_URI=http://localhost:8000/callback
 QUICKBOOKS_ENVIRONMENT=sandbox
+
 # Restriction Mode — omit or set to false to register all tools (default: all tools registered)
-# DISABLE_WRITE=false    # suppress create_* and create-* tools
-# DISABLE_UPDATE=false   # suppress update_* and update-* tools
-# DISABLE_DELETE=false   # suppress delete_* and delete-* tools
+# DISABLE_WRITE=true    # suppress create_* and create-* tools
+# DISABLE_UPDATE=true   # suppress update_* and update-* tools
+# DISABLE_DELETE=true   # suppress delete_* and delete-* tools

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ QUICKBOOKS_CLIENT_SECRET=your_client_secret
 QUICKBOOKS_ENVIRONMENT=sandbox
 QUICKBOOKS_REFRESH_TOKEN=your_refresh_token
 QUICKBOOKS_REALM_ID=your_realm_id
+
+# Optional: restrict which tool categories are registered (default: all enabled)
+# DISABLE_WRITE=true    # suppress create_* tools
+# DISABLE_UPDATE=true   # suppress update_* tools
+# DISABLE_DELETE=true   # suppress delete_* tools
 ```
 
 `.env` is gitignored so your real credentials stay local.
@@ -83,12 +88,17 @@ Add to your Claude Code MCP configuration:
         "QUICKBOOKS_CLIENT_SECRET": "your_client_secret",
         "QUICKBOOKS_REFRESH_TOKEN": "your_refresh_token",
         "QUICKBOOKS_REALM_ID": "your_realm_id",
-        "QUICKBOOKS_ENVIRONMENT": "sandbox"
+        "QUICKBOOKS_ENVIRONMENT": "sandbox",
+        "DISABLE_WRITE": "false",
+        "DISABLE_UPDATE": "false",
+        "DISABLE_DELETE": "false"
       }
     }
   }
 }
 ```
+
+Set any of the `DISABLE_*` flags to `"true"` to prevent that category of tools from being registered. Read tools (`get_*`, `search_*`) are always available.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -471,6 +471,19 @@ If you encounter connection errors:
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+### Tool naming convention
+
+All tool names must follow the `{verb}_{entity}` convention using underscores. The verb prefix determines CRUD Restriction Mode behaviour:
+
+| Prefix | Category | Suppressed by |
+|--------|----------|---------------|
+| `create_` | WRITE | `DISABLE_WRITE=true` |
+| `update_` | UPDATE | `DISABLE_UPDATE=true` |
+| `delete_` | DELETE | `DISABLE_DELETE=true` |
+| `get_`, `search_`, `read_` | READ | never |
+
+New tools that do not follow this convention will not be correctly categorised and may appear or be suppressed unexpectedly.
+
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ QUICKBOOKS_REFRESH_TOKEN=your_refresh_token
 QUICKBOOKS_REALM_ID=your_realm_id
 
 # Optional: restrict which tool categories are registered (default: all enabled)
-# DISABLE_WRITE=true    # suppress create_* tools
-# DISABLE_UPDATE=true   # suppress update_* tools
-# DISABLE_DELETE=true   # suppress delete_* tools
+# QUICKBOOKS_DISABLE_WRITE=true    # suppress create_* tools
+# QUICKBOOKS_DISABLE_UPDATE=true   # suppress update_* tools
+# QUICKBOOKS_DISABLE_DELETE=true   # suppress delete_* tools
 ```
 
 `.env` is gitignored so your real credentials stay local.
@@ -89,9 +89,9 @@ Add to your Claude Code MCP configuration:
         "QUICKBOOKS_REFRESH_TOKEN": "your_refresh_token",
         "QUICKBOOKS_REALM_ID": "your_realm_id",
         "QUICKBOOKS_ENVIRONMENT": "sandbox",
-        "DISABLE_WRITE": "false",
-        "DISABLE_UPDATE": "false",
-        "DISABLE_DELETE": "false"
+        "QUICKBOOKS_DISABLE_WRITE": "false",
+        "QUICKBOOKS_DISABLE_UPDATE": "false",
+        "QUICKBOOKS_DISABLE_DELETE": "false"
       }
     }
   }
@@ -477,9 +477,9 @@ All tool names must follow the `{verb}_{entity}` convention using underscores. T
 
 | Prefix | Category | Suppressed by |
 |--------|----------|---------------|
-| `create_` | WRITE | `DISABLE_WRITE=true` |
-| `update_` | UPDATE | `DISABLE_UPDATE=true` |
-| `delete_` | DELETE | `DISABLE_DELETE=true` |
+| `create_` | WRITE | `QUICKBOOKS_DISABLE_WRITE=true` |
+| `update_` | UPDATE | `QUICKBOOKS_DISABLE_UPDATE=true` |
+| `delete_` | DELETE | `QUICKBOOKS_DISABLE_DELETE=true` |
 | `get_`, `search_`, `read_` | READ | never |
 
 New tools that do not follow this convention will not be correctly categorised and may appear or be suppressed unexpectedly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
+                "@jest/globals": "^30.3.0",
                 "@types/jest": "^30.0.0",
                 "@types/node": "^22.13.10",
                 "eslint": "^9.22.0",
@@ -1172,19 +1173,436 @@
             }
         },
         "node_modules/@jest/globals": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+            "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.2.0",
-                "@jest/expect": "30.2.0",
-                "@jest/types": "30.2.0",
-                "jest-mock": "30.2.0"
+                "@jest/environment": "30.4.1",
+                "@jest/expect": "30.4.1",
+                "@jest/types": "30.4.1",
+                "jest-mock": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/diff-sequences": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+            "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/environment": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "jest-mock": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/expect": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+            "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "30.4.1",
+                "jest-snapshot": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/expect-utils": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+            "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/fake-timers": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@sinonjs/fake-timers": "^15.4.0",
+                "@types/node": "*",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/pattern": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-regex-util": "30.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/schemas": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/snapshot-utils": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+            "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "natural-compare": "^1.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/transform": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+            "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/types": "30.4.1",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "babel-plugin-istanbul": "^7.0.1",
+                "chalk": "^4.1.2",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-util": "30.4.1",
+                "pirates": "^4.0.7",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^5.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/types": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.4.0",
+                "@jest/schemas": "30.4.1",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@sinonjs/fake-timers": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/expect": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+            "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/expect-utils": "30.4.1",
+                "@jest/get-type": "30.1.0",
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-diff": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+            "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/diff-sequences": "30.4.0",
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-haste-map": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+            "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "anymatch": "^3.1.3",
+                "fb-watchman": "^2.0.2",
+                "graceful-fs": "^4.2.11",
+                "jest-regex-util": "30.4.0",
+                "jest-util": "30.4.1",
+                "jest-worker": "30.4.1",
+                "picomatch": "^4.0.3",
+                "walker": "^1.0.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.3"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-matcher-utils": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+            "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "jest-diff": "30.4.1",
+                "pretty-format": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-message-util": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.4.1",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "jest-util": "30.4.1",
+                "picomatch": "^4.0.3",
+                "pretty-format": "30.4.1",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-mock": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "jest-util": "30.4.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-regex-util": {
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-snapshot": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+            "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@babel/generator": "^7.27.5",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1",
+                "@babel/types": "^7.27.3",
+                "@jest/expect-utils": "30.4.1",
+                "@jest/get-type": "30.1.0",
+                "@jest/snapshot-utils": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
+                "babel-preset-current-node-syntax": "^1.2.0",
+                "chalk": "^4.1.2",
+                "expect": "30.4.1",
+                "graceful-fs": "^4.2.11",
+                "jest-diff": "30.4.1",
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-util": "30.4.1",
+                "pretty-format": "30.4.1",
+                "semver": "^7.7.2",
+                "synckit": "^0.11.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-util": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.4.1",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-worker": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+            "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@ungap/structured-clone": "^1.3.0",
+                "jest-util": "30.4.1",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/pretty-format": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.4.1",
+                "ansi-styles": "^5.2.0",
+                "react-is-18": "npm:react-is@^18.3.1",
+                "react-is-19": "npm:react-is@^19.2.5"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/@jest/pattern": {
@@ -5223,6 +5641,22 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
+        "node_modules/jest-runtime/node_modules/@jest/globals": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.2.0",
+                "@jest/expect": "30.2.0",
+                "@jest/types": "30.2.0",
+                "jest-mock": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -6527,6 +6961,22 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/react-is-18": {
+            "name": "react-is",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/react-is-19": {
+            "name": "react-is",
+            "version": "19.2.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+            "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
             "dev": true,
             "license": "MIT"
         },
@@ -8835,15 +9285,326 @@
             "dev": true
         },
         "@jest/globals": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+            "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
             "dev": true,
             "requires": {
-                "@jest/environment": "30.2.0",
-                "@jest/expect": "30.2.0",
-                "@jest/types": "30.2.0",
-                "jest-mock": "30.2.0"
+                "@jest/environment": "30.4.1",
+                "@jest/expect": "30.4.1",
+                "@jest/types": "30.4.1",
+                "jest-mock": "30.4.1"
+            },
+            "dependencies": {
+                "@jest/diff-sequences": {
+                    "version": "30.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+                    "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+                    "dev": true
+                },
+                "@jest/environment": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+                    "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/fake-timers": "30.4.1",
+                        "@jest/types": "30.4.1",
+                        "@types/node": "*",
+                        "jest-mock": "30.4.1"
+                    }
+                },
+                "@jest/expect": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+                    "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+                    "dev": true,
+                    "requires": {
+                        "expect": "30.4.1",
+                        "jest-snapshot": "30.4.1"
+                    }
+                },
+                "@jest/expect-utils": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+                    "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/get-type": "30.1.0"
+                    }
+                },
+                "@jest/fake-timers": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+                    "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.4.1",
+                        "@sinonjs/fake-timers": "^15.4.0",
+                        "@types/node": "*",
+                        "jest-message-util": "30.4.1",
+                        "jest-mock": "30.4.1",
+                        "jest-util": "30.4.1"
+                    }
+                },
+                "@jest/pattern": {
+                    "version": "30.4.0",
+                    "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+                    "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "jest-regex-util": "30.4.0"
+                    }
+                },
+                "@jest/schemas": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+                    "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+                    "dev": true,
+                    "requires": {
+                        "@sinclair/typebox": "^0.34.0"
+                    }
+                },
+                "@jest/snapshot-utils": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+                    "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.4.1",
+                        "chalk": "^4.1.2",
+                        "graceful-fs": "^4.2.11",
+                        "natural-compare": "^1.4.0"
+                    }
+                },
+                "@jest/transform": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+                    "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.27.4",
+                        "@jest/types": "30.4.1",
+                        "@jridgewell/trace-mapping": "^0.3.25",
+                        "babel-plugin-istanbul": "^7.0.1",
+                        "chalk": "^4.1.2",
+                        "convert-source-map": "^2.0.0",
+                        "fast-json-stable-stringify": "^2.1.0",
+                        "graceful-fs": "^4.2.11",
+                        "jest-haste-map": "30.4.1",
+                        "jest-regex-util": "30.4.0",
+                        "jest-util": "30.4.1",
+                        "pirates": "^4.0.7",
+                        "slash": "^3.0.0",
+                        "write-file-atomic": "^5.0.1"
+                    }
+                },
+                "@jest/types": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+                    "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/pattern": "30.4.0",
+                        "@jest/schemas": "30.4.1",
+                        "@types/istanbul-lib-coverage": "^2.0.6",
+                        "@types/istanbul-reports": "^3.0.4",
+                        "@types/node": "*",
+                        "@types/yargs": "^17.0.33",
+                        "chalk": "^4.1.2"
+                    }
+                },
+                "@sinonjs/fake-timers": {
+                    "version": "15.4.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+                    "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^3.0.1"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                    "dev": true
+                },
+                "expect": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+                    "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/expect-utils": "30.4.1",
+                        "@jest/get-type": "30.1.0",
+                        "jest-matcher-utils": "30.4.1",
+                        "jest-message-util": "30.4.1",
+                        "jest-mock": "30.4.1",
+                        "jest-util": "30.4.1"
+                    }
+                },
+                "jest-diff": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+                    "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/diff-sequences": "30.4.0",
+                        "@jest/get-type": "30.1.0",
+                        "chalk": "^4.1.2",
+                        "pretty-format": "30.4.1"
+                    }
+                },
+                "jest-haste-map": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+                    "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.4.1",
+                        "@types/node": "*",
+                        "anymatch": "^3.1.3",
+                        "fb-watchman": "^2.0.2",
+                        "fsevents": "^2.3.3",
+                        "graceful-fs": "^4.2.11",
+                        "jest-regex-util": "30.4.0",
+                        "jest-util": "30.4.1",
+                        "jest-worker": "30.4.1",
+                        "picomatch": "^4.0.3",
+                        "walker": "^1.0.8"
+                    }
+                },
+                "jest-matcher-utils": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+                    "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/get-type": "30.1.0",
+                        "chalk": "^4.1.2",
+                        "jest-diff": "30.4.1",
+                        "pretty-format": "30.4.1"
+                    }
+                },
+                "jest-message-util": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+                    "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.27.1",
+                        "@jest/types": "30.4.1",
+                        "@types/stack-utils": "^2.0.3",
+                        "chalk": "^4.1.2",
+                        "graceful-fs": "^4.2.11",
+                        "jest-util": "30.4.1",
+                        "picomatch": "^4.0.3",
+                        "pretty-format": "30.4.1",
+                        "slash": "^3.0.0",
+                        "stack-utils": "^2.0.6"
+                    }
+                },
+                "jest-mock": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+                    "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.4.1",
+                        "@types/node": "*",
+                        "jest-util": "30.4.1"
+                    }
+                },
+                "jest-regex-util": {
+                    "version": "30.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+                    "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+                    "dev": true
+                },
+                "jest-snapshot": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+                    "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.27.4",
+                        "@babel/generator": "^7.27.5",
+                        "@babel/plugin-syntax-jsx": "^7.27.1",
+                        "@babel/plugin-syntax-typescript": "^7.27.1",
+                        "@babel/types": "^7.27.3",
+                        "@jest/expect-utils": "30.4.1",
+                        "@jest/get-type": "30.1.0",
+                        "@jest/snapshot-utils": "30.4.1",
+                        "@jest/transform": "30.4.1",
+                        "@jest/types": "30.4.1",
+                        "babel-preset-current-node-syntax": "^1.2.0",
+                        "chalk": "^4.1.2",
+                        "expect": "30.4.1",
+                        "graceful-fs": "^4.2.11",
+                        "jest-diff": "30.4.1",
+                        "jest-matcher-utils": "30.4.1",
+                        "jest-message-util": "30.4.1",
+                        "jest-util": "30.4.1",
+                        "pretty-format": "30.4.1",
+                        "semver": "^7.7.2",
+                        "synckit": "^0.11.8"
+                    }
+                },
+                "jest-util": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+                    "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.4.1",
+                        "@types/node": "*",
+                        "chalk": "^4.1.2",
+                        "ci-info": "^4.2.0",
+                        "graceful-fs": "^4.2.11",
+                        "picomatch": "^4.0.3"
+                    }
+                },
+                "jest-worker": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+                    "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "@ungap/structured-clone": "^1.3.0",
+                        "jest-util": "30.4.1",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^8.1.1"
+                    }
+                },
+                "picomatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+                    "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "30.4.1",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+                    "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/schemas": "30.4.1",
+                        "ansi-styles": "^5.2.0",
+                        "react-is-18": "npm:react-is@^18.3.1",
+                        "react-is-19": "npm:react-is@^19.2.5"
+                    }
+                },
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "@jest/pattern": {
@@ -11626,6 +12387,18 @@
                 "strip-bom": "^4.0.0"
             },
             "dependencies": {
+                "@jest/globals": {
+                    "version": "30.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+                    "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/environment": "30.2.0",
+                        "@jest/expect": "30.2.0",
+                        "@jest/types": "30.2.0",
+                        "jest-mock": "30.2.0"
+                    }
+                },
                 "brace-expansion": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -12561,6 +13334,18 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true
+        },
+        "react-is-18": {
+            "version": "npm:react-is@18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true
+        },
+        "react-is-19": {
+            "version": "npm:react-is@19.2.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+            "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
             "dev": true
         },
         "readable-stream": {

--- a/src/clients/GETTING_STARTED.md
+++ b/src/clients/GETTING_STARTED.md
@@ -10,6 +10,11 @@ npm install
 QUICKBOOKS_CLIENT_ID=your_client_id
 QUICKBOOKS_CLIENT_SECRET=your_client_secret
 QUICKBOOKS_ENVIRONMENT=production # or sandbox
+
+# Optional: restrict which tool categories are registered (default: all enabled)
+# DISABLE_WRITE=true    # suppress create_* tools
+# DISABLE_UPDATE=true   # suppress update_* tools
+# DISABLE_DELETE=true   # suppress delete_* tools
 ```
 
 3. Get your Client ID and Client Secret:

--- a/src/clients/GETTING_STARTED.md
+++ b/src/clients/GETTING_STARTED.md
@@ -12,9 +12,9 @@ QUICKBOOKS_CLIENT_SECRET=your_client_secret
 QUICKBOOKS_ENVIRONMENT=production # or sandbox
 
 # Optional: restrict which tool categories are registered (default: all enabled)
-# DISABLE_WRITE=true    # suppress create_* tools
-# DISABLE_UPDATE=true   # suppress update_* tools
-# DISABLE_DELETE=true   # suppress delete_* tools
+# QUICKBOOKS_DISABLE_WRITE=true    # suppress create_* tools
+# QUICKBOOKS_DISABLE_UPDATE=true   # suppress update_* tools
+# QUICKBOOKS_DISABLE_DELETE=true   # suppress delete_* tools
 ```
 
 3. Get your Client ID and Client Secret:

--- a/src/helpers/register-tool.ts
+++ b/src/helpers/register-tool.ts
@@ -58,10 +58,17 @@ export function isToolDisabled(toolName: string): boolean {
   if (category === CRUD_CATEGORY.READ) return false;
   return process.env[DISABLE_ENV[category]] === "true";
 }
+
+/** 
+ * Registers a tool with the MCP server if it is not disabled.
+ * Tools are categorized by their name prefix (e.g. create_, update_, delete_).
+ * The corresponding environment variable (e.g. DISABLE_WRITE) determines if the tool is registered.
+ */
 export function RegisterTool<T extends z.ZodType<any, any>>(
   server: McpServer,
   toolDefinition: ToolDefinition<T>
 ) {
+  if (isToolDisabled(toolDefinition.name)) return;
   server.tool(
     toolDefinition.name,
     toolDefinition.description,

--- a/src/helpers/register-tool.ts
+++ b/src/helpers/register-tool.ts
@@ -37,6 +37,27 @@ export const PREFIX_CATEGORY_MAP: Record<string, CrudCategory> = {
   "delete_": CRUD_CATEGORY.DELETE,
   "delete-": CRUD_CATEGORY.DELETE,
 };
+
+/** 
+ * Determines the CRUD category of a tool based on its name prefix.
+ * Defaults to READ if no prefix matches.
+ */
+export function getCrudCategory(toolName: string): CrudCategory {
+  for (const [prefix, category] of Object.entries(PREFIX_CATEGORY_MAP)) {
+    if (toolName.startsWith(prefix)) return category;
+  }
+  return CRUD_CATEGORY.READ;
+}
+
+/** 
+ * Checks if a tool is disabled based on its CRUD category and corresponding environment variable.
+ * READ tools are never disabled.
+ */
+export function isToolDisabled(toolName: string): boolean {
+  const category = getCrudCategory(toolName);
+  if (category === CRUD_CATEGORY.READ) return false;
+  return process.env[DISABLE_ENV[category]] === "true";
+}
 export function RegisterTool<T extends z.ZodType<any, any>>(
   server: McpServer,
   toolDefinition: ToolDefinition<T>

--- a/src/helpers/register-tool.ts
+++ b/src/helpers/register-tool.ts
@@ -2,6 +2,41 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
+/**
+ * Defines CRUD categories for tools
+ */
+export const CRUD_CATEGORY = {
+  WRITE:  "WRITE",
+  UPDATE: "UPDATE",
+  DELETE: "DELETE",
+  READ:   "READ",
+} as const;
+
+export type CrudCategory = typeof CRUD_CATEGORY[keyof typeof CRUD_CATEGORY];
+
+/** 
+ * Maps each CRUD category to its corresponding environment variable for disabling tools.
+ */
+export const DISABLE_ENV = {
+  [CRUD_CATEGORY.WRITE]:  "DISABLE_WRITE",
+  [CRUD_CATEGORY.UPDATE]: "DISABLE_UPDATE",
+  [CRUD_CATEGORY.DELETE]: "DISABLE_DELETE",
+} as const;
+
+/** 
+ * Maps every non-READ verb prefix to its category. Handles both underscore
+ * and legacy hyphen separator variants (e.g. create-bill, update-vendor).
+ * Insertion order is preserved in V8; all prefixes are distinct so order
+ * does not affect correctness.
+ */
+export const PREFIX_CATEGORY_MAP: Record<string, CrudCategory> = {
+  "create_": CRUD_CATEGORY.WRITE,
+  "create-": CRUD_CATEGORY.WRITE,
+  "update_": CRUD_CATEGORY.UPDATE,
+  "update-": CRUD_CATEGORY.UPDATE,
+  "delete_": CRUD_CATEGORY.DELETE,
+  "delete-": CRUD_CATEGORY.DELETE,
+};
 export function RegisterTool<T extends z.ZodType<any, any>>(
   server: McpServer,
   toolDefinition: ToolDefinition<T>

--- a/src/helpers/register-tool.ts
+++ b/src/helpers/register-tool.ts
@@ -18,9 +18,9 @@ export type CrudCategory = typeof CRUD_CATEGORY[keyof typeof CRUD_CATEGORY];
  * Maps each CRUD category to its corresponding environment variable for disabling tools.
  */
 export const DISABLE_ENV = {
-  [CRUD_CATEGORY.WRITE]:  "DISABLE_WRITE",
-  [CRUD_CATEGORY.UPDATE]: "DISABLE_UPDATE",
-  [CRUD_CATEGORY.DELETE]: "DISABLE_DELETE",
+  [CRUD_CATEGORY.WRITE]:  "QUICKBOOKS_DISABLE_WRITE",
+  [CRUD_CATEGORY.UPDATE]: "QUICKBOOKS_DISABLE_UPDATE",
+  [CRUD_CATEGORY.DELETE]: "QUICKBOOKS_DISABLE_DELETE",
 } as const;
 
 /** 
@@ -62,7 +62,7 @@ export function isToolDisabled(toolName: string): boolean {
 /** 
  * Registers a tool with the MCP server if it is not disabled.
  * Tools are categorized by their name prefix (e.g. create_, update_, delete_).
- * The corresponding environment variable (e.g. DISABLE_WRITE) determines if the tool is registered.
+ * The corresponding environment variable (e.g. QUICKBOOKS_DISABLE_WRITE) determines if the tool is registered.
  */
 export function RegisterTool<T extends z.ZodType<any, any>>(
   server: McpServer,

--- a/tests/unit/helpers/register-tool.test.ts
+++ b/tests/unit/helpers/register-tool.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, afterEach, jest } from "@jest/globals";
+import {
+  getCrudCategory,
+  isToolDisabled,
+  RegisterTool,
+} from "../../../src/helpers/register-tool";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ToolDefinition } from "../../../src/types/tool-definition";
+
+// ── getCrudCategory ──────────────────────────────────────────────────────────
+
+describe("getCrudCategory", () => {
+  it("returns WRITE for create_ prefix",  () => expect(getCrudCategory("create_invoice")).toBe("WRITE"));
+  it("returns WRITE for create- prefix",  () => expect(getCrudCategory("create-bill")).toBe("WRITE"));
+  it("returns UPDATE for update_ prefix", () => expect(getCrudCategory("update_customer")).toBe("UPDATE"));
+  it("returns UPDATE for update- prefix", () => expect(getCrudCategory("update-vendor")).toBe("UPDATE"));
+  it("returns DELETE for delete_ prefix", () => expect(getCrudCategory("delete_payment")).toBe("DELETE"));
+  it("returns DELETE for delete- prefix", () => expect(getCrudCategory("delete-bill")).toBe("DELETE"));
+  it("returns READ for get_ prefix",      () => expect(getCrudCategory("get_invoice")).toBe("READ"));
+  it("returns READ for get- prefix",      () => expect(getCrudCategory("get-vendor")).toBe("READ"));
+  it("returns READ for search_ prefix",   () => expect(getCrudCategory("search_customers")).toBe("READ"));
+  it("returns READ for read_ prefix",     () => expect(getCrudCategory("read_invoice")).toBe("READ"));
+});
+
+// ── isToolDisabled ───────────────────────────────────────────────────────────
+
+describe("isToolDisabled", () => {
+  afterEach(() => {
+    delete process.env["DISABLE_WRITE"];
+    delete process.env["DISABLE_UPDATE"];
+    delete process.env["DISABLE_DELETE"];
+  });
+
+  it("returns false for READ tool with no env vars set", () =>
+    expect(isToolDisabled("get_invoice")).toBe(false));
+
+  it("returns false for READ tool even when all DISABLE vars are true", () => {
+    process.env["DISABLE_WRITE"]  = "true";
+    process.env["DISABLE_UPDATE"] = "true";
+    process.env["DISABLE_DELETE"] = "true";
+    expect(isToolDisabled("search_customers")).toBe(false);
+  });
+
+  it("returns true for WRITE tool when DISABLE_WRITE=true",        () => { process.env["DISABLE_WRITE"]  = "true"; expect(isToolDisabled("create_invoice")).toBe(true); });
+  it("returns false for WRITE tool when DISABLE_WRITE unset",       () => expect(isToolDisabled("create_invoice")).toBe(false));
+  it("returns true for hyphen WRITE tool when DISABLE_WRITE=true",  () => { process.env["DISABLE_WRITE"]  = "true"; expect(isToolDisabled("create-bill")).toBe(true); });
+
+  it("returns true for UPDATE tool when DISABLE_UPDATE=true",       () => { process.env["DISABLE_UPDATE"] = "true"; expect(isToolDisabled("update_customer")).toBe(true); });
+  it("returns false for UPDATE tool when DISABLE_UPDATE unset",      () => expect(isToolDisabled("update_customer")).toBe(false));
+  it("returns true for hyphen UPDATE tool when DISABLE_UPDATE=true", () => { process.env["DISABLE_UPDATE"] = "true"; expect(isToolDisabled("update-vendor")).toBe(true); });
+
+  it("returns true for DELETE tool when DISABLE_DELETE=true",       () => { process.env["DISABLE_DELETE"] = "true"; expect(isToolDisabled("delete_payment")).toBe(true); });
+  it("returns false for DELETE tool when DISABLE_DELETE unset",      () => expect(isToolDisabled("delete_payment")).toBe(false));
+  it("returns true for hyphen DELETE tool when DISABLE_DELETE=true", () => { process.env["DISABLE_DELETE"] = "true"; expect(isToolDisabled("delete-bill")).toBe(true); });
+
+  it('returns false when env var is "false"', () => { process.env["DISABLE_WRITE"] = "false"; expect(isToolDisabled("create_invoice")).toBe(false); });
+  it('returns false when env var is "1"',     () => { process.env["DISABLE_WRITE"] = "1";     expect(isToolDisabled("create_invoice")).toBe(false); });
+});
+
+// ── RegisterTool ─────────────────────────────────────────────────────────────
+
+describe("RegisterTool", () => {
+  afterEach(() => {
+    delete process.env["DISABLE_WRITE"];
+    delete process.env["DISABLE_UPDATE"];
+    delete process.env["DISABLE_DELETE"];
+  });
+
+  const schema = z.object({ id: z.string() });
+  const handler = jest.fn() as ToolDefinition<typeof schema>["handler"];
+  const def = (name: string): ToolDefinition<typeof schema> =>
+    ({ name, description: `desc:${name}`, schema, handler });
+
+  it("calls server.tool() with all definition fields when enabled", () => {
+    const server = { tool: jest.fn() } as unknown as McpServer;
+    const d = def("get_invoice");
+    RegisterTool(server, d);
+    expect(server.tool).toHaveBeenCalledTimes(1);
+    expect(server.tool).toHaveBeenCalledWith(d.name, d.description, { params: d.schema }, d.handler);
+  });
+
+  it("skips server.tool() for disabled WRITE tool", () => {
+    process.env["DISABLE_WRITE"] = "true";
+    const server = { tool: jest.fn() } as unknown as McpServer;
+    RegisterTool(server, def("create_invoice"));
+    expect(server.tool).not.toHaveBeenCalled();
+  });
+
+  it("skips server.tool() for disabled UPDATE tool", () => {
+    process.env["DISABLE_UPDATE"] = "true";
+    const server = { tool: jest.fn() } as unknown as McpServer;
+    RegisterTool(server, def("update_customer"));
+    expect(server.tool).not.toHaveBeenCalled();
+  });
+
+  it("skips server.tool() for disabled DELETE tool", () => {
+    process.env["DISABLE_DELETE"] = "true";
+    const server = { tool: jest.fn() } as unknown as McpServer;
+    RegisterTool(server, def("delete_payment"));
+    expect(server.tool).not.toHaveBeenCalled();
+  });
+
+  it("registers READ tool even when all DISABLE vars are true", () => {
+    process.env["DISABLE_WRITE"]  = "true";
+    process.env["DISABLE_UPDATE"] = "true";
+    process.env["DISABLE_DELETE"] = "true";
+    const server = { tool: jest.fn() } as unknown as McpServer;
+    RegisterTool(server, def("search_invoices"));
+    expect(server.tool).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips hyphen-prefixed WRITE tool when DISABLE_WRITE=true", () => {
+    process.env["DISABLE_WRITE"] = "true";
+    const server = { tool: jest.fn() } as unknown as McpServer;
+    RegisterTool(server, def("create-bill"));
+    expect(server.tool).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/helpers/register-tool.test.ts
+++ b/tests/unit/helpers/register-tool.test.ts
@@ -9,6 +9,10 @@ import { z } from "zod";
 import type { ToolDefinition } from "../../../src/types/tool-definition";
 
 // ── getCrudCategory ──────────────────────────────────────────────────────────
+// Verifies that every verb prefix maps to the correct CRUD category string.
+// Uses literal expected values (not re-exported constants) so the test catches
+// both a wrong mapping AND a wrong constant value simultaneously.
+// Covers both underscore (standard) and hyphen (legacy) separator variants.
 
 describe("getCrudCategory", () => {
   it("returns WRITE for create_ prefix",  () => expect(getCrudCategory("create_invoice")).toBe("WRITE"));
@@ -24,47 +28,60 @@ describe("getCrudCategory", () => {
 });
 
 // ── isToolDisabled ───────────────────────────────────────────────────────────
+// Verifies that the correct env var name gates each CRUD category.
+// Uses literal env var names ("QUICKBOOKS_DISABLE_WRITE" etc.) so the test catches any
+// mismatch between the documented env var and what the implementation reads.
+// afterEach deletes all three vars to prevent state leaking between tests.
 
 describe("isToolDisabled", () => {
   afterEach(() => {
-    delete process.env["DISABLE_WRITE"];
-    delete process.env["DISABLE_UPDATE"];
-    delete process.env["DISABLE_DELETE"];
+    delete process.env["QUICKBOOKS_DISABLE_WRITE"];
+    delete process.env["QUICKBOOKS_DISABLE_UPDATE"];
+    delete process.env["QUICKBOOKS_DISABLE_DELETE"];
   });
 
+  // READ tools must never be suppressed regardless of env state.
   it("returns false for READ tool with no env vars set", () =>
     expect(isToolDisabled("get_invoice")).toBe(false));
 
   it("returns false for READ tool even when all DISABLE vars are true", () => {
-    process.env["DISABLE_WRITE"]  = "true";
-    process.env["DISABLE_UPDATE"] = "true";
-    process.env["DISABLE_DELETE"] = "true";
+    process.env["QUICKBOOKS_DISABLE_WRITE"]  = "true";
+    process.env["QUICKBOOKS_DISABLE_UPDATE"] = "true";
+    process.env["QUICKBOOKS_DISABLE_DELETE"] = "true";
     expect(isToolDisabled("search_customers")).toBe(false);
   });
 
-  it("returns true for WRITE tool when DISABLE_WRITE=true",        () => { process.env["DISABLE_WRITE"]  = "true"; expect(isToolDisabled("create_invoice")).toBe(true); });
-  it("returns false for WRITE tool when DISABLE_WRITE unset",       () => expect(isToolDisabled("create_invoice")).toBe(false));
-  it("returns true for hyphen WRITE tool when DISABLE_WRITE=true",  () => { process.env["DISABLE_WRITE"]  = "true"; expect(isToolDisabled("create-bill")).toBe(true); });
+  // WRITE — underscore and hyphen variants, both enabled and disabled states.
+  it("returns true for WRITE tool when QUICKBOOKS_DISABLE_WRITE=true",        () => { process.env["QUICKBOOKS_DISABLE_WRITE"]  = "true"; expect(isToolDisabled("create_invoice")).toBe(true); });
+  it("returns false for WRITE tool when QUICKBOOKS_DISABLE_WRITE unset",       () => expect(isToolDisabled("create_invoice")).toBe(false));
+  it("returns true for hyphen WRITE tool when QUICKBOOKS_DISABLE_WRITE=true",  () => { process.env["QUICKBOOKS_DISABLE_WRITE"]  = "true"; expect(isToolDisabled("create-bill")).toBe(true); });
 
-  it("returns true for UPDATE tool when DISABLE_UPDATE=true",       () => { process.env["DISABLE_UPDATE"] = "true"; expect(isToolDisabled("update_customer")).toBe(true); });
-  it("returns false for UPDATE tool when DISABLE_UPDATE unset",      () => expect(isToolDisabled("update_customer")).toBe(false));
-  it("returns true for hyphen UPDATE tool when DISABLE_UPDATE=true", () => { process.env["DISABLE_UPDATE"] = "true"; expect(isToolDisabled("update-vendor")).toBe(true); });
+  // UPDATE — underscore and hyphen variants, both enabled and disabled states.
+  it("returns true for UPDATE tool when QUICKBOOKS_DISABLE_UPDATE=true",       () => { process.env["QUICKBOOKS_DISABLE_UPDATE"] = "true"; expect(isToolDisabled("update_customer")).toBe(true); });
+  it("returns false for UPDATE tool when QUICKBOOKS_DISABLE_UPDATE unset",      () => expect(isToolDisabled("update_customer")).toBe(false));
+  it("returns true for hyphen UPDATE tool when QUICKBOOKS_DISABLE_UPDATE=true", () => { process.env["QUICKBOOKS_DISABLE_UPDATE"] = "true"; expect(isToolDisabled("update-vendor")).toBe(true); });
 
-  it("returns true for DELETE tool when DISABLE_DELETE=true",       () => { process.env["DISABLE_DELETE"] = "true"; expect(isToolDisabled("delete_payment")).toBe(true); });
-  it("returns false for DELETE tool when DISABLE_DELETE unset",      () => expect(isToolDisabled("delete_payment")).toBe(false));
-  it("returns true for hyphen DELETE tool when DISABLE_DELETE=true", () => { process.env["DISABLE_DELETE"] = "true"; expect(isToolDisabled("delete-bill")).toBe(true); });
+  // DELETE — underscore and hyphen variants, both enabled and disabled states.
+  it("returns true for DELETE tool when QUICKBOOKS_DISABLE_DELETE=true",       () => { process.env["QUICKBOOKS_DISABLE_DELETE"] = "true"; expect(isToolDisabled("delete_payment")).toBe(true); });
+  it("returns false for DELETE tool when QUICKBOOKS_DISABLE_DELETE unset",      () => expect(isToolDisabled("delete_payment")).toBe(false));
+  it("returns true for hyphen DELETE tool when QUICKBOOKS_DISABLE_DELETE=true", () => { process.env["QUICKBOOKS_DISABLE_DELETE"] = "true"; expect(isToolDisabled("delete-bill")).toBe(true); });
 
-  it('returns false when env var is "false"', () => { process.env["DISABLE_WRITE"] = "false"; expect(isToolDisabled("create_invoice")).toBe(false); });
-  it('returns false when env var is "1"',     () => { process.env["DISABLE_WRITE"] = "1";     expect(isToolDisabled("create_invoice")).toBe(false); });
+  // Boundary: only the exact string "true" disables a tool; other truthy-ish values must not.
+  it('returns false when env var is "false"', () => { process.env["QUICKBOOKS_DISABLE_WRITE"] = "false"; expect(isToolDisabled("create_invoice")).toBe(false); });
+  it('returns false when env var is "1"',     () => { process.env["QUICKBOOKS_DISABLE_WRITE"] = "1";     expect(isToolDisabled("create_invoice")).toBe(false); });
 });
 
 // ── RegisterTool ─────────────────────────────────────────────────────────────
+// Verifies the integration between isToolDisabled and server.tool():
+//   - Enabled tools are registered with the exact fields from ToolDefinition.
+//   - Disabled tools cause RegisterTool to return early without calling server.tool().
+// Uses a minimal mock server object to avoid coupling to the MCP SDK internals.
 
 describe("RegisterTool", () => {
   afterEach(() => {
-    delete process.env["DISABLE_WRITE"];
-    delete process.env["DISABLE_UPDATE"];
-    delete process.env["DISABLE_DELETE"];
+    delete process.env["QUICKBOOKS_DISABLE_WRITE"];
+    delete process.env["QUICKBOOKS_DISABLE_UPDATE"];
+    delete process.env["QUICKBOOKS_DISABLE_DELETE"];
   });
 
   const schema = z.object({ id: z.string() });
@@ -72,6 +89,7 @@ describe("RegisterTool", () => {
   const def = (name: string): ToolDefinition<typeof schema> =>
     ({ name, description: `desc:${name}`, schema, handler });
 
+  // Confirm all four ToolDefinition fields are forwarded to server.tool() unchanged.
   it("calls server.tool() with all definition fields when enabled", () => {
     const server = { tool: jest.fn() } as unknown as McpServer;
     const d = def("get_invoice");
@@ -80,38 +98,41 @@ describe("RegisterTool", () => {
     expect(server.tool).toHaveBeenCalledWith(d.name, d.description, { params: d.schema }, d.handler);
   });
 
+  // One test per mutable category to confirm the early-return path is reached.
   it("skips server.tool() for disabled WRITE tool", () => {
-    process.env["DISABLE_WRITE"] = "true";
+    process.env["QUICKBOOKS_DISABLE_WRITE"] = "true";
     const server = { tool: jest.fn() } as unknown as McpServer;
     RegisterTool(server, def("create_invoice"));
     expect(server.tool).not.toHaveBeenCalled();
   });
 
   it("skips server.tool() for disabled UPDATE tool", () => {
-    process.env["DISABLE_UPDATE"] = "true";
+    process.env["QUICKBOOKS_DISABLE_UPDATE"] = "true";
     const server = { tool: jest.fn() } as unknown as McpServer;
     RegisterTool(server, def("update_customer"));
     expect(server.tool).not.toHaveBeenCalled();
   });
 
   it("skips server.tool() for disabled DELETE tool", () => {
-    process.env["DISABLE_DELETE"] = "true";
+    process.env["QUICKBOOKS_DISABLE_DELETE"] = "true";
     const server = { tool: jest.fn() } as unknown as McpServer;
     RegisterTool(server, def("delete_payment"));
     expect(server.tool).not.toHaveBeenCalled();
   });
 
+  // READ tools must register even when all three DISABLE vars are set.
   it("registers READ tool even when all DISABLE vars are true", () => {
-    process.env["DISABLE_WRITE"]  = "true";
-    process.env["DISABLE_UPDATE"] = "true";
-    process.env["DISABLE_DELETE"] = "true";
+    process.env["QUICKBOOKS_DISABLE_WRITE"]  = "true";
+    process.env["QUICKBOOKS_DISABLE_UPDATE"] = "true";
+    process.env["QUICKBOOKS_DISABLE_DELETE"] = "true";
     const server = { tool: jest.fn() } as unknown as McpServer;
     RegisterTool(server, def("search_invoices"));
     expect(server.tool).toHaveBeenCalledTimes(1);
   });
 
-  it("skips hyphen-prefixed WRITE tool when DISABLE_WRITE=true", () => {
-    process.env["DISABLE_WRITE"] = "true";
+  // Confirm the legacy hyphen separator is handled by the early-return path.
+  it("skips hyphen-prefixed WRITE tool when QUICKBOOKS_DISABLE_WRITE=true", () => {
+    process.env["QUICKBOOKS_DISABLE_WRITE"] = "true";
     const server = { tool: jest.fn() } as unknown as McpServer;
     RegisterTool(server, def("create-bill"));
     expect(server.tool).not.toHaveBeenCalled();


### PR DESCRIPTION
Implements #57 

## Restriction Mode

Adds opt-in environment variables to suppress tool categories at server startup. Restricted tools are never registered with the MCP server, so they are invisible to clients. No changes to tool logic or handlers are required.

### New env vars (all default to off)

| Variable | Effect |
|---|---|
| `QUICKBOOKS_DISABLE_WRITE=true` | Suppresses `create_*` / `create-*` tools |
| `QUICKBOOKS_DISABLE_UPDATE=true` | Suppresses `update_*` / `update-*` tools |
| `QUICKBOOKS_DISABLE_DELETE=true` | Suppresses `delete_*` / `delete-*` tools |

Read tools (`get_*`, `search_*`, `read_*`) are always registered and cannot be disabled.

### Design decisions to avoid breaking changes

- **All tools registered by default.** No env vars are required to preserve existing behaviour. Restriction is strictly opt-in.
- **Filtered at registration, not invocation.** The check runs once at startup inside `RegisterTool`. Tools that pass the filter behave identically to before; no runtime overhead or behavioural difference is introduced for registered tools.
- **No changes to tool logic or handlers.** `src/index.ts`, all `src/tools/*.tool.ts` files, and all `src/handlers/*.handler.ts` files are untouched. The entire feature is contained in `src/helpers/register-tool.ts`.
- **READ tools unconditionally registered.** `get_*`, `search_*`, and `read_*` tools can never be suppressed, ensuring a client always has at minimum read access.
- **Legacy hyphen tools handled transparently.** The 8 pre-existing non-standard tool names (`create-bill`, `create-vendor`, etc.) are covered by the same `PREFIX_CATEGORY_MAP` without any renames or aliases.

### Implementation

- **`src/helpers/register-tool.ts`**: Added `CRUD_CATEGORY`, `DISABLE_ENV`, and `PREFIX_CATEGORY_MAP` constants; exported `getCrudCategory` and `isToolDisabled` helpers; `RegisterTool` returns early when a tool is suppressed.
- **`tests/unit/helpers/register-tool.test.ts`**: New test file with 29 tests at 100% coverage. Assertions use literal string values (not re-exported constants) to ensure env var names and category mappings are verified against actual expected values.

### Documentation

- `.env.example`: Added `QUICKBOOKS_DISABLE_*` vars as commented-out opt-in options
- `README.md`: Updated `.env` config block and MCP JSON config to include `QUICKBOOKS_DISABLE_*` vars; added tool naming  convention to the Contributing section
- `src/clients/GETTING_STARTED.md`: Added `QUICKBOOKS_DISABLE_*` vars to the setup `.env` block