### PR TITLE
feat(attachable): add binary file upload via base64_content

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -376,6 +376,24 @@ export class QuickbooksClient {
     return quickbooksClient.quickbooksInstance!;
   }
 
+  // Static counterpart to getInstance() — returns raw OAuth credentials for
+  // handlers that need to call QBO endpoints not wrapped by node-quickbooks
+  // (e.g. POST /upload for binary attachments). Ensures token freshness on
+  // every invocation, same as getInstance().
+  static async getAuthCredentials(): Promise<{ accessToken: string; realmId: string; isSandbox: boolean }> {
+    if (quickbooksClient.isTokenExpiredOrExpiringSoon() || !quickbooksClient.accessToken) {
+      await quickbooksClient.authenticate();
+    }
+    if (!quickbooksClient.accessToken || !quickbooksClient.realmId) {
+      throw new Error('Quickbooks not authenticated');
+    }
+    return {
+      accessToken: quickbooksClient.accessToken,
+      realmId: quickbooksClient.realmId,
+      isSandbox: quickbooksClient.environment === 'sandbox',
+    };
+  }
+
   getQuickbooks() {
     if (!this.quickbooksInstance) {
       throw new Error('Quickbooks not authenticated. Call authenticate() first');

--- a/src/handlers/create-quickbooks-attachable.handler.ts
+++ b/src/handlers/create-quickbooks-attachable.handler.ts
@@ -1,34 +1,237 @@
+import https from "https";
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+
+// QBO Attachable upload — file types accepted by the QBO /upload endpoint.
+// Source: developer.intuit.com Attachable API reference (16 unique MIME types
+// covering 17 documented file extensions; .ai and .eps both map to
+// application/postscript).
+//
+// Two entries deviate from RFC standards but match QBO's documented spec
+// literally — keep them so payloads round-trip without QBO rejecting them:
+//   - image/jpg  (RFC standard is image/jpeg; QBO accepts both)
+//   - image/tif  (RFC standard is image/tiff; QBO accepts both)
+//
+// One entry is corrected from a documentation typo:
+//   - QBO docs list application/vnd/ms-excel for .xls. A forward slash in a
+//     MIME subtype is invalid per RFC 6838. We use the correct form here.
+const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
+  "application/postscript",          // .ai, .eps
+  "text/csv",                        // .csv
+  "application/msword",              // .doc
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+  "image/gif",                       // .gif
+  "image/jpeg",                      // .jpeg
+  "image/jpg",                       // .jpg
+  "application/vnd.oasis.opendocument.spreadsheet", // .ods
+  "application/pdf",                 // .pdf
+  "image/png",                       // .png
+  "text/rtf",                        // .rtf
+  "image/tif",                       // .tif
+  "text/plain",                      // .txt
+  "application/vnd.ms-excel",        // .xls
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+  "text/xml",                        // .xml
+]);
+
+// QBO documents a 100 MB per-request cap on /upload. We enforce client-side
+// BEFORE allocating Buffer.from(base64) so an unbounded base64 string cannot
+// be decoded into memory.
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+// Approximate decoded size of a base64 string without decoding it. base64
+// expands 3 bytes -> 4 chars; subtract padding to get the decoded length.
+function approximateDecodedSize(base64: string): number {
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
 
 export interface CreateAttachableInput {
   file_name: string;
   note?: string;
   category?: string;
   content_type?: string;
+  base64_content?: string;
   attachable_ref?: {
     entity_ref_type: string;
     entity_ref_value: string;
+    include_on_send?: boolean;
   };
 }
 
-export async function createQuickbooksAttachable(data: CreateAttachableInput): Promise<ToolResponse<any>> {
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\r\n"\\]/g, "_");
+}
+
+// Map a status code to a user-safe error message. The raw QBO response body
+// can include realm IDs, internal trace identifiers, and other detail that
+// should not be returned to an MCP client — the LLM has no business seeing
+// internal QBO error envelopes. Raw bodies are still logged server-side for
+// operator debugging.
+function redactedUploadError(statusCode: number | undefined): string {
+  if (!statusCode) return "QBO upload failed: network error";
+  if (statusCode === 401 || statusCode === 403) return `QBO upload failed (${statusCode}): authentication or authorization error`;
+  if (statusCode === 413) return `QBO upload failed (${statusCode}): payload too large`;
+  if (statusCode >= 400 && statusCode < 500) return `QBO upload failed (${statusCode}): client error`;
+  if (statusCode >= 500) return `QBO upload failed (${statusCode}): QBO server error`;
+  /* istanbul ignore next — defensive: <400 status codes never reach this function */
+  return `QBO upload failed (${statusCode}): unexpected status`;
+}
+
+// Raw multipart/form-data POST to /v3/company/{realmId}/upload. node-quickbooks
+// does not wrap this endpoint, so we construct the request manually.
+//
+// QBO supports multi-file uploads in a single request, but this handler sends
+// exactly one file per request — single-file covers the 99% MCP/LLM case and
+// multi-file would require a different input schema. Out of scope here.
+async function uploadAttachableFile(
+  fileBuffer: Buffer,
+  metadata: Record<string, unknown>,
+  accessToken: string,
+  realmId: string,
+  isSandbox: boolean
+): Promise<unknown> {
+  const boundary = `----QBOBoundary${Date.now()}`;
+  const metadataJson = JSON.stringify(metadata);
+  const fileName = sanitizeFilename(metadata.FileName as string);
+  const contentType = metadata.ContentType as string;
+
+  const bodyParts: Buffer[] = [
+    Buffer.from(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file_metadata_01"\r\n` +
+        `Content-Type: application/json\r\n` +
+        `\r\n` +
+        `${metadataJson}\r\n`
+    ),
+    Buffer.from(
+      `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file_content_01"; filename="${fileName}"\r\n` +
+        `Content-Type: ${contentType}\r\n` +
+        `\r\n`
+    ),
+    fileBuffer,
+    Buffer.from(`\r\n--${boundary}--\r\n`),
+  ];
+
+  const body = Buffer.concat(bodyParts);
+  const host = isSandbox
+    ? "sandbox-quickbooks.api.intuit.com"
+    : "quickbooks.api.intuit.com";
+  const requestPath = `/v3/company/${realmId}/upload`;
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: host,
+        path: requestPath,
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+          "Content-Length": body.length,
+          Accept: "application/json",
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const responseText = Buffer.concat(chunks).toString("utf-8");
+          if (res.statusCode && res.statusCode >= 400) {
+            console.error(`[qbo-attachable-upload] QBO ${res.statusCode}: ${responseText}`);
+            reject(new Error(redactedUploadError(res.statusCode)));
+            return;
+          }
+          try {
+            resolve(JSON.parse(responseText) as unknown);
+          } catch {
+            console.error(`[qbo-attachable-upload] QBO ${res.statusCode} non-JSON: ${responseText}`);
+            reject(new Error(redactedUploadError(res.statusCode)));
+          }
+        });
+      }
+    );
+    req.on("error", (err) => {
+      console.error(`[qbo-attachable-upload] network error: ${err.message}`);
+      reject(new Error(redactedUploadError(undefined)));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function createQuickbooksAttachable(
+  data: CreateAttachableInput
+): Promise<ToolResponse<any>> {
   try {
-    const quickbooks = await QuickbooksClient.getInstance();
-    const payload: any = { FileName: data.file_name };
+    // Build payload — same shape whether or not we're uploading binary content.
+    const payload: Record<string, unknown> = { FileName: data.file_name };
     if (data.note) payload.Note = data.note;
     if (data.category) payload.Category = data.category;
     if (data.content_type) payload.ContentType = data.content_type;
     if (data.attachable_ref) {
-      payload.AttachableRef = [{
+      const entityRef: Record<string, unknown> = {
         EntityRef: {
           type: data.attachable_ref.entity_ref_type,
-          value: data.attachable_ref.entity_ref_value
-        }
-      }];
+          value: data.attachable_ref.entity_ref_value,
+        },
+      };
+      if (typeof data.attachable_ref.include_on_send === "boolean") {
+        entityRef.IncludeOnSend = data.attachable_ref.include_on_send;
+      }
+      payload.AttachableRef = [entityRef];
     }
 
+    // ── Binary upload path ────────────────────────────────────────────────
+    if (data.base64_content) {
+      const effectiveContentType = data.content_type ?? "application/octet-stream";
+      if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(effectiveContentType)) {
+        return {
+          result: null,
+          isError: true,
+          error: `Unsupported content_type "${effectiveContentType}". Allowed: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].sort().join(", ")}`,
+        };
+      }
+
+      // Enforce size cap BEFORE decoding to a Buffer.
+      const approxSize = approximateDecodedSize(data.base64_content);
+      if (approxSize > MAX_UPLOAD_BYTES) {
+        return {
+          result: null,
+          isError: true,
+          error: `File too large: approximately ${approxSize} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+        };
+      }
+
+      const fileBuffer = Buffer.from(data.base64_content, "base64");
+
+      /* istanbul ignore next — defensive: the approxSize check above already
+         rejects oversized input; this guards only the malformed-base64 edge
+         case where decoded length unexpectedly exceeds the approximation. */
+      if (fileBuffer.length > MAX_UPLOAD_BYTES) {
+        return {
+          result: null,
+          isError: true,
+          error: `File too large: ${fileBuffer.length} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+        };
+      }
+
+      const { accessToken, realmId, isSandbox } =
+        await QuickbooksClient.getAuthCredentials();
+      const uploadResult = await uploadAttachableFile(
+        fileBuffer,
+        payload,
+        accessToken,
+        realmId,
+        isSandbox
+      );
+      return { result: uploadResult, isError: false, error: null };
+    }
+
+    // ── Metadata-only path (preserved behavior, post-#41 auth) ────────────
+    const quickbooks = await QuickbooksClient.getInstance();
     return new Promise((resolve) => {
       (quickbooks as any).createAttachable(payload, (err: any, created: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
@@ -39,4 +242,3 @@ export async function createQuickbooksAttachable(data: CreateAttachableInput): P
     return { result: null, isError: true, error: formatError(error) };
   }
 }
-

--- a/src/tools/create-attachable.tool.ts
+++ b/src/tools/create-attachable.tool.ts
@@ -3,22 +3,52 @@ import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
 const toolName = "create_attachable";
-const toolDescription = "Create a new attachable (file attachment reference) in QuickBooks Online.";
+const toolDescription =
+  "Create an attachable (file attachment) in QuickBooks Online. Without base64_content, creates a metadata-only attachment record. With base64_content, uploads the actual file bytes to QBO's /upload endpoint.";
+
 const toolSchema = z.object({
-  file_name: z.string().min(1).describe("File name"),
-  note: z.string().optional().describe("Note about the attachment"),
-  category: z.string().optional().describe("Attachment category"),
-  content_type: z.string().optional().describe("MIME content type"),
-  attachable_ref: z.object({
-    entity_ref_type: z.string().describe("Entity type (e.g., 'Invoice', 'Bill')"),
-    entity_ref_value: z.string().describe("Entity ID to attach to"),
-  }).optional().describe("Reference to entity to attach to"),
+  file_name: z.string().min(1).describe("File name including extension (e.g., 'receipt.pdf')."),
+  note: z.string().optional().describe("Optional note describing the attachment."),
+  category: z.string().optional().describe("Optional QBO attachment category."),
+  content_type: z
+    .string()
+    .optional()
+    .describe(
+      "MIME content type. Required when base64_content is provided. Supported by QBO: application/postscript (.ai, .eps), text/csv, application/msword (.doc), application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), image/gif, image/jpeg, image/jpg, application/vnd.oasis.opendocument.spreadsheet (.ods), application/pdf, image/png, text/rtf, image/tif, text/plain (.txt), application/vnd.ms-excel (.xls), application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), text/xml."
+    ),
+  base64_content: z
+    .string()
+    .optional()
+    .describe(
+      "Optional base64-encoded file bytes. When provided, the decoded file is uploaded to QBO's /upload endpoint as multipart/form-data. Maximum 100 MB decoded. Omit to create a metadata-only attachment record."
+    ),
+  attachable_ref: z
+    .object({
+      entity_ref_type: z.string().describe("Entity type (e.g., 'Invoice', 'Bill', 'Purchase')."),
+      entity_ref_value: z.string().describe("Entity ID to attach to."),
+      include_on_send: z
+        .boolean()
+        .optional()
+        .describe("If true, include this attachment when the parent entity is emailed to a customer."),
+    })
+    .optional()
+    .describe("Optional reference to a QBO entity this file is attached to."),
 });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksAttachable(params);
   if (response.isError) return { content: [{ type: "text" as const, text: `Error: ${response.error}` }] };
-  return { content: [{ type: "text" as const, text: `Attachable created:` }, { type: "text" as const, text: JSON.stringify(response.result, null, 2) }] };
+  return {
+    content: [
+      { type: "text" as const, text: `Attachable created:` },
+      { type: "text" as const, text: JSON.stringify(response.result, null, 2) },
+    ],
+  };
 };
 
-export const CreateAttachableTool: ToolDefinition<typeof toolSchema> = { name: toolName, description: toolDescription, schema: toolSchema, handler: toolHandler };
+export const CreateAttachableTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -220,9 +220,18 @@ export const mockQuickbooksClient = {
   refreshAccessToken: jest.fn<() => Promise<{ access_token: string; expires_in: number }>>().mockResolvedValue({ access_token: 'mock-token', expires_in: 3600 }),
 };
 
-// Mock QuickbooksClient class (for handlers using QuickbooksClient.getInstance())
+// Mock QuickbooksClient class (for handlers using QuickbooksClient.getInstance()
+// and QuickbooksClient.getAuthCredentials() — the latter is used by handlers
+// that need raw OAuth credentials for QBO endpoints not wrapped by
+// node-quickbooks, e.g. POST /upload for binary attachments).
+export const mockAuthCredentials = {
+  accessToken: 'mock-access-token',
+  realmId: 'mock-realm-id',
+  isSandbox: true,
+};
 export const mockQuickbooksClientClass = {
   getInstance: jest.fn<() => Promise<typeof mockQuickBooksInstance>>().mockResolvedValue(mockQuickBooksInstance),
+  getAuthCredentials: jest.fn<() => Promise<typeof mockAuthCredentials>>().mockResolvedValue(mockAuthCredentials),
 };
 
 // Helper to create a successful callback mock
@@ -262,4 +271,6 @@ export function resetAllMocks() {
   (mockQuickbooksClient.authenticate as any).mockResolvedValue(mockQuickBooksInstance);
   mockQuickbooksClientClass.getInstance.mockReset();
   (mockQuickbooksClientClass.getInstance as any).mockResolvedValue(mockQuickBooksInstance);
+  mockQuickbooksClientClass.getAuthCredentials.mockReset();
+  (mockQuickbooksClientClass.getAuthCredentials as any).mockResolvedValue(mockAuthCredentials);
 }

--- a/tests/unit/handlers/company-attachable.handlers.test.ts
+++ b/tests/unit/handlers/company-attachable.handlers.test.ts
@@ -7,6 +7,43 @@ jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   QuickbooksClient: mockQuickbooksClientClass,
 }));
 
+// Mock https for binary upload tests
+const mockHttpsRequest = jest.fn();
+jest.unstable_mockModule('https', () => ({
+  default: { request: mockHttpsRequest },
+  request: mockHttpsRequest,
+}));
+
+function mockHttpsUploadResponse(statusCode: number, responseBody: unknown) {
+  const mockReq = { write: jest.fn(), end: jest.fn(), on: jest.fn() };
+  (mockHttpsRequest as any).mockImplementation((_options: unknown, callback: (res: unknown) => void) => {
+    const mockRes = {
+      statusCode,
+      on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'data') {
+          const payload = typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody);
+          handler(Buffer.from(payload));
+        } else if (event === 'end') {
+          handler();
+        }
+      }),
+    };
+    callback(mockRes);
+    return mockReq;
+  });
+}
+
+function mockHttpsUploadNetworkError(err: Error) {
+  const mockReq = {
+    write: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === 'error') handler(err);
+    }),
+  };
+  (mockHttpsRequest as any).mockImplementation((_options: unknown, _callback: unknown) => mockReq);
+}
+
 // Dynamic imports after mock setup
 const { getQuickbooksCompanyInfo } = await import('../../../src/handlers/get-quickbooks-company-info.handler');
 const { updateQuickbooksCompanyInfo } = await import('../../../src/handlers/update-quickbooks-company-info.handler');
@@ -191,6 +228,251 @@ describe('Company and Attachable Handlers', () => {
 
       expect(result.isError).toBe(true);
       expect(result.error).toContain('Auth failed');
+    });
+
+    it('should propagate IncludeOnSend through attachable_ref', async () => {
+      let capturedPayload: any = null;
+      mockQuickBooksInstance.createAttachable.mockImplementation((payload: any, cb: any) => {
+        capturedPayload = payload;
+        cb(null, { Id: '1' });
+      });
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'invoice.pdf',
+        attachable_ref: {
+          entity_ref_type: 'Invoice',
+          entity_ref_value: '42',
+          include_on_send: true,
+        },
+      });
+
+      expect(result.isError).toBe(false);
+      expect(capturedPayload.AttachableRef[0].IncludeOnSend).toBe(true);
+      expect(capturedPayload.AttachableRef[0].EntityRef).toEqual({ type: 'Invoice', value: '42' });
+    });
+  });
+
+  describe('createQuickbooksAttachable — binary upload', () => {
+    it('should upload PDF when base64_content is provided', async () => {
+      const uploadResponse = {
+        AttachableResponse: [
+          { Attachable: { Id: '99', FileName: 'invoice.pdf' }, responseStatus: '200' },
+        ],
+      };
+      mockHttpsUploadResponse(200, uploadResponse);
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'invoice.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('fake-pdf-bytes').toString('base64'),
+        attachable_ref: { entity_ref_type: 'Bill', entity_ref_value: '123' },
+      });
+
+      expect(result.isError).toBe(false);
+      expect(result.result).toEqual(uploadResponse);
+      expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+      const [[reqOptions]] = (mockHttpsRequest as jest.Mock).mock.calls as any[][];
+      expect(reqOptions.method).toBe('POST');
+      expect(reqOptions.path).toBe('/v3/company/mock-realm-id/upload');
+      expect(reqOptions.hostname).toBe('sandbox-quickbooks.api.intuit.com');
+      expect(reqOptions.headers.Authorization).toBe('Bearer mock-access-token');
+    });
+
+    it('should select production host when isSandbox is false', async () => {
+      const { mockAuthCredentials } = await import('../../mocks/quickbooks.mock');
+      (mockQuickbooksClientClass.getAuthCredentials as any).mockResolvedValue({
+        ...mockAuthCredentials,
+        isSandbox: false,
+      });
+      mockHttpsUploadResponse(200, { AttachableResponse: [] });
+
+      await createQuickbooksAttachable({
+        file_name: 'doc.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      const [[reqOptions]] = (mockHttpsRequest as jest.Mock).mock.calls as any[][];
+      expect(reqOptions.hostname).toBe('quickbooks.api.intuit.com');
+    });
+
+    it('should reject unsupported content_type before any upload', async () => {
+      const result = await createQuickbooksAttachable({
+        file_name: 'sketch.psd',
+        content_type: 'image/vnd.adobe.photoshop',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Unsupported content_type');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing content_type before any upload', async () => {
+      const result = await createQuickbooksAttachable({
+        file_name: 'unknown.bin',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Unsupported content_type');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should accept all 16 documented QBO MIME types', async () => {
+      const supportedTypes = [
+        'application/postscript',
+        'text/csv',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'image/gif',
+        'image/jpeg',
+        'image/jpg',
+        'application/vnd.oasis.opendocument.spreadsheet',
+        'application/pdf',
+        'image/png',
+        'text/rtf',
+        'image/tif',
+        'text/plain',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'text/xml',
+      ];
+
+      for (const ct of supportedTypes) {
+        mockHttpsUploadResponse(200, { AttachableResponse: [] });
+        const result = await createQuickbooksAttachable({
+          file_name: `file-${ct.replace(/[^a-z0-9]/gi, '-')}`,
+          content_type: ct,
+          base64_content: Buffer.from('x').toString('base64'),
+        });
+        expect(result.isError).toBe(false);
+      }
+    });
+
+    it('should reject base64_content exceeding 100 MB before decoding', async () => {
+      // Construct a base64 string whose approximate decoded size is > 100 MB
+      // without actually allocating 100 MB of bytes. base64 length ~ size * 4/3.
+      const overLimitBase64Length = Math.ceil(((100 * 1024 * 1024) + 1) * 4 / 3);
+      const oversized = 'A'.repeat(overLimitBase64Length);
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'huge.pdf',
+        content_type: 'application/pdf',
+        base64_content: oversized,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('File too large');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should redact QBO response body on HTTP 4xx error', async () => {
+      const sensitiveBody = JSON.stringify({
+        Fault: {
+          Error: [{ Detail: 'realm 9341454900 trace=abc123 user=foo@bar.com' }],
+        },
+      });
+      mockHttpsUploadResponse(401, sensitiveBody);
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'doc.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('401');
+      expect(result.error).toContain('authentication or authorization error');
+      // The raw QBO body must NOT appear in the returned error.
+      expect(result.error).not.toContain('9341454900');
+      expect(result.error).not.toContain('trace=abc123');
+      expect(result.error).not.toContain('foo@bar.com');
+    });
+
+    it('should label HTTP 413 as payload too large', async () => {
+      mockHttpsUploadResponse(413, 'realm 9341454900 says request too big');
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'doc.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('413');
+      expect(result.error).toContain('payload too large');
+      expect(result.error).not.toContain('9341454900');
+    });
+
+    it('should label generic HTTP 4xx as client error', async () => {
+      mockHttpsUploadResponse(400, 'realm 9341454900 bad request detail');
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'doc.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('400');
+      expect(result.error).toContain('client error');
+      expect(result.error).not.toContain('9341454900');
+    });
+
+    it('should redact QBO response body on HTTP 5xx error', async () => {
+      mockHttpsUploadResponse(503, 'internal trace 7f8a9b: realm 9341454900');
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'doc.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('503');
+      expect(result.error).toContain('QBO server error');
+      expect(result.error).not.toContain('9341454900');
+      expect(result.error).not.toContain('trace 7f8a9b');
+    });
+
+    it('should redact network errors as generic message', async () => {
+      mockHttpsUploadNetworkError(new Error('ECONNREFUSED 10.0.0.1:443'));
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'doc.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('network error');
+      // Internal IP must not leak into the caller-facing error.
+      expect(result.error).not.toContain('10.0.0.1');
+    });
+
+    it('should reject when QBO returns 200 with non-JSON body', async () => {
+      mockHttpsUploadResponse(200, '<html>not json</html>');
+
+      const result = await createQuickbooksAttachable({
+        file_name: 'doc.pdf',
+        content_type: 'application/pdf',
+        base64_content: Buffer.from('x').toString('base64'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toMatch(/QBO upload failed/);
+    });
+
+    it('should not call /upload when base64_content is omitted (metadata-only path)', async () => {
+      mockQuickBooksInstance.createAttachable.mockImplementation((_payload: any, cb: any) =>
+        cb(null, { Id: '1', FileName: 'metadata-only.pdf' })
+      );
+
+      const result = await createQuickbooksAttachable({ file_name: 'metadata-only.pdf' });
+
+      expect(result.isError).toBe(false);
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/handlers/general-ledger.prototype-shape.test.ts
+++ b/tests/unit/handlers/general-ledger.prototype-shape.test.ts
@@ -14,8 +14,16 @@ const mockQuickbooksClient = {
   getQuickbooks: jest.fn<() => QuickBooks>(),
 };
 
+// Post-PR #41, handlers import the QuickbooksClient class and call its
+// static getInstance(). Provide a mock for both shapes so this test stays
+// black-box against the handler's auth pattern.
+const mockQuickbooksClientClass = {
+  getInstance: jest.fn<() => Promise<QuickBooks>>(),
+};
+
 jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
   quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
 }));
 
 const { getQuickbooksGeneralLedger } = await import('../../../src/handlers/get-quickbooks-general-ledger.handler');
@@ -33,6 +41,7 @@ describe('get_general_ledger prototype-shape contract', () => {
   it('handler invokes a method that exists on the real QuickBooks prototype', async () => {
     const qb = Object.create(QuickBooks.prototype) as QuickBooks;
     mockQuickbooksClient.getQuickbooks.mockReturnValue(qb);
+    mockQuickbooksClientClass.getInstance.mockResolvedValue(qb);
 
     const spy = jest
       .spyOn(QuickBooks.prototype as any, 'reportGeneralLedgerDetail')


### PR DESCRIPTION
## Summary

Extends `create_attachable` to accept an optional `base64_content` field. When provided, the decoded bytes are POSTed to QBO's `/upload` endpoint as `multipart/form-data`. When omitted, the existing metadata-only behavior is preserved unchanged.

This PR is **cherry-picked from #48** (Nelson Alfonso's initial commit) with the four blockers from my [May 15 review](https://github.com/intuit/quickbooks-online-mcp-server/pull/48#pullrequestreview-3151034431) addressed, scope reset to the original feature, and rebased onto post-#41 `main`.

#48 is being closed in favor of this PR.

## What's included from #48

- `base64_content` field on `create_attachable`
- Raw multipart upload to `POST /v3/company/{realmId}/upload`
- Nelson's original test scaffolding (`mockHttpsRequest` helpers)

## What's fixed vs #48

1. **MIME allowlist expanded from 3 types to all 16 unique MIMEs** that QBO documents — covers the 17 documented file extensions (`.ai`, `.eps` share `application/postscript`). Corrects QBO's documentation typo for `.xls` (`application/vnd/ms-excel` → `application/vnd.ms-excel`).

2. **100 MB size cap enforced before `Buffer.from(base64)`** so unbounded base64 input cannot be decoded into memory. Approximation is computed from the string length first; a defensive post-decode re-check guards malformed-base64 edge cases.

3. **QBO response bodies redacted** from caller-facing errors. Status code is mapped to a category (`authentication or authorization error`, `payload too large`, `client error`, `QBO server error`, `unexpected status`). Raw response bodies are logged server-side only — they can contain realm IDs, internal trace identifiers, and other internal details that should not round-trip into an MCP conversation transcript.

4. **`IncludeOnSend` field added** to `attachable_ref` so attach-and-email-to-customer workflows work without a follow-up update call.

## What's NOT included from #48

- Redis token storage (`src/clients/redis-token-store.ts`)
- Per-user OAuth via `AsyncLocalStorage` (overlaps with #25)
- `upload_attachment_from_url` tool (separate feature with SSRF surface)
- Unrelated search tool schema changes (4 files)

Those directions are best explored in separate, focused PRs — particularly the per-user OAuth work which overlaps architecturally with #25.

## Compatibility with post-#41 main

- Metadata-only path uses `QuickbooksClient.getInstance()` (post-#41 pattern)
- Upload path uses a new `QuickbooksClient.getAuthCredentials()` static helper that mirrors `getInstance()` — token freshness check + raw OAuth credentials for endpoints `node-quickbooks` does not wrap

## Bonus fix included

`tests/unit/handlers/general-ledger.prototype-shape.test.ts` was broken by #41's handler migration — its module mock only exposed the `quickbooksClient` singleton, not the `QuickbooksClient` class export the handler now imports. CI has been red since #41 merged this morning. Adding the missing class mock (2 lines) un-breaks it. This is strictly a test-mock alignment with what production already does post-#41.

## Files changed

| File | Change | Purpose |
|---|---|---|
| `src/clients/quickbooks-client.ts` | +18 | Static `QuickbooksClient.getAuthCredentials()` |
| `src/handlers/create-quickbooks-attachable.handler.ts` | +218 / -32 | Binary upload + 4 fixes |
| `src/tools/create-attachable.tool.ts` | +44 / -15 | Schema additions: `base64_content`, `include_on_send`, MIME description |
| `tests/mocks/quickbooks.mock.ts` | +13 | `getAuthCredentials` mock |
| `tests/unit/handlers/company-attachable.handlers.test.ts` | +282 | 12 new tests covering all 4 fixes |
| `tests/unit/handlers/general-ledger.prototype-shape.test.ts` | +9 | Pre-existing #41 test-mock fix |

## Verification

- `npm run build` clean (TypeScript strict mode)
- `npm test` — **443/443 tests pass, 100% statement/branch/function/line coverage maintained**
- Metadata-only path produces identical payload, identical auth, identical `quickbooks.createAttachable()` call as before
- Binary upload path verified via mocked HTTPS request (sandbox + production host selection, all 16 MIMEs, size cap, error redaction across 401/413/4xx/5xx/network)

## Test plan

- [x] All 443 unit tests pass with 100% coverage
- [ ] Smoke test against QBO sandbox: upload a PDF receipt via `base64_content`, verify the attachment appears in the sandbox company file
- [ ] Smoke test the metadata-only path unchanged: call `create_attachable` without `base64_content` and verify behavior matches pre-PR

## Compatibility note

`get_balance_sheet`-style behavior change does **not** apply here — this PR is purely additive on the tool schema (new optional fields). Existing callers see no change.

Co-Authored-By: Nelson Alfonso <nelson_alfonso@icloud.com>