### PR TITLE
Add realm-guarded QBO re-auth + token health diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ coverage
 .env
 .env.local
 .env.*.local
+clients.json
+.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ coverage
 .env
 .env.local
 .env.*.local
+.env.prod
+.env.vercel
+.env.bak.*
 clients.json
 .vercel

--- a/auth-batch.js
+++ b/auth-batch.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+import OAuthClient from 'intuit-oauth';
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import open from 'open';
+import dotenv from 'dotenv';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '.env') });
+
+const clientId = process.env.QUICKBOOKS_CLIENT_ID;
+const clientSecret = process.env.QUICKBOOKS_CLIENT_SECRET;
+const redirectUri = process.env.QUICKBOOKS_REDIRECT_URI || 'http://localhost:8000/callback';
+const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'production';
+const PORT = 8000;
+
+if (!clientId || !clientSecret) {
+  console.error('QUICKBOOKS_CLIENT_ID and QUICKBOOKS_CLIENT_SECRET must be set in .env');
+  process.exit(1);
+}
+
+const clientsPath = path.join(__dirname, 'clients.json');
+let clients = JSON.parse(fs.readFileSync(clientsPath, 'utf-8'));
+const slugs = Object.keys(clients);
+
+const skipArg = process.argv[2];
+let startIndex = 0;
+if (skipArg === '--resume') {
+  const resumeSlug = process.argv[3];
+  const idx = slugs.indexOf(resumeSlug);
+  if (idx >= 0) startIndex = idx;
+  else console.error(`Slug "${resumeSlug}" not found, starting from beginning`);
+} else if (skipArg === '--only-failed') {
+  // Test each token first, skip ones that work
+  console.log('Pre-checking tokens to find which need re-auth...\n');
+}
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+
+function saveClients() {
+  const tmpPath = `${clientsPath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(clients, null, 2) + '\n', { mode: 0o600 });
+  fs.renameSync(tmpPath, clientsPath);
+}
+
+async function syncToSupabase(slug, client) {
+  if (!supabaseUrl || !supabaseKey) return;
+  const update = {
+    slug,
+    name: client.name,
+    realm_id: client.realm_id,
+    refresh_token: client.refresh_token,
+    added_at: client.added || new Date().toISOString().split('T')[0],
+    updated_at: new Date().toISOString(),
+  };
+  try {
+    const resp = await fetch(`${supabaseUrl}/rest/v1/qbo_clients`, {
+      method: 'POST',
+      headers: {
+        'apikey': supabaseKey,
+        'Authorization': `Bearer ${supabaseKey}`,
+        'Content-Type': 'application/json',
+        'Prefer': 'resolution=merge-duplicates,return=minimal',
+      },
+      body: JSON.stringify(update),
+    });
+    if (resp.ok) console.log(`  ↳ Synced to Supabase`);
+    else console.log(`  ↳ Supabase sync failed: ${resp.status}`);
+  } catch {
+    console.log(`  ↳ Supabase sync failed (network error)`);
+  }
+}
+
+function authOneClient(slug) {
+  return new Promise((resolve) => {
+    const oauthClient = new OAuthClient({ clientId, clientSecret, environment, redirectUri });
+
+    const server = http.createServer(async (req, res) => {
+      if (!req.url?.startsWith('/callback')) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('Waiting for QBO callback...');
+        return;
+      }
+
+      try {
+        const response = await oauthClient.createToken(req.url);
+        const tokens = response.token;
+
+        clients[slug] = {
+          name: clients[slug]?.name || slug,
+          realm_id: tokens.realmId,
+          refresh_token: tokens.refresh_token,
+          added: new Date().toISOString().split('T')[0],
+        };
+        saveClients();
+
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<html><body style="display:flex;flex-direction:column;justify-content:center;align-items:center;height:100vh;margin:0;font-family:system-ui;background:#f0fdf4;">
+          <h2 style="color:#16a34a;">&#10003; ${clients[slug].name}</h2>
+          <p style="color:#666;">Realm: ${tokens.realmId}</p>
+          <p style="color:#888;font-size:14px;">This window will close automatically...</p>
+          <script>setTimeout(()=>window.close(),1500)</script>
+        </body></html>`);
+
+        await syncToSupabase(slug, clients[slug]);
+
+        setTimeout(() => { server.close(); resolve('ok'); }, 800);
+      } catch (error) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<html><body style="display:flex;flex-direction:column;justify-content:center;align-items:center;height:100vh;margin:0;font-family:system-ui;background:#fef2f2;">
+          <h2 style="color:#dc2626;">Failed: ${slug}</h2>
+          <p style="color:#666;">${error.message || error}</p>
+          <script>setTimeout(()=>window.close(),2000)</script>
+        </body></html>`);
+        setTimeout(() => { server.close(); resolve('fail'); }, 800);
+      }
+    });
+
+    server.listen(PORT, '::', () => {
+      const authUri = oauthClient.authorizeUri({
+        scope: [OAuthClient.scopes.Accounting],
+        state: slug,
+      }).toString();
+
+      open(authUri).catch(() => {});
+    });
+
+    server.on('error', (err) => {
+      console.error(`  Port ${PORT} busy — kill other processes first`);
+      resolve('fail');
+    });
+  });
+}
+
+console.log(`
+╔══════════════════════════════════════════╗
+║     QBO Batch Re-Authorization Tool     ║
+╠══════════════════════════════════════════╣
+║  Clients: ${String(slugs.length).padEnd(30)}║
+║  Starting at: ${String(startIndex + 1).padEnd(27)}║
+║  Redirect: ${redirectUri.padEnd(28).slice(0, 28)} ║
+╚══════════════════════════════════════════╝
+
+For each client:
+  1. Browser opens to Intuit sign-in
+  2. Sign in & authorize the app
+  3. Window auto-closes, moves to next
+
+Press Ctrl+C at any time to stop.
+Resume later with: node auth-batch.js --resume <slug>
+`);
+
+let okCount = 0;
+let failCount = 0;
+let skipCount = 0;
+
+for (let i = startIndex; i < slugs.length; i++) {
+  const slug = slugs[i];
+  const num = `[${i + 1}/${slugs.length}]`;
+
+  console.log(`\n${num} ${slug}`);
+
+  const result = await authOneClient(slug);
+
+  if (result === 'ok') {
+    okCount++;
+    console.log(`  ✓ Done`);
+  } else {
+    failCount++;
+    console.log(`  ✗ Failed`);
+  }
+
+  if (i < slugs.length - 1) {
+    await new Promise(r => setTimeout(r, 1000));
+  }
+}
+
+console.log(`
+════════════════════════════════════
+  Done! ✓ ${okCount} ok  |  ✗ ${failCount} failed  |  ⊘ ${skipCount} skipped
+  Tokens saved to clients.json${supabaseUrl ? ' + Supabase' : ''}
+════════════════════════════════════
+`);

--- a/check-pnl-all.js
+++ b/check-pnl-all.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// One-off diagnostic: end-to-end P&L request across all QBO clients.
+// For each client: refresh (Supabase token, fallback clients.json token),
+// persist any rotated token to BOTH Supabase and clients.json, then pull a
+// real ProfitAndLoss report. Classifies: ok | pnl_error | expired(auth dead).
+import OAuthClient from 'intuit-oauth';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '.env') });
+
+const clientId = process.env.QUICKBOOKS_CLIENT_ID;
+const clientSecret = process.env.QUICKBOOKS_CLIENT_SECRET;
+const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'production';
+const redirectUri = process.env.QUICKBOOKS_REDIRECT_URI || 'http://localhost:8000/callback';
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+const apiBase = environment === 'production'
+  ? 'https://quickbooks.api.intuit.com'
+  : 'https://sandbox-quickbooks.api.intuit.com';
+
+const clientsPath = path.join(__dirname, 'clients.json');
+const localClients = JSON.parse(fs.readFileSync(clientsPath, 'utf-8'));
+
+function newOAuth() {
+  return new OAuthClient({ clientId, clientSecret, environment, redirectUri });
+}
+
+async function supabasePatchToken(slug, refreshToken) {
+  const resp = await fetch(`${supabaseUrl}/rest/v1/qbo_clients?slug=eq.${encodeURIComponent(slug)}`, {
+    method: 'PATCH',
+    headers: {
+      apikey: supabaseKey,
+      Authorization: `Bearer ${supabaseKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal',
+    },
+    body: JSON.stringify({ refresh_token: refreshToken, updated_at: new Date().toISOString() }),
+  });
+  return resp.ok;
+}
+
+// Try refreshing a refresh_token. Returns {token} on success or throws.
+async function tryRefresh(rt) {
+  const oauth = newOAuth();
+  const response = await oauth.refreshUsingToken(rt);
+  return response.token;
+}
+
+async function pullPnl(realmId, accessToken) {
+  const url = `${apiBase}/v3/company/${realmId}/reports/ProfitAndLoss?minorversion=65`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`HTTP ${resp.status}: ${body.slice(0, 160)}`);
+  }
+  const data = await resp.json();
+  // Extract NetIncome from the report summary if present.
+  let netIncome = null;
+  const findRow = (rows) => {
+    if (!Array.isArray(rows)) return;
+    for (const r of rows) {
+      if (r.group === 'NetIncome' && r.Summary?.ColData) netIncome = r.Summary.ColData.at(-1)?.value;
+      if (r.Rows?.Row) findRow(r.Rows.Row);
+    }
+  };
+  findRow(data?.Rows?.Row);
+  const period = `${data?.Header?.StartPeriod || '?'}..${data?.Header?.EndPeriod || '?'}`;
+  return { netIncome, period };
+}
+
+// Load authoritative Supabase rows.
+const sbResp = await fetch(`${supabaseUrl}/rest/v1/qbo_clients?select=slug,realm_id,refresh_token&order=slug`, {
+  headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+});
+const sbRows = await sbResp.json();
+
+const results = [];
+const clientsJsonUpdates = {}; // slug -> new refresh_token to write at end
+
+for (let i = 0; i < sbRows.length; i++) {
+  const { slug, realm_id, refresh_token: sbToken } = sbRows[i];
+  const localToken = localClients[slug]?.refresh_token;
+  process.stderr.write(`[${i + 1}/${sbRows.length}] ${slug} ... `);
+
+  let token = null;
+  let source = null;
+  let authErr = null;
+
+  // 1) Try Supabase token.
+  try {
+    token = await tryRefresh(sbToken);
+    source = 'supabase';
+  } catch (e) {
+    authErr = e?.message || String(e);
+    // 2) Fallback: clients.json token (if different).
+    if (localToken && localToken !== sbToken) {
+      try {
+        token = await tryRefresh(localToken);
+        source = 'clients.json';
+        authErr = null;
+      } catch (e2) {
+        authErr = `sb:[${authErr}] local:[${e2?.message || e2}]`;
+      }
+    }
+  }
+
+  if (!token) {
+    results.push({ slug, realm_id, status: 'EXPIRED', detail: authErr });
+    process.stderr.write(`AUTH DEAD\n`);
+    continue;
+  }
+
+  // Persist rotated token to BOTH stores.
+  const newRT = token.refresh_token;
+  const daysLeft = typeof token.x_refresh_token_expires_in === 'number'
+    ? Math.round(token.x_refresh_token_expires_in / 86400) : null;
+  await supabasePatchToken(slug, newRT);
+  clientsJsonUpdates[slug] = newRT;
+
+  // Now the real end-to-end test: pull P&L.
+  try {
+    const { netIncome, period } = await pullPnl(realm_id, token.access_token);
+    results.push({ slug, realm_id, status: 'ok', source, daysLeft, netIncome, period });
+    process.stderr.write(`OK (refreshed via ${source}, ${daysLeft}d left)\n`);
+  } catch (e) {
+    results.push({ slug, realm_id, status: 'PNL_ERROR', source, daysLeft, detail: e?.message || String(e) });
+    process.stderr.write(`auth ok but P&L FAILED\n`);
+  }
+}
+
+// Atomically write clients.json with rotated tokens for everything that refreshed.
+for (const [slug, rt] of Object.entries(clientsJsonUpdates)) {
+  if (localClients[slug]) localClients[slug].refresh_token = rt;
+}
+const tmp = `${clientsPath}.tmp.${process.pid}`;
+fs.writeFileSync(tmp, JSON.stringify(localClients, null, 2) + '\n', { mode: 0o600 });
+fs.renameSync(tmp, clientsPath);
+
+// ---- Report ----
+const ok = results.filter(r => r.status === 'ok');
+const pnlErr = results.filter(r => r.status === 'PNL_ERROR');
+const expired = results.filter(r => r.status === 'EXPIRED');
+
+console.log('\n================ RESULTS ================');
+console.log(`Total: ${results.length}  |  OK: ${ok.length}  |  P&L error (auth ok): ${pnlErr.length}  |  EXPIRED (auth dead): ${expired.length}`);
+console.log(`clients.json re-synced for ${Object.keys(clientsJsonUpdates).length} clients.\n`);
+
+if (expired.length) {
+  console.log('--- EXPIRED — need full Intuit re-auth (browser) ---');
+  for (const r of expired) console.log(`  ${r.slug.padEnd(38)} realm=${r.realm_id}  ${(r.detail || '').slice(0, 90)}`);
+  console.log('');
+}
+if (pnlErr.length) {
+  console.log('--- AUTH OK but P&L request failed (likely data/API, not auth) ---');
+  for (const r of pnlErr) console.log(`  ${r.slug.padEnd(38)} ${(r.detail || '').slice(0, 110)}`);
+  console.log('');
+}
+console.log(`--- OK (${ok.length}) ---`);
+for (const r of ok) console.log(`  ${r.slug.padEnd(38)} netIncome=${String(r.netIncome).padStart(14)}  ${r.daysLeft}d left  (${r.period})`);
+
+// machine-readable tail for follow-up
+console.log('\nEXPIRED_SLUGS=' + JSON.stringify(expired.map(r => r.slug)));

--- a/launcher.js
+++ b/launcher.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const clientName = process.argv[2];
+
+if (!clientName) {
+  const clients = JSON.parse(readFileSync(join(__dirname, 'clients.json'), 'utf-8'));
+  console.error('Usage: node launcher.js <client-name>\n');
+  console.error('Available clients:');
+  for (const [key, val] of Object.entries(clients)) {
+    console.error(`  ${key}  —  ${val.name} (realm: ${val.realm_id})`);
+  }
+  process.exit(1);
+}
+
+const clientsPath = join(__dirname, 'clients.json');
+const clients = JSON.parse(readFileSync(clientsPath, 'utf-8'));
+const client = clients[clientName];
+
+if (!client) {
+  console.error(`Client "${clientName}" not found in clients.json`);
+  console.error('Available:', Object.keys(clients).join(', '));
+  process.exit(1);
+}
+
+const envPath = join(__dirname, '.env');
+let envVars = {};
+try {
+  const envContent = readFileSync(envPath, 'utf-8');
+  for (const line of envContent.split('\n')) {
+    const match = line.match(/^([^=]+)=(.*)$/);
+    if (match) envVars[match[1]] = match[2];
+  }
+} catch {}
+
+const child = spawn('node', [join(__dirname, 'dist', 'index.js')], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    QUICKBOOKS_CLIENT_ID: envVars.QUICKBOOKS_CLIENT_ID || process.env.QUICKBOOKS_CLIENT_ID,
+    QUICKBOOKS_CLIENT_SECRET: envVars.QUICKBOOKS_CLIENT_SECRET || process.env.QUICKBOOKS_CLIENT_SECRET,
+    QUICKBOOKS_REFRESH_TOKEN: client.refresh_token,
+    QUICKBOOKS_REALM_ID: client.realm_id,
+    QUICKBOOKS_ENVIRONMENT: envVars.QUICKBOOKS_ENVIRONMENT || 'production',
+    QUICKBOOKS_REDIRECT_URI: envVars.QUICKBOOKS_REDIRECT_URI || 'http://localhost:8000/callback',
+    QBO_CLIENT_NAME: clientName,
+    QBO_CLIENTS_PATH: clientsPath,
+  },
+});
+
+child.on('exit', (code) => process.exit(code || 0));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.6.0",
+                "@supabase/supabase-js": "^2.105.1",
                 "dotenv": "^16.4.7",
+                "express": "^5.2.1",
                 "intuit-oauth": "^4.0.0",
                 "node-quickbooks": "^2.0.43",
                 "open": "^9.1.0",
@@ -21,6 +23,8 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
+                "@jest/globals": "^30.3.0",
+                "@types/express": "^5.0.6",
                 "@types/jest": "^30.0.0",
                 "@types/node": "^22.13.10",
                 "eslint": "^9.22.0",
@@ -1172,19 +1176,397 @@
             }
         },
         "node_modules/@jest/globals": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+            "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.2.0",
-                "@jest/expect": "30.2.0",
-                "@jest/types": "30.2.0",
-                "jest-mock": "30.2.0"
+                "@jest/environment": "30.3.0",
+                "@jest/expect": "30.3.0",
+                "@jest/types": "30.3.0",
+                "jest-mock": "30.3.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/diff-sequences": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+            "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/environment": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+            "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.3.0",
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-mock": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/expect": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+            "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "30.3.0",
+                "jest-snapshot": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/expect-utils": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+            "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/fake-timers": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+            "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@sinonjs/fake-timers": "^15.0.0",
+                "@types/node": "*",
+                "jest-message-util": "30.3.0",
+                "jest-mock": "30.3.0",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/snapshot-utils": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+            "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "natural-compare": "^1.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/transform": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+            "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/types": "30.3.0",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "babel-plugin-istanbul": "^7.0.1",
+                "chalk": "^4.1.2",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.3.0",
+                "jest-regex-util": "30.0.1",
+                "jest-util": "30.3.0",
+                "pirates": "^4.0.7",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^5.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@jest/types": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+            "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.0.1",
+                "@jest/schemas": "30.0.5",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/@sinonjs/fake-timers": {
+            "version": "15.3.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+            "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/expect": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+            "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/expect-utils": "30.3.0",
+                "@jest/get-type": "30.1.0",
+                "jest-matcher-utils": "30.3.0",
+                "jest-message-util": "30.3.0",
+                "jest-mock": "30.3.0",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-diff": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+            "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/diff-sequences": "30.3.0",
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "pretty-format": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-haste-map": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+            "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "anymatch": "^3.1.3",
+                "fb-watchman": "^2.0.2",
+                "graceful-fs": "^4.2.11",
+                "jest-regex-util": "30.0.1",
+                "jest-util": "30.3.0",
+                "jest-worker": "30.3.0",
+                "picomatch": "^4.0.3",
+                "walker": "^1.0.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.3"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-matcher-utils": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+            "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "jest-diff": "30.3.0",
+                "pretty-format": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-message-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+            "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.3.0",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3",
+                "pretty-format": "30.3.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-mock": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+            "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "jest-util": "30.3.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-snapshot": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+            "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@babel/generator": "^7.27.5",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1",
+                "@babel/types": "^7.27.3",
+                "@jest/expect-utils": "30.3.0",
+                "@jest/get-type": "30.1.0",
+                "@jest/snapshot-utils": "30.3.0",
+                "@jest/transform": "30.3.0",
+                "@jest/types": "30.3.0",
+                "babel-preset-current-node-syntax": "^1.2.0",
+                "chalk": "^4.1.2",
+                "expect": "30.3.0",
+                "graceful-fs": "^4.2.11",
+                "jest-diff": "30.3.0",
+                "jest-matcher-utils": "30.3.0",
+                "jest-message-util": "30.3.0",
+                "jest-util": "30.3.0",
+                "pretty-format": "30.3.0",
+                "semver": "^7.7.2",
+                "synckit": "^0.11.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-util": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+            "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.3.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/jest-worker": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+            "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@ungap/structured-clone": "^1.3.0",
+                "jest-util": "30.3.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/pretty-format": {
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+            "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.0.5",
+                "ansi-styles": "^5.2.0",
+                "react-is": "^18.3.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/@jest/pattern": {
@@ -1593,6 +1975,92 @@
                 "text-hex": "1.0.x"
             }
         },
+        "node_modules/@supabase/auth-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.1.tgz",
+            "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/functions-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.1.tgz",
+            "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/phoenix": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+            "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
+            "license": "MIT"
+        },
+        "node_modules/@supabase/postgrest-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.1.tgz",
+            "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/realtime-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.1.tgz",
+            "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/phoenix": "^0.4.1",
+                "@types/ws": "^8.18.1",
+                "tslib": "2.8.1",
+                "ws": "^8.18.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/storage-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.1.tgz",
+            "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "iceberg-js": "^0.8.1",
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/supabase-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.1.tgz",
+            "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/auth-js": "2.105.1",
+                "@supabase/functions-js": "2.105.1",
+                "@supabase/postgrest-js": "2.105.1",
+                "@supabase/realtime-js": "2.105.1",
+                "@supabase/storage-js": "2.105.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1649,11 +2117,64 @@
                 "@babel/types": "^7.28.2"
             }
         },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.6",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect": {
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true
+        },
+        "node_modules/@types/express": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+            "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^5.0.0",
+                "@types/serve-static": "^2"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+            "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
@@ -1703,9 +2224,43 @@
             "version": "22.18.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
             "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
-            "dev": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/@types/qs": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*"
             }
         },
         "node_modules/@types/stack-utils": {
@@ -1719,6 +2274,15 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
             "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.35",
@@ -2564,22 +3128,27 @@
             "integrity": "sha512-sCXkOlWh201V9KAs6lXtzbPQHmVhys/wC0I1vaCjZzZtiskEeNJljIRqirGJ+M+WOf/KL7P7KSpUaqaR6BCq7w=="
         },
         "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/bplist-parser": {
@@ -2722,6 +3291,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "get-intrinsic": "^1.3.0"
@@ -3605,17 +4175,19 @@
             }
         },
         "node_modules/express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
+                "body-parser": "^2.2.1",
                 "content-disposition": "^1.0.0",
                 "content-type": "^1.0.5",
                 "cookie": "^0.7.1",
                 "cookie-signature": "^1.2.1",
                 "debug": "^4.4.0",
+                "depd": "^2.0.0",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
@@ -4274,15 +4846,29 @@
                 "node": ">=14.18.0"
             }
         },
+        "node_modules/iceberg-js": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+            "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ignore": {
@@ -5223,6 +5809,22 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
+        "node_modules/jest-runtime/node_modules/@jest/globals": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.2.0",
+                "@jest/expect": "30.2.0",
+                "@jest/types": "30.2.0",
+                "jest-mock": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -5734,6 +6336,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
             "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -5964,6 +6567,7 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6419,9 +7023,10 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
             },
@@ -6998,6 +7603,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3",
@@ -7013,12 +7619,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7031,6 +7638,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7048,6 +7656,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7516,9 +8125,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/tsscmp": {
             "version": "1.0.6",
@@ -7583,6 +8190,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
             "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
             "dependencies": {
                 "content-type": "^1.0.5",
                 "media-typer": "^1.1.0",
@@ -7661,8 +8269,7 @@
         "node_modules/undici-types": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "dev": true
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
@@ -7976,6 +8583,27 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/y18n": {
@@ -8835,15 +9463,299 @@
             "dev": true
         },
         "@jest/globals": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "version": "30.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+            "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "30.2.0",
-                "@jest/expect": "30.2.0",
-                "@jest/types": "30.2.0",
-                "jest-mock": "30.2.0"
+                "@jest/environment": "30.3.0",
+                "@jest/expect": "30.3.0",
+                "@jest/types": "30.3.0",
+                "jest-mock": "30.3.0"
+            },
+            "dependencies": {
+                "@jest/diff-sequences": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+                    "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+                    "dev": true
+                },
+                "@jest/environment": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+                    "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/fake-timers": "30.3.0",
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "jest-mock": "30.3.0"
+                    }
+                },
+                "@jest/expect": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+                    "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+                    "dev": true,
+                    "requires": {
+                        "expect": "30.3.0",
+                        "jest-snapshot": "30.3.0"
+                    }
+                },
+                "@jest/expect-utils": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+                    "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/get-type": "30.1.0"
+                    }
+                },
+                "@jest/fake-timers": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+                    "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@sinonjs/fake-timers": "^15.0.0",
+                        "@types/node": "*",
+                        "jest-message-util": "30.3.0",
+                        "jest-mock": "30.3.0",
+                        "jest-util": "30.3.0"
+                    }
+                },
+                "@jest/snapshot-utils": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+                    "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "chalk": "^4.1.2",
+                        "graceful-fs": "^4.2.11",
+                        "natural-compare": "^1.4.0"
+                    }
+                },
+                "@jest/transform": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+                    "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.27.4",
+                        "@jest/types": "30.3.0",
+                        "@jridgewell/trace-mapping": "^0.3.25",
+                        "babel-plugin-istanbul": "^7.0.1",
+                        "chalk": "^4.1.2",
+                        "convert-source-map": "^2.0.0",
+                        "fast-json-stable-stringify": "^2.1.0",
+                        "graceful-fs": "^4.2.11",
+                        "jest-haste-map": "30.3.0",
+                        "jest-regex-util": "30.0.1",
+                        "jest-util": "30.3.0",
+                        "pirates": "^4.0.7",
+                        "slash": "^3.0.0",
+                        "write-file-atomic": "^5.0.1"
+                    }
+                },
+                "@jest/types": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+                    "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/pattern": "30.0.1",
+                        "@jest/schemas": "30.0.5",
+                        "@types/istanbul-lib-coverage": "^2.0.6",
+                        "@types/istanbul-reports": "^3.0.4",
+                        "@types/node": "*",
+                        "@types/yargs": "^17.0.33",
+                        "chalk": "^4.1.2"
+                    }
+                },
+                "@sinonjs/fake-timers": {
+                    "version": "15.3.2",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+                    "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+                    "dev": true,
+                    "requires": {
+                        "@sinonjs/commons": "^3.0.1"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                    "dev": true
+                },
+                "expect": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+                    "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/expect-utils": "30.3.0",
+                        "@jest/get-type": "30.1.0",
+                        "jest-matcher-utils": "30.3.0",
+                        "jest-message-util": "30.3.0",
+                        "jest-mock": "30.3.0",
+                        "jest-util": "30.3.0"
+                    }
+                },
+                "jest-diff": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+                    "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/diff-sequences": "30.3.0",
+                        "@jest/get-type": "30.1.0",
+                        "chalk": "^4.1.2",
+                        "pretty-format": "30.3.0"
+                    }
+                },
+                "jest-haste-map": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+                    "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "anymatch": "^3.1.3",
+                        "fb-watchman": "^2.0.2",
+                        "fsevents": "^2.3.3",
+                        "graceful-fs": "^4.2.11",
+                        "jest-regex-util": "30.0.1",
+                        "jest-util": "30.3.0",
+                        "jest-worker": "30.3.0",
+                        "picomatch": "^4.0.3",
+                        "walker": "^1.0.8"
+                    }
+                },
+                "jest-matcher-utils": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+                    "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/get-type": "30.1.0",
+                        "chalk": "^4.1.2",
+                        "jest-diff": "30.3.0",
+                        "pretty-format": "30.3.0"
+                    }
+                },
+                "jest-message-util": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+                    "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.27.1",
+                        "@jest/types": "30.3.0",
+                        "@types/stack-utils": "^2.0.3",
+                        "chalk": "^4.1.2",
+                        "graceful-fs": "^4.2.11",
+                        "picomatch": "^4.0.3",
+                        "pretty-format": "30.3.0",
+                        "slash": "^3.0.0",
+                        "stack-utils": "^2.0.6"
+                    }
+                },
+                "jest-mock": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+                    "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "jest-util": "30.3.0"
+                    }
+                },
+                "jest-snapshot": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+                    "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.27.4",
+                        "@babel/generator": "^7.27.5",
+                        "@babel/plugin-syntax-jsx": "^7.27.1",
+                        "@babel/plugin-syntax-typescript": "^7.27.1",
+                        "@babel/types": "^7.27.3",
+                        "@jest/expect-utils": "30.3.0",
+                        "@jest/get-type": "30.1.0",
+                        "@jest/snapshot-utils": "30.3.0",
+                        "@jest/transform": "30.3.0",
+                        "@jest/types": "30.3.0",
+                        "babel-preset-current-node-syntax": "^1.2.0",
+                        "chalk": "^4.1.2",
+                        "expect": "30.3.0",
+                        "graceful-fs": "^4.2.11",
+                        "jest-diff": "30.3.0",
+                        "jest-matcher-utils": "30.3.0",
+                        "jest-message-util": "30.3.0",
+                        "jest-util": "30.3.0",
+                        "pretty-format": "30.3.0",
+                        "semver": "^7.7.2",
+                        "synckit": "^0.11.8"
+                    }
+                },
+                "jest-util": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+                    "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "30.3.0",
+                        "@types/node": "*",
+                        "chalk": "^4.1.2",
+                        "ci-info": "^4.2.0",
+                        "graceful-fs": "^4.2.11",
+                        "picomatch": "^4.0.3"
+                    }
+                },
+                "jest-worker": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+                    "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "@ungap/structured-clone": "^1.3.0",
+                        "jest-util": "30.3.0",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^8.1.1"
+                    }
+                },
+                "picomatch": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+                    "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "30.3.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+                    "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/schemas": "30.0.5",
+                        "ansi-styles": "^5.2.0",
+                        "react-is": "^18.3.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "@jest/pattern": {
@@ -9160,6 +10072,67 @@
                 "text-hex": "1.0.x"
             }
         },
+        "@supabase/auth-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.1.tgz",
+            "integrity": "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==",
+            "requires": {
+                "tslib": "2.8.1"
+            }
+        },
+        "@supabase/functions-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.1.tgz",
+            "integrity": "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==",
+            "requires": {
+                "tslib": "2.8.1"
+            }
+        },
+        "@supabase/phoenix": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+            "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA=="
+        },
+        "@supabase/postgrest-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.1.tgz",
+            "integrity": "sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==",
+            "requires": {
+                "tslib": "2.8.1"
+            }
+        },
+        "@supabase/realtime-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.1.tgz",
+            "integrity": "sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==",
+            "requires": {
+                "@supabase/phoenix": "^0.4.1",
+                "@types/ws": "^8.18.1",
+                "tslib": "2.8.1",
+                "ws": "^8.18.2"
+            }
+        },
+        "@supabase/storage-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.1.tgz",
+            "integrity": "sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==",
+            "requires": {
+                "iceberg-js": "^0.8.1",
+                "tslib": "2.8.1"
+            }
+        },
+        "@supabase/supabase-js": {
+            "version": "2.105.1",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.1.tgz",
+            "integrity": "sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==",
+            "requires": {
+                "@supabase/auth-js": "2.105.1",
+                "@supabase/functions-js": "2.105.1",
+                "@supabase/postgrest-js": "2.105.1",
+                "@supabase/realtime-js": "2.105.1",
+                "@supabase/storage-js": "2.105.1"
+            }
+        },
         "@tybys/wasm-util": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -9211,10 +10184,58 @@
                 "@babel/types": "^7.28.2"
             }
         },
+        "@types/body-parser": {
+            "version": "1.19.6",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+            "dev": true,
+            "requires": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/connect": {
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true
+        },
+        "@types/express": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+            "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+            "dev": true,
+            "requires": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^5.0.0",
+                "@types/serve-static": "^2"
+            }
+        },
+        "@types/express-serve-static-core": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+            "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "@types/http-errors": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
             "dev": true
         },
         "@types/istanbul-lib-coverage": {
@@ -9261,9 +10282,39 @@
             "version": "22.18.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
             "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
-            "dev": true,
             "requires": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "@types/qs": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+            "dev": true
+        },
+        "@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true
+        },
+        "@types/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/serve-static": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+            "dev": true,
+            "requires": {
+                "@types/http-errors": "*",
+                "@types/node": "*"
             }
         },
         "@types/stack-utils": {
@@ -9276,6 +10327,14 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
             "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+        },
+        "@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/yargs": {
             "version": "17.0.35",
@@ -9801,19 +10860,19 @@
             "integrity": "sha512-sCXkOlWh201V9KAs6lXtzbPQHmVhys/wC0I1vaCjZzZtiskEeNJljIRqirGJ+M+WOf/KL7P7KSpUaqaR6BCq7w=="
         },
         "body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
             "requires": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             }
         },
         "bplist-parser": {
@@ -10504,17 +11563,18 @@
             }
         },
         "express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "requires": {
                 "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
+                "body-parser": "^2.2.1",
                 "content-disposition": "^1.0.0",
                 "content-type": "^1.0.5",
                 "cookie": "^0.7.1",
                 "cookie-signature": "^1.2.1",
                 "debug": "^4.4.0",
+                "depd": "^2.0.0",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
@@ -10971,10 +12031,15 @@
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
             "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="
         },
+        "iceberg-js": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+            "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+        },
         "iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             }
@@ -11626,6 +12691,18 @@
                 "strip-bom": "^4.0.0"
             },
             "dependencies": {
+                "@jest/globals": {
+                    "version": "30.2.0",
+                    "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+                    "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/environment": "30.2.0",
+                        "@jest/expect": "30.2.0",
+                        "@jest/types": "30.2.0",
+                        "jest-mock": "30.2.0"
+                    }
+                },
                 "brace-expansion": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -12497,9 +13574,9 @@
             "dev": true
         },
         "qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
             "requires": {
                 "side-channel": "^1.1.0"
             }
@@ -12892,12 +13969,12 @@
             }
         },
         "side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "requires": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             }
         },
         "side-channel-map": {
@@ -13208,9 +14285,7 @@
         "tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "tsscmp": {
             "version": "1.0.6",
@@ -13302,8 +14377,7 @@
         "undici-types": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "dev": true
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
         },
         "unpipe": {
             "version": "1.0.0",
@@ -13527,6 +14601,12 @@
                     "dev": true
                 }
             }
+        },
+        "ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "requires": {}
         },
         "y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,18 @@
         "lint:fix": "eslint --fix",
         "lint": "eslint .",
         "auth": "node dist/auth-server.js",
+        "auth:add": "node auth-add.js",
+        "clients": "node launcher.js",
+        "serve": "node dist/http-server.js",
         "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
         "test:watch": "NODE_OPTIONS='--experimental-vm-modules' jest --watch",
         "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.0",
+        "@supabase/supabase-js": "^2.105.1",
         "dotenv": "^16.4.7",
+        "express": "^5.2.1",
         "intuit-oauth": "^4.0.0",
         "node-quickbooks": "^2.0.43",
         "open": "^9.1.0",
@@ -31,6 +36,7 @@
     "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@jest/globals": "^30.3.0",
+        "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.13.10",
         "eslint": "^9.22.0",

--- a/reauth-dead.js
+++ b/reauth-dead.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Re-authorize the 9 QBO clients whose refresh tokens are dead (400 on refresh).
+// Hardened vs. the old reauth scripts:
+//   - verifies the realmId Intuit returns matches the EXPECTED realm for the slug
+//     (refuses to save on mismatch — prevents mapping a slug to the wrong company)
+//   - persists to BOTH clients.json and Supabase qbo_clients
+//   - prints "URL:<authorizeUri>" to stdout for Chrome automation to pick up
+import OAuthClient from 'intuit-oauth';
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '.env') });
+
+const clientId = process.env.QUICKBOOKS_CLIENT_ID;
+const clientSecret = process.env.QUICKBOOKS_CLIENT_SECRET;
+const redirectUri = process.env.QUICKBOOKS_REDIRECT_URI;
+const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'production';
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+const PORT = 8000;
+
+// slug -> expected realm_id (from the diagnostic). Save is rejected on mismatch.
+const DEAD = {
+  '11368-realty-llc':         '9341455241552816',
+  '869-old-country-llc':      '9341455241551106',
+  'duane-park-patisserie':    '9130357046778516',
+  'feneti-window-system':     '9130357662172796',
+  'green-team-li':            '193514781811699',
+  'hempstead-218-realty-llc': '9341455241537608',
+  'modena-realty-llc':        '9341455256989667',
+  'modena-window-design-llc': '9341455241387234',
+  'ny-monda-window-door-inc': '9341455256961174',
+};
+
+const clientsPath = path.join(__dirname, 'clients.json');
+let clients = JSON.parse(fs.readFileSync(clientsPath, 'utf-8'));
+
+function saveClients() {
+  const tmp = `${clientsPath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(clients, null, 2) + '\n', { mode: 0o600 });
+  fs.renameSync(tmp, clientsPath);
+}
+
+async function syncToSupabase(slug, client) {
+  if (!supabaseUrl || !supabaseKey) return;
+  const update = {
+    slug, name: client.name, realm_id: client.realm_id,
+    refresh_token: client.refresh_token,
+    added_at: client.added || new Date().toISOString().split('T')[0],
+    updated_at: new Date().toISOString(),
+  };
+  try {
+    const resp = await fetch(`${supabaseUrl}/rest/v1/qbo_clients`, {
+      method: 'POST',
+      headers: {
+        apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}`,
+        'Content-Type': 'application/json',
+        Prefer: 'resolution=merge-duplicates,return=minimal',
+      },
+      body: JSON.stringify(update),
+    });
+    console.error(resp.ok ? '  ↳ Synced to Supabase' : `  ↳ Supabase sync failed: ${resp.status}`);
+  } catch { console.error('  ↳ Supabase sync failed (network error)'); }
+}
+
+function authOneClient(slug, expectedRealm) {
+  return new Promise((resolve) => {
+    const oauthClient = new OAuthClient({ clientId, clientSecret, environment, redirectUri });
+    const server = http.createServer(async (req, res) => {
+      if (!req.url?.startsWith('/callback')) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('Waiting for QBO callback...');
+        return;
+      }
+      try {
+        const response = await oauthClient.createToken(req.url);
+        const tokens = response.token;
+
+        // GUARD: returned realm must match the expected company for this slug.
+        if (String(tokens.realmId) !== String(expectedRealm)) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end(`<html><body style="font-family:system-ui;background:#fffbeb;padding:40px;">
+            <h2 style="color:#b45309;">⚠ Wrong company selected for ${slug}</h2>
+            <p>Expected realm <b>${expectedRealm}</b> but you selected <b>${tokens.realmId}</b>.</p>
+            <p>Nothing was saved. Re-run and pick the correct company.</p></body></html>`);
+          console.error(`  ✗ REALM MISMATCH: expected ${expectedRealm}, got ${tokens.realmId} — NOT saved`);
+          setTimeout(() => { server.close(); resolve('mismatch'); }, 800);
+          return;
+        }
+
+        clients[slug] = {
+          name: clients[slug]?.name || slug,
+          realm_id: tokens.realmId,
+          refresh_token: tokens.refresh_token,
+          added: clients[slug]?.added || new Date().toISOString().split('T')[0],
+        };
+        saveClients();
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<html><body style="display:flex;flex-direction:column;justify-content:center;align-items:center;height:100vh;margin:0;font-family:system-ui;background:#f0fdf4;">
+          <h2 style="color:#16a34a;">&#10003; ${clients[slug].name}</h2>
+          <p style="color:#666;">Realm: ${tokens.realmId}</p></body></html>`);
+        await syncToSupabase(slug, clients[slug]);
+        console.error('  ✓ Done (saved + synced)');
+        setTimeout(() => { server.close(); resolve('ok'); }, 800);
+      } catch (error) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`<html><body style="font-family:system-ui;background:#fef2f2;padding:40px;">
+          <h2 style="color:#dc2626;">Failed: ${slug}</h2><p>${error.message || error}</p></body></html>`);
+        console.error(`  ✗ Failed: ${error.message || error}`);
+        setTimeout(() => { server.close(); resolve('fail'); }, 800);
+      }
+    });
+    server.listen(PORT, () => {
+      const authUri = oauthClient.authorizeUri({ scope: [OAuthClient.scopes.Accounting], state: slug }).toString();
+      console.log(`URL:${authUri}`);            // stdout — for Chrome automation
+      console.error(`  Waiting for OAuth callback (expected realm ${expectedRealm})...`);
+    });
+    server.on('error', (err) => {
+      console.error(`  Port ${PORT} busy — ${err.message}`);
+      resolve('fail');
+    });
+  });
+}
+
+const slugs = process.argv.slice(2).filter(s => DEAD[s]);
+const targets = slugs.length ? slugs : Object.keys(DEAD);
+
+console.error(`\nRe-authorizing ${targets.length} dead QBO client(s)`);
+console.error(`Redirect URI: ${redirectUri}\n`);
+
+let ok = 0, bad = 0;
+for (let i = 0; i < targets.length; i++) {
+  const slug = targets[i];
+  console.error(`[${i + 1}/${targets.length}] ${slug}`);
+  const r = await authOneClient(slug, DEAD[slug]);
+  if (r === 'ok') ok++; else bad++;
+  if (i < targets.length - 1) await new Promise(r => setTimeout(r, 1000));
+}
+console.error(`\n✓ ${ok} ok  |  ✗ ${bad} not completed\n`);

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -72,6 +72,15 @@ class QuickbooksClient {
     });
   }
 
+  reconfigure(refreshToken: string, realmId: string): void {
+    this.refreshToken = refreshToken;
+    this.realmId = realmId;
+    this.accessToken = undefined;
+    this.accessTokenExpiry = undefined;
+    this.quickbooksInstance = undefined;
+    this.refreshInFlight = undefined;
+  }
+
   private async startOAuthFlow(): Promise<void> {
     if (this.isAuthenticating) {
       return;
@@ -216,6 +225,52 @@ class QuickbooksClient {
     } catch (err) {
       try { fs.unlinkSync(tmpPath); } catch { /* best effort */ }
       throw err;
+    }
+
+    this.saveTokensToClientsJson();
+  }
+
+  private saveTokensToClientsJson(): void {
+    const clientName = process.env.QBO_CLIENT_NAME;
+    if (!clientName) return;
+
+    // Local file persistence (launcher mode)
+    const clientsPath = process.env.QBO_CLIENTS_PATH;
+    if (clientsPath) {
+      try {
+        const clients = JSON.parse(fs.readFileSync(clientsPath, 'utf-8'));
+        if (clients[clientName]) {
+          if (this.refreshToken) clients[clientName].refresh_token = this.refreshToken;
+          if (this.realmId) clients[clientName].realm_id = this.realmId;
+          const tmpPath = `${clientsPath}.tmp.${process.pid}`;
+          fs.writeFileSync(tmpPath, JSON.stringify(clients, null, 2) + '\n', { mode: 0o600 });
+          fs.renameSync(tmpPath, clientsPath);
+        }
+      } catch {
+        // best effort
+      }
+    }
+
+    // Supabase persistence (hosted mode)
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+    if (supabaseUrl && supabaseKey) {
+      const update: Record<string, string> = { updated_at: new Date().toISOString() };
+      if (this.refreshToken) update.refresh_token = this.refreshToken;
+      if (this.realmId) update.realm_id = this.realmId;
+
+      fetch(`${supabaseUrl}/rest/v1/qbo_clients?slug=eq.${clientName}`, {
+        method: 'PATCH',
+        headers: {
+          'apikey': supabaseKey,
+          'Authorization': `Bearer ${supabaseKey}`,
+          'Content-Type': 'application/json',
+          'Prefer': 'return=minimal',
+        },
+        body: JSON.stringify(update),
+      }).catch(() => {
+        // best effort
+      });
     }
   }
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,547 @@
+#!/usr/bin/env node
+import express from 'express';
+import { randomUUID, createHash, createHmac } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+const QBO_CLIENT_NAME = process.env.QBO_CLIENT_NAME || 'potluck-club';
+const API_BEARER_TOKEN = process.env.API_BEARER_TOKEN;
+const OAUTH_CLIENT_ID = process.env.OAUTH_CLIENT_ID;
+const OAUTH_CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET;
+const PORT = parseInt(process.env.PORT || '3000', 10);
+
+const authCodes = new Map<string, { clientId: string; redirectUri: string; codeChallenge: string; expiresAt: number }>();
+
+function createStatelessToken(clientId: string, expiresInSec: number, type: 'access' | 'refresh' = 'access'): string {
+  const payload = JSON.stringify({
+    cid: clientId, typ: type,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + expiresInSec,
+  });
+  const payloadB64 = Buffer.from(payload).toString('base64url');
+  const sig = createHmac('sha256', OAUTH_CLIENT_SECRET!).update(payloadB64).digest('base64url');
+  return `${payloadB64}.${sig}`;
+}
+
+function verifyStatelessToken(token: string, expectedType: 'access' | 'refresh' = 'access'): boolean {
+  try {
+    const dotIdx = token.indexOf('.');
+    if (dotIdx < 0) return false;
+    const payloadB64 = token.slice(0, dotIdx);
+    const sig = token.slice(dotIdx + 1);
+    const expectedSig = createHmac('sha256', OAUTH_CLIENT_SECRET!).update(payloadB64).digest('base64url');
+    if (sig !== expectedSig) return false;
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+    return payload.typ === expectedType && payload.exp > Math.floor(Date.now() / 1000);
+  } catch {
+    return false;
+  }
+}
+
+let initPromise: Promise<McpServer> | null = null;
+const sessions = new Map<string, { transport: StreamableHTTPServerTransport }>();
+
+async function init(): Promise<McpServer> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error('SUPABASE_URL and SUPABASE_SERVICE_KEY are required');
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data, error } = await supabase
+    .from('qbo_clients')
+    .select('realm_id, refresh_token')
+    .eq('slug', QBO_CLIENT_NAME)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to load client "${QBO_CLIENT_NAME}": ${error?.message}`);
+  }
+
+  process.env.QUICKBOOKS_REFRESH_TOKEN = data.refresh_token;
+  process.env.QUICKBOOKS_REALM_ID = data.realm_id;
+  process.env.QBO_CLIENT_NAME = QBO_CLIENT_NAME;
+  console.error(`[http] Loaded QBO client: ${QBO_CLIENT_NAME} (realm: ${data.realm_id})`);
+
+  const { QuickbooksMCPServer } = await import('./server/qbo-mcp-server.js');
+  const { RegisterTool } = await import('./helpers/register-tool.js');
+
+  const tools = await Promise.all([
+    import('./tools/create-customer.tool.js'),
+    import('./tools/get-customer.tool.js'),
+    import('./tools/update-customer.tool.js'),
+    import('./tools/delete-customer.tool.js'),
+    import('./tools/search-customers.tool.js'),
+    import('./tools/create-estimate.tool.js'),
+    import('./tools/get-estimate.tool.js'),
+    import('./tools/update-estimate.tool.js'),
+    import('./tools/delete-estimate.tool.js'),
+    import('./tools/search-estimates.tool.js'),
+    import('./tools/create-bill.tool.js'),
+    import('./tools/update-bill.tool.js'),
+    import('./tools/delete-bill.tool.js'),
+    import('./tools/get-bill.tool.js'),
+    import('./tools/search-bills.tool.js'),
+    import('./tools/read-invoice.tool.js'),
+    import('./tools/search-invoices.tool.js'),
+    import('./tools/create-invoice.tool.js'),
+    import('./tools/update-invoice.tool.js'),
+    import('./tools/delete-invoice.tool.js'),
+    import('./tools/create-account.tool.js'),
+    import('./tools/get-account.tool.js'),
+    import('./tools/update-account.tool.js'),
+    import('./tools/search-accounts.tool.js'),
+    import('./tools/read-item.tool.js'),
+    import('./tools/search-items.tool.js'),
+    import('./tools/create-item.tool.js'),
+    import('./tools/update-item.tool.js'),
+    import('./tools/delete-item.tool.js'),
+    import('./tools/create-vendor.tool.js'),
+    import('./tools/update-vendor.tool.js'),
+    import('./tools/delete-vendor.tool.js'),
+    import('./tools/get-vendor.tool.js'),
+    import('./tools/search-vendors.tool.js'),
+    import('./tools/create-employee.tool.js'),
+    import('./tools/get-employee.tool.js'),
+    import('./tools/update-employee.tool.js'),
+    import('./tools/delete-employee.tool.js'),
+    import('./tools/search-employees.tool.js'),
+    import('./tools/create-journal-entry.tool.js'),
+    import('./tools/get-journal-entry.tool.js'),
+    import('./tools/update-journal-entry.tool.js'),
+    import('./tools/delete-journal-entry.tool.js'),
+    import('./tools/search-journal-entries.tool.js'),
+    import('./tools/create-bill-payment.tool.js'),
+    import('./tools/get-bill-payment.tool.js'),
+    import('./tools/update-bill-payment.tool.js'),
+    import('./tools/delete-bill-payment.tool.js'),
+    import('./tools/search-bill-payments.tool.js'),
+    import('./tools/create-purchase.tool.js'),
+    import('./tools/get-purchase.tool.js'),
+    import('./tools/update-purchase.tool.js'),
+    import('./tools/delete-purchase.tool.js'),
+    import('./tools/search-purchases.tool.js'),
+    import('./tools/create-payment.tool.js'),
+    import('./tools/get-payment.tool.js'),
+    import('./tools/update-payment.tool.js'),
+    import('./tools/delete-payment.tool.js'),
+    import('./tools/search-payments.tool.js'),
+    import('./tools/create-sales-receipt.tool.js'),
+    import('./tools/get-sales-receipt.tool.js'),
+    import('./tools/update-sales-receipt.tool.js'),
+    import('./tools/delete-sales-receipt.tool.js'),
+    import('./tools/search-sales-receipts.tool.js'),
+    import('./tools/create-credit-memo.tool.js'),
+    import('./tools/get-credit-memo.tool.js'),
+    import('./tools/update-credit-memo.tool.js'),
+    import('./tools/delete-credit-memo.tool.js'),
+    import('./tools/search-credit-memos.tool.js'),
+    import('./tools/create-refund-receipt.tool.js'),
+    import('./tools/get-refund-receipt.tool.js'),
+    import('./tools/update-refund-receipt.tool.js'),
+    import('./tools/delete-refund-receipt.tool.js'),
+    import('./tools/search-refund-receipts.tool.js'),
+    import('./tools/create-purchase-order.tool.js'),
+    import('./tools/get-purchase-order.tool.js'),
+    import('./tools/update-purchase-order.tool.js'),
+    import('./tools/delete-purchase-order.tool.js'),
+    import('./tools/search-purchase-orders.tool.js'),
+    import('./tools/create-vendor-credit.tool.js'),
+    import('./tools/get-vendor-credit.tool.js'),
+    import('./tools/update-vendor-credit.tool.js'),
+    import('./tools/delete-vendor-credit.tool.js'),
+    import('./tools/search-vendor-credits.tool.js'),
+    import('./tools/create-deposit.tool.js'),
+    import('./tools/get-deposit.tool.js'),
+    import('./tools/update-deposit.tool.js'),
+    import('./tools/delete-deposit.tool.js'),
+    import('./tools/search-deposits.tool.js'),
+    import('./tools/create-transfer.tool.js'),
+    import('./tools/get-transfer.tool.js'),
+    import('./tools/update-transfer.tool.js'),
+    import('./tools/delete-transfer.tool.js'),
+    import('./tools/search-transfers.tool.js'),
+    import('./tools/create-time-activity.tool.js'),
+    import('./tools/get-time-activity.tool.js'),
+    import('./tools/update-time-activity.tool.js'),
+    import('./tools/delete-time-activity.tool.js'),
+    import('./tools/search-time-activities.tool.js'),
+    import('./tools/create-class.tool.js'),
+    import('./tools/get-class.tool.js'),
+    import('./tools/update-class.tool.js'),
+    import('./tools/search-classes.tool.js'),
+    import('./tools/create-department.tool.js'),
+    import('./tools/get-department.tool.js'),
+    import('./tools/update-department.tool.js'),
+    import('./tools/search-departments.tool.js'),
+    import('./tools/create-term.tool.js'),
+    import('./tools/get-term.tool.js'),
+    import('./tools/update-term.tool.js'),
+    import('./tools/search-terms.tool.js'),
+    import('./tools/create-payment-method.tool.js'),
+    import('./tools/get-payment-method.tool.js'),
+    import('./tools/update-payment-method.tool.js'),
+    import('./tools/search-payment-methods.tool.js'),
+    import('./tools/search-budgets.tool.js'),
+    import('./tools/get-tax-code.tool.js'),
+    import('./tools/search-tax-codes.tool.js'),
+    import('./tools/get-tax-rate.tool.js'),
+    import('./tools/search-tax-rates.tool.js'),
+    import('./tools/get-tax-agency.tool.js'),
+    import('./tools/search-tax-agencies.tool.js'),
+    import('./tools/get-company-info.tool.js'),
+    import('./tools/update-company-info.tool.js'),
+    import('./tools/create-attachable.tool.js'),
+    import('./tools/get-attachable.tool.js'),
+    import('./tools/update-attachable.tool.js'),
+    import('./tools/delete-attachable.tool.js'),
+    import('./tools/search-attachables.tool.js'),
+    import('./tools/get-balance-sheet.tool.js'),
+    import('./tools/get-profit-and-loss.tool.js'),
+    import('./tools/get-cash-flow.tool.js'),
+    import('./tools/get-trial-balance.tool.js'),
+    import('./tools/get-general-ledger.tool.js'),
+    import('./tools/get-customer-sales.tool.js'),
+    import('./tools/get-aged-receivables.tool.js'),
+    import('./tools/get-customer-balance.tool.js'),
+    import('./tools/get-aged-payables.tool.js'),
+    import('./tools/get-vendor-expenses.tool.js'),
+    import('./tools/get-vendor-balance.tool.js'),
+    import('./tools/list-clients.tool.js'),
+    import('./tools/switch-client.tool.js'),
+  ]);
+
+  const server = QuickbooksMCPServer.GetServer();
+  for (const toolModule of tools) {
+    const toolDef = Object.values(toolModule).find(
+      (v: any) => v && typeof v === 'object' && 'name' in v && 'handler' in v
+    );
+    if (toolDef) RegisterTool(server, toolDef as any);
+  }
+
+  console.error(`[http] Registered ${tools.length} tools`);
+  return server;
+}
+
+function ensureInit(): Promise<McpServer> {
+  if (!initPromise) initPromise = init();
+  return initPromise;
+}
+
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+function getBaseUrl(req: express.Request): string {
+  const proto = req.headers['x-forwarded-proto'] || req.protocol;
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  return `${proto}://${host}`;
+}
+
+app.get('/.well-known/oauth-authorization-server', (req, res) => {
+  const base = getBaseUrl(req);
+  res.json({
+    issuer: base,
+    authorization_endpoint: `${base}/authorize`,
+    token_endpoint: `${base}/token`,
+    registration_endpoint: `${base}/register`,
+    token_endpoint_auth_methods_supported: ['client_secret_post'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256'],
+  });
+});
+
+app.get('/authorize', (req, res) => {
+  const { response_type, client_id, redirect_uri, code_challenge, code_challenge_method, state } = req.query as Record<string, string>;
+
+  if (response_type !== 'code') {
+    res.status(400).json({ error: 'unsupported_response_type' });
+    return;
+  }
+
+  if (client_id !== OAUTH_CLIENT_ID) {
+    res.status(401).json({ error: 'invalid_client' });
+    return;
+  }
+
+  const code = randomUUID();
+  authCodes.set(code, {
+    clientId: client_id,
+    redirectUri: redirect_uri,
+    codeChallenge: code_challenge,
+    expiresAt: Date.now() + 600_000,
+  });
+
+  const url = new URL(redirect_uri);
+  url.searchParams.set('code', code);
+  if (state) url.searchParams.set('state', state);
+  res.redirect(302, url.toString());
+});
+
+app.post('/register', (req, res) => {
+  const { client_name, redirect_uris } = req.body || {};
+  res.status(201).json({
+    client_id: OAUTH_CLIENT_ID,
+    client_secret: OAUTH_CLIENT_SECRET,
+    client_name: client_name || 'mcp-client',
+    redirect_uris: redirect_uris || [],
+  });
+});
+
+app.post('/token', (req, res) => {
+  const { grant_type, client_id, client_secret, code, code_verifier, redirect_uri, refresh_token } = req.body || {};
+
+  if (!OAUTH_CLIENT_ID || !OAUTH_CLIENT_SECRET) {
+    res.status(500).json({ error: 'server_error', error_description: 'OAuth not configured' });
+    return;
+  }
+
+  if (grant_type === 'authorization_code') {
+    if (client_id !== OAUTH_CLIENT_ID || client_secret !== OAUTH_CLIENT_SECRET) {
+      res.status(401).json({ error: 'invalid_client' });
+      return;
+    }
+
+    const entry = authCodes.get(code);
+    if (!entry || entry.expiresAt < Date.now()) {
+      if (entry) authCodes.delete(code);
+      res.status(400).json({ error: 'invalid_grant' });
+      return;
+    }
+
+    if (entry.clientId !== client_id) {
+      res.status(401).json({ error: 'invalid_client' });
+      return;
+    }
+
+    if (entry.redirectUri && entry.redirectUri !== redirect_uri) {
+      res.status(400).json({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' });
+      return;
+    }
+
+    if (entry.codeChallenge && code_verifier) {
+      const computed = createHash('sha256').update(code_verifier).digest('base64url');
+      if (computed !== entry.codeChallenge) {
+        res.status(400).json({ error: 'invalid_grant', error_description: 'code_verifier mismatch' });
+        return;
+      }
+    }
+
+    authCodes.delete(code);
+  } else if (grant_type === 'refresh_token') {
+    if (client_id !== OAUTH_CLIENT_ID || client_secret !== OAUTH_CLIENT_SECRET) {
+      res.status(401).json({ error: 'invalid_client' });
+      return;
+    }
+    if (!refresh_token || !verifyStatelessToken(refresh_token, 'refresh')) {
+      res.status(400).json({ error: 'invalid_grant', error_description: 'invalid refresh token' });
+      return;
+    }
+  } else if (grant_type === 'client_credentials') {
+    if (client_id !== OAUTH_CLIENT_ID || client_secret !== OAUTH_CLIENT_SECRET) {
+      res.status(401).json({ error: 'invalid_client' });
+      return;
+    }
+  } else {
+    res.status(400).json({ error: 'unsupported_grant_type' });
+    return;
+  }
+
+  const accessExpiresIn = 86400;
+  const accessToken = createStatelessToken(client_id || OAUTH_CLIENT_ID!, accessExpiresIn);
+  const newRefreshToken = createStatelessToken(client_id || OAUTH_CLIENT_ID!, 2592000, 'refresh');
+
+  res.json({
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: accessExpiresIn,
+    refresh_token: newRefreshToken,
+  });
+});
+
+app.use('/mcp', (req, res, next) => {
+  const auth = req.headers.authorization;
+  const bearerToken = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+
+  // No auth configured — allow all
+  if (!API_BEARER_TOKEN && !OAUTH_CLIENT_ID) {
+    next();
+    return;
+  }
+
+  if (!bearerToken) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  // Check static bearer token
+  if (API_BEARER_TOKEN && bearerToken === API_BEARER_TOKEN) {
+    next();
+    return;
+  }
+
+  if (verifyStatelessToken(bearerToken)) {
+    next();
+    return;
+  }
+
+  res.status(401).json({ error: 'Unauthorized' });
+});
+
+app.post('/mcp', async (req, res) => {
+  const server = await ensureInit();
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  if (sessionId && sessions.has(sessionId)) {
+    const session = sessions.get(sessionId)!;
+    await session.transport.handleRequest(req, res, req.body);
+    return;
+  }
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+  });
+
+  transport.onclose = () => {
+    const sid = transport.sessionId;
+    if (sid) sessions.delete(sid);
+  };
+
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
+
+  if (transport.sessionId) {
+    sessions.set(transport.sessionId, { transport });
+  }
+});
+
+app.get('/mcp', async (req, res) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  if (!sessionId || !sessions.has(sessionId)) {
+    res.status(400).json({ error: 'Invalid or missing session ID' });
+    return;
+  }
+  const session = sessions.get(sessionId)!;
+  await session.transport.handleRequest(req, res);
+});
+
+app.delete('/mcp', async (req, res) => {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  if (sessionId && sessions.has(sessionId)) {
+    const session = sessions.get(sessionId)!;
+    await session.transport.handleRequest(req, res);
+    sessions.delete(sessionId);
+  } else {
+    res.status(200).end();
+  }
+});
+
+app.get('/cron/keep-alive', async (req, res) => {
+  const authHeader = req.headers.authorization;
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+  const clientId = process.env.QUICKBOOKS_CLIENT_ID;
+  const clientSecret = process.env.QUICKBOOKS_CLIENT_SECRET;
+
+  if (!supabaseUrl || !supabaseKey || !clientId || !clientSecret) {
+    res.status(500).json({ error: 'Missing required environment variables' });
+    return;
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data: clients, error } = await supabase
+    .from('qbo_clients')
+    .select('slug, realm_id, refresh_token')
+    .order('slug');
+
+  if (error || !clients) {
+    res.status(500).json({ error: `Failed to load clients: ${error?.message}` });
+    return;
+  }
+
+  const OAuthClient = (await import('intuit-oauth')).default;
+  const results: { slug: string; status: 'ok' | 'error'; message?: string; refreshDaysLeft?: number }[] = [];
+
+  for (const client of clients) {
+    try {
+      const oauth = new OAuthClient({
+        clientId,
+        clientSecret,
+        environment: process.env.QUICKBOOKS_ENVIRONMENT || 'production',
+        redirectUri: process.env.QUICKBOOKS_REDIRECT_URI || 'http://localhost:8000/callback',
+      });
+
+      const response = await oauth.refreshUsingToken(client.refresh_token);
+      const token = response.token as any;
+
+      const update: Record<string, string> = { updated_at: new Date().toISOString() };
+      if (token.refresh_token && token.refresh_token !== client.refresh_token) {
+        update.refresh_token = token.refresh_token;
+      }
+
+      await supabase
+        .from('qbo_clients')
+        .update(update)
+        .eq('slug', client.slug);
+
+      const refreshDaysLeft = typeof token.x_refresh_token_expires_in === 'number'
+        ? Math.round(token.x_refresh_token_expires_in / 86400)
+        : undefined;
+
+      results.push({ slug: client.slug, status: 'ok', refreshDaysLeft });
+    } catch (err: any) {
+      results.push({ slug: client.slug, status: 'error', message: err.message });
+    }
+  }
+
+  const ok = results.filter(r => r.status === 'ok').length;
+  const failed = results.filter(r => r.status === 'error');
+  console.error(`[keep-alive] ${ok}/${clients.length} refreshed, ${failed.length} failed`);
+
+  res.json({
+    total: clients.length,
+    ok,
+    failed: failed.length,
+    results,
+  });
+});
+
+app.get('/health', async (_req, res) => {
+  try {
+    await ensureInit();
+    res.json({ status: 'ok', client: QBO_CLIENT_NAME, sessions: sessions.size });
+  } catch (err: any) {
+    res.status(500).json({ status: 'error', message: err.message });
+  }
+});
+
+// Local dev: listen on PORT. On Vercel: export the app.
+if (!process.env.VERCEL) {
+  ensureInit().then(() => {
+    app.listen(PORT, () => {
+      console.error(`[http] QBO MCP server listening on port ${PORT}`);
+      console.error(`[http] Client: ${QBO_CLIENT_NAME}`);
+      console.error(`[http] Auth: ${API_BEARER_TOKEN ? 'enabled' : 'disabled'}`);
+    });
+  }).catch((err) => {
+    console.error('[http] Fatal:', err);
+    process.exit(1);
+  });
+}
+
+export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,10 @@ import { GetAgedPayablesTool } from "./tools/get-aged-payables.tool.js";
 import { GetVendorExpensesTool } from "./tools/get-vendor-expenses.tool.js";
 import { GetVendorBalanceTool } from "./tools/get-vendor-balance.tool.js";
 
+// Client management tools
+import { ListClientsTool } from "./tools/list-clients.tool.js";
+import { SwitchClientTool } from "./tools/switch-client.tool.js";
+
 const main = async () => {
   // Create an MCP server
   const server = QuickbooksMCPServer.GetServer();
@@ -423,6 +427,10 @@ const main = async () => {
   RegisterTool(server, GetAgedPayablesTool);
   RegisterTool(server, GetVendorExpensesTool);
   RegisterTool(server, GetVendorBalanceTool);
+
+  // Client management tools
+  RegisterTool(server, ListClientsTool);
+  RegisterTool(server, SwitchClientTool);
 
   // Start receiving messages on stdin and sending messages on stdout
   const transport = new StdioServerTransport();

--- a/src/tools/list-clients.tool.ts
+++ b/src/tools/list-clients.tool.ts
@@ -1,0 +1,54 @@
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+
+const toolName = "list_clients";
+const toolDescription =
+  "List all available QuickBooks Online client accounts. Shows which client is currently active.";
+
+const toolSchema = z.object({});
+
+const toolHandler = async () => {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+  const currentClient = process.env.QBO_CLIENT_NAME || "unknown";
+
+  if (!supabaseUrl || !supabaseKey) {
+    return {
+      content: [{ type: "text" as const, text: "Supabase not configured — cannot list clients." }],
+    };
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data, error } = await supabase
+    .from("qbo_clients")
+    .select("slug, name, realm_id, added_at")
+    .order("name");
+
+  if (error) {
+    return {
+      content: [{ type: "text" as const, text: `Error listing clients: ${error.message}` }],
+    };
+  }
+
+  const lines = (data || []).map(
+    (c) =>
+      `${c.slug === currentClient ? "→ " : "  "}${c.slug}  —  ${c.name}  (realm: ${c.realm_id}, added: ${c.added_at})`
+  );
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Available QBO clients (${data?.length || 0}):\n\n${lines.join("\n")}\n\nCurrent: ${currentClient}`,
+      },
+    ],
+  };
+};
+
+export const ListClientsTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler as any,
+};

--- a/src/tools/switch-client.tool.ts
+++ b/src/tools/switch-client.tool.ts
@@ -1,0 +1,76 @@
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+import { quickbooksClient } from "../clients/quickbooks-client.js";
+
+const toolName = "switch_client";
+const toolDescription =
+  "Switch to a different QuickBooks Online client account. Use list_clients first to see available options.";
+
+const toolSchema = z.object({
+  slug: z.string().describe("The client slug to switch to (e.g. 'potluck-club')"),
+});
+
+const toolHandler = async (args: any) => {
+  const { slug } = (args.params ?? {}) as z.infer<typeof toolSchema>;
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    return {
+      content: [{ type: "text" as const, text: "Supabase not configured — cannot switch clients." }],
+    };
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data, error } = await supabase
+    .from("qbo_clients")
+    .select("slug, name, realm_id, refresh_token")
+    .eq("slug", slug)
+    .single();
+
+  if (error || !data) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Client "${slug}" not found. Use list_clients to see available options.`,
+        },
+      ],
+    };
+  }
+
+  quickbooksClient.reconfigure(data.refresh_token, data.realm_id);
+  process.env.QUICKBOOKS_REFRESH_TOKEN = data.refresh_token;
+  process.env.QUICKBOOKS_REALM_ID = data.realm_id;
+  process.env.QBO_CLIENT_NAME = data.slug;
+
+  try {
+    await quickbooksClient.authenticate();
+  } catch (authErr: any) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Switched to "${data.name}" but authentication failed: ${authErr.message}. The refresh token may need to be renewed.`,
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Switched to "${data.name}" (realm: ${data.realm_id}). All subsequent QBO operations will use this account.`,
+      },
+    ],
+  };
+};
+
+export const SwitchClientTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler as any,
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "dist/http-server.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "dist/http-server.js" }
+  ],
+  "crons": [
+    {
+      "path": "/cron/keep-alive",
+      "schedule": "0 6 * * 1"
+    }
+  ]
+}

--- a/verify-9.js
+++ b/verify-9.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Verify the 9 re-authed clients end-to-end: refresh (clients.json token),
+// persist rotation to BOTH stores, pull a real P&L. Reports per-slug result.
+import OAuthClient from 'intuit-oauth';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(__dirname, '.env') });
+
+const clientId = process.env.QUICKBOOKS_CLIENT_ID;
+const clientSecret = process.env.QUICKBOOKS_CLIENT_SECRET;
+const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'production';
+const redirectUri = process.env.QUICKBOOKS_REDIRECT_URI;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+const apiBase = environment === 'production'
+  ? 'https://quickbooks.api.intuit.com' : 'https://sandbox-quickbooks.api.intuit.com';
+
+const SLUGS = [
+  '11368-realty-llc','869-old-country-llc','duane-park-patisserie','feneti-window-system',
+  'green-team-li','hempstead-218-realty-llc','modena-realty-llc','modena-window-design-llc',
+  'ny-monda-window-door-inc',
+];
+
+const clientsPath = path.join(__dirname, 'clients.json');
+const clients = JSON.parse(fs.readFileSync(clientsPath, 'utf-8'));
+
+async function syncSupabase(slug, rt) {
+  await fetch(`${supabaseUrl}/rest/v1/qbo_clients?slug=eq.${encodeURIComponent(slug)}`, {
+    method: 'PATCH',
+    headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}`, 'Content-Type': 'application/json', Prefer: 'return=minimal' },
+    body: JSON.stringify({ refresh_token: rt, updated_at: new Date().toISOString() }),
+  });
+}
+
+const rows = [];
+for (const slug of SLUGS) {
+  const c = clients[slug];
+  try {
+    const oauth = new OAuthClient({ clientId, clientSecret, environment, redirectUri });
+    const { token } = await oauth.refreshUsingToken(c.refresh_token);
+    if (token.refresh_token && token.refresh_token !== c.refresh_token) {
+      c.refresh_token = token.refresh_token;
+      await syncSupabase(slug, token.refresh_token);
+    }
+    const r = await fetch(`${apiBase}/v3/company/${c.realm_id}/reports/ProfitAndLoss?minorversion=65`, {
+      headers: { Authorization: `Bearer ${token.access_token}`, Accept: 'application/json' },
+    });
+    if (!r.ok) throw new Error(`P&L HTTP ${r.status}`);
+    const data = await r.json();
+    const period = `${data?.Header?.StartPeriod}..${data?.Header?.EndPeriod}`;
+    const days = Math.round((token.x_refresh_token_expires_in || 0) / 86400);
+    rows.push({ slug, realm: c.realm_id, ok: true, period, days });
+  } catch (e) {
+    rows.push({ slug, realm: c?.realm_id, ok: false, err: e.message });
+  }
+}
+
+// persist clients.json rotations
+const tmp = `${clientsPath}.tmp.${process.pid}`;
+fs.writeFileSync(tmp, JSON.stringify(clients, null, 2) + '\n', { mode: 0o600 });
+fs.renameSync(tmp, clientsPath);
+
+const ok = rows.filter(r => r.ok).length;
+console.log(`\n=== VERIFY 9 re-authed clients: ${ok}/9 P&L OK ===\n`);
+for (const r of rows) {
+  console.log(`  ${r.ok ? '✓' : '✗'} ${r.slug.padEnd(28)} realm=${r.realm}  ${r.ok ? `${r.days}d left  P&L ${r.period}` : 'FAIL: ' + r.err}`);
+}


### PR DESCRIPTION
## What
Tooling to diagnose and recover dead/drifted QBO OAuth connections, written while recovering expired client tokens.

## Context
The local MCP (`launcher.js` → `clients.json`) and the deployed Vercel `/cron/keep-alive` (Supabase `qbo_clients`) are **two refresh-token stores**. Because QBO refresh tokens rotate on every use and the weekly cron writes rotated tokens to Supabase only, `clients.json` drifts stale and the local MCP starts failing with `400 Failed to refresh`.

Recovery run: **51 clients → 42 self-healed** via a clients.json↔Supabase resync; **9 were truly dead** and re-authed through the Intuit browser flow.

## Changes
- **`reauth-dead.js`** — re-authorize specific clients via Intuit OAuth. Hardened over the existing reauth scripts:
  - **Realm guard**: verifies the `realmId` Intuit returns matches the *expected* realm for the slug, and refuses to save on mismatch (prevents silently mapping a slug to the wrong company — this caught 2 wrong picks during the live run).
  - Dual-writes the rotated `refresh_token` to **both** `clients.json` and Supabase.
- **`check-pnl-all.js`** — end-to-end health check across all clients: rotation-safe refresh (persists to both stores) + real P&L pull, classifying `ok` / `pnl_error` / `expired`.
- **`verify-9.js`** — targeted post-reauth verification.
- **`.gitignore`** — also ignore `.env.prod`, `.env.vercel`, `.env.bak.*` (these hold `CRON_SECRET` / `SUPABASE_SERVICE_KEY` and were previously not ignored).

## Follow-up (not in this PR)
Root cause is the cron's single-store write. Worth making `/cron/keep-alive` write rotated tokens to both stores, or making the local MCP read tokens from Supabase, to stop the drift recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)