### PR TITLE
docs: clarify Intuit OAuth app setup constraints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This MCP server provides complete QuickBooks Online API integration for Claude C
 
 > Note: this is a local MCP server. It runs as a stdio subprocess on the developer's or partner's machine and authenticates to a QuickBooks Online company.
 
+> **Before you start:** This MCP server is easy to run once authenticated, but QuickBooks Online integration is gated by Intuit's OAuth app setup. You must register an app on the [Intuit Developer Portal](https://developer.intuit.com) and complete a one-time, browser-based OAuth handshake. **Sandbox** supports `http://localhost` redirect URIs; **production** requires a public HTTPS callback for the initial authorization. After that initial handshake, the server runs locally without further browser interaction (until the 100-day refresh window lapses). See [Authentication](#authentication) for full details.
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Fixes #62 — Adds an upfront callout in the Overview section making the Intuit OAuth app constraints explicit before users discover them through trial and error.

## Changes

- Added a blockquote in the Overview section (right after the existing local-server note) that:
  - States the MCP server requires Intuit OAuth app registration
  - Clarifies sandbox accepts localhost redirects while production requires HTTPS
  - Notes the OAuth handshake is one-time and browser-based
  - Mentions the 100-day refresh window
  - Links to the Authentication section for full details

## Acceptance Criteria (from #62)

- [x] Constraints called out before users hit them
- [x] Sandbox vs production redirect-URI distinction is clear
- [x] Tone matches the existing README (informative, not apologetic)