### PR TITLE
feat(invoice): add LinkedTxn support for quote-to-invoice conversion

### DIFF
--- a/src/handlers/create-quickbooks-invoice.handler.ts
+++ b/src/handlers/create-quickbooks-invoice.handler.ts
@@ -12,6 +12,10 @@ export interface CreateInvoiceInput {
   }>;
   doc_number?: string;
   txn_date?: string; // YYYY-MM-DD
+  linked_txn?: Array<{
+    txn_id: string;
+    txn_type: string;
+  }>;
 }
 
 // Primitive field type map (based on Quickbooks Invoice entity reference docs)
@@ -69,6 +73,12 @@ export async function createQuickbooksInvoice(data: CreateInvoiceInput): Promise
       })),
       DocNumber: data.doc_number,
       TxnDate: data.txn_date,
+      ...(data.linked_txn && {
+        LinkedTxn: data.linked_txn.map((lt) => ({
+          TxnId: lt.txn_id,
+          TxnType: lt.txn_type,
+        })),
+      }),
     };
 
     const normalizedPayload = normalizeInvoiceFields(invoicePayload);

--- a/src/tools/create-invoice.tool.ts
+++ b/src/tools/create-invoice.tool.ts
@@ -12,11 +12,17 @@ const lineItemSchema = z.object({
   description: z.string().optional(),
 });
 
+const linkedTxnSchema = z.object({
+  txn_id: z.string().min(1),
+  txn_type: z.string().min(1),
+});
+
 const toolSchema = z.object({
   customer_ref: z.string().min(1),
   line_items: z.array(lineItemSchema).min(1),
   doc_number: z.string().optional(),
   txn_date: z.string().optional(),
+  linked_txn: z.array(linkedTxnSchema).optional(),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/tests/unit/handlers/invoice-linked-txn.handlers.test.ts
+++ b/tests/unit/handlers/invoice-linked-txn.handlers.test.ts
@@ -1,0 +1,67 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+const { createQuickbooksInvoice } = await import('../../../src/handlers/create-quickbooks-invoice.handler');
+
+describe('Create Invoice Handler - LinkedTxn', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  it('should create an invoice with LinkedTxn when linked_txn is provided', async () => {
+    const mockInvoice = { Id: '789', TotalAmt: 500, LinkedTxn: [{ TxnId: '123', TxnType: 'Estimate' }] };
+    mockQuickBooksInstance.createInvoice.mockImplementation((_payload: any, cb: any) => cb(null, mockInvoice));
+
+    const result = await createQuickbooksInvoice({
+      customer_ref: '42',
+      line_items: [{ item_ref: '1', qty: 5, unit_price: 100 }],
+      linked_txn: [{ txn_id: '123', txn_type: 'Estimate' }],
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.result).toEqual(mockInvoice);
+
+    const payload = mockQuickBooksInstance.createInvoice.mock.calls[0][0] as any;
+    expect(payload.LinkedTxn).toEqual([{ TxnId: '123', TxnType: 'Estimate' }]);
+  });
+
+  it('should not include LinkedTxn when linked_txn is omitted', async () => {
+    const mockInvoice = { Id: '790', TotalAmt: 200 };
+    mockQuickBooksInstance.createInvoice.mockImplementation((_payload: any, cb: any) => cb(null, mockInvoice));
+
+    const result = await createQuickbooksInvoice({
+      customer_ref: '42',
+      line_items: [{ item_ref: '2', qty: 2, unit_price: 100 }],
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockQuickBooksInstance.createInvoice.mock.calls[0][0] as any;
+    expect(payload.LinkedTxn).toBeUndefined();
+  });
+
+  it('should support multiple linked transactions', async () => {
+    const mockInvoice = { Id: '791', TotalAmt: 300 };
+    mockQuickBooksInstance.createInvoice.mockImplementation((_payload: any, cb: any) => cb(null, mockInvoice));
+
+    const result = await createQuickbooksInvoice({
+      customer_ref: '42',
+      line_items: [{ item_ref: '1', qty: 3, unit_price: 100 }],
+      linked_txn: [
+        { txn_id: '100', txn_type: 'Estimate' },
+        { txn_id: '200', txn_type: 'Payment' },
+      ],
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockQuickBooksInstance.createInvoice.mock.calls[0][0] as any;
+    expect(payload.LinkedTxn).toHaveLength(2);
+    expect(payload.LinkedTxn[0]).toEqual({ TxnId: '100', TxnType: 'Estimate' });
+    expect(payload.LinkedTxn[1]).toEqual({ TxnId: '200', TxnType: 'Payment' });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #54 — adds `LinkedTxn` support to the `create_invoice` tool, enabling the standard QuickBooks Online pattern for converting estimates/quotes to invoices.

## Problem

The `create_invoice` tool schema doesn't expose the `LinkedTxn` field. Without it, users cannot create an invoice linked to an existing estimate using the documented QBO pattern:

```json
{
  "LinkedTxn": [{"TxnId": "<estimateId>", "TxnType": "Estimate"}]
}
```

## Changes

1. **`src/tools/create-invoice.tool.ts`** — Added optional `linked_txn` array field to the Zod schema with `txn_id` (string) and `txn_type` (string) per entry.

2. **`src/handlers/create-quickbooks-invoice.handler.ts`** — Extended `CreateInvoiceInput` interface and maps `linked_txn` entries to QBO API's `LinkedTxn` format (`TxnId`/`TxnType`). Only included in payload when provided (no breaking change).

3. **`tests/unit/handlers/invoice-linked-txn.handlers.test.ts`** — Unit tests covering:
   - LinkedTxn passed through correctly when provided
   - LinkedTxn omitted from payload when not provided (backwards compat)
   - Multiple linked transactions

## Usage

```typescript
// Convert an estimate to an invoice
await callTool("create_invoice", {
  customer_ref: "42",
  line_items: [{ item_ref: "1", qty: 5, unit_price: 100 }],
  linked_txn: [{ txn_id: "123", txn_type: "Estimate" }]
});
```

## QBO API Reference

- [Invoice LinkedTxn](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#create-an-invoice) — `LinkedTxn` array links invoices to estimates, payments, or other transactions.
