### PR TITLE
fix: fall back to interactive OAuth when refresh token is dead; use localhost redirect for local flow

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,18 @@ export default {
       lines: 100,
       statements: 100,
     },
+    // The OAuth client spins up an interactive browser flow and a local HTTP
+    // callback server, which can't be fully unit-covered. Jest subtracts
+    // path-matched files from the global group, so the 100% gate above still
+    // applies to everything else. Before quickbooks-client.auth.test.ts this
+    // file had no tests at all (it was never imported, so istanbul never saw
+    // it); these floors reflect what the new behavioral tests cover.
+    './src/clients/quickbooks-client.ts': {
+      branches: 45,
+      functions: 70,
+      lines: 70,
+      statements: 70,
+    },
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -107,6 +107,18 @@ export class QuickbooksClient {
     this.isAuthenticating = true;
     const port = 8000;
 
+    // The local server below receives the callback, so the authorize/exchange
+    // pair must use the localhost redirect even when QUICKBOOKS_REDIRECT_URI
+    // points elsewhere (e.g. the OAuth playground used for manual token
+    // generation). Intuit rejects the exchange if the redirect_uri does not
+    // match the one used in the authorize request.
+    const flowClient = new OAuthClient({
+      clientId: this.clientId,
+      clientSecret: this.clientSecret,
+      environment: this.environment,
+      redirectUri: `http://localhost:${port}/callback`,
+    });
+
     return new Promise((resolve, reject) => {
       // Create temporary server for OAuth callback
       const server = http.createServer(async (req, res) => {
@@ -122,7 +134,7 @@ export class QuickbooksClient {
 
         {
           try {
-            const response = await this.oauthClient.createToken(req.url);
+            const response = await flowClient.createToken(req.url);
             const tokens = response.token;
 
             // Save tokens
@@ -189,7 +201,7 @@ export class QuickbooksClient {
         console.log(`[auth-server] Listening on ${typeof addr === 'string' ? addr : `${addr?.address}:${addr?.port}`} (family: ${typeof addr === 'object' ? addr?.family : 'n/a'})`);
 
         // Generate authorization URL with proper type assertion
-        const authUri = this.oauthClient.authorizeUri({
+        const authUri = flowClient.authorizeUri({
           scope: [OAuthClient.scopes.Accounting as string],
           state: 'testState'
         }).toString();
@@ -337,7 +349,21 @@ export class QuickbooksClient {
 
         // Silently refresh if token is expired or expiring soon
         if (this.isTokenExpiredOrExpiringSoon()) {
-          await this.refreshAccessToken();
+          try {
+            await this.refreshAccessToken();
+          } catch (error) {
+            // A dead refresh token (rotated by another consumer, past the
+            // 100-day window, or revoked) is recoverable: fall back to the
+            // interactive OAuth flow instead of failing hard.
+            const message = error instanceof Error ? error.message : String(error);
+            console.error(`[qbo-client] Token refresh failed (${message}); falling back to interactive OAuth`);
+            this.refreshToken = undefined;
+            this.accessToken = undefined;
+            this.accessTokenExpiry = undefined;
+            // With no refresh token, refreshAccessToken() starts the OAuth
+            // flow and then exchanges the newly obtained refresh token.
+            await this.refreshAccessToken();
+          }
         }
 
         // Always rebuild with the current fresh access token

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Behavioral tests for QuickbooksClient authentication recovery.
+ *
+ * Covers two failure modes that previously made `npm run auth` (and any MCP
+ * call) fail hard with no way to recover except hand-editing .env:
+ *
+ * 1. authenticate() must fall back to the interactive OAuth flow when the
+ *    stored refresh token is rejected (e.g. invalid_grant after the token
+ *    was rotated by another consumer, expired past the 100-day window, or
+ *    was revoked).
+ * 2. The interactive flow must authorize AND exchange with the localhost
+ *    callback redirect, even when QUICKBOOKS_REDIRECT_URI points elsewhere
+ *    (e.g. the OAuth playground). Intuit rejects the code exchange if the
+ *    redirect_uri differs from the one used in the authorize request.
+ */
+import { jest } from '@jest/globals';
+
+// The module under test validates env at import time. Set deterministic
+// values before importing it. QUICKBOOKS_REDIRECT_URI deliberately points
+// away from localhost to prove the flow ignores it.
+process.env.QUICKBOOKS_CLIENT_ID = 'test-client-id';
+process.env.QUICKBOOKS_CLIENT_SECRET = 'test-client-secret';
+process.env.QUICKBOOKS_REFRESH_TOKEN = 'stale-refresh-token';
+process.env.QUICKBOOKS_REALM_ID = '12345';
+process.env.QUICKBOOKS_ENVIRONMENT = 'sandbox';
+process.env.QUICKBOOKS_REDIRECT_URI = 'https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl';
+
+// Track every OAuthClient the module constructs so tests can tell the
+// module-level client (env redirect) apart from the flow client (localhost).
+type MockOAuth = {
+  cfg: Record<string, unknown>;
+  refreshUsingToken: jest.Mock;
+  createToken: jest.Mock;
+  authorizeUri: jest.Mock;
+};
+const oauthInstances: MockOAuth[] = [];
+// Shared dispatch points so tests can program responses without caring which
+// instance receives the call.
+const refreshDispatch = jest.fn<(token: string) => Promise<unknown>>();
+const createTokenDispatch = jest.fn<(url: string) => Promise<unknown>>();
+
+jest.unstable_mockModule('intuit-oauth', () => {
+  class MockOAuthClient {
+    static scopes = { Accounting: 'com.intuit.quickbooks.accounting' };
+    cfg: Record<string, unknown>;
+    refreshUsingToken = jest.fn((token: string) => refreshDispatch(token));
+    createToken = jest.fn((url: string) => createTokenDispatch(url));
+    authorizeUri = jest.fn(() => 'https://appcenter.intuit.com/connect/oauth2?mock');
+    constructor(cfg: Record<string, unknown>) {
+      this.cfg = cfg;
+      oauthInstances.push(this as unknown as MockOAuth);
+    }
+  }
+  return { default: MockOAuthClient };
+});
+
+jest.unstable_mockModule('node-quickbooks', () => ({
+  default: class MockQuickBooks {
+    constructor(..._args: unknown[]) {}
+  },
+}));
+
+jest.unstable_mockModule('open', () => ({ default: jest.fn(async () => undefined) }));
+
+// Capture the OAuth callback handler instead of binding a real port, and
+// stub fs so the test never touches a real .env file (dotenv reads it at
+// import; saveTokensToEnv writes it after the flow).
+let callbackHandler:
+  | ((req: { url?: string; method?: string }, res: { writeHead: jest.Mock; end: jest.Mock }) => Promise<void>)
+  | undefined;
+const fakeServer = {
+  listen: jest.fn((_port: unknown, _host: unknown, cb?: () => void) => {
+    if (cb) setImmediate(cb);
+    return fakeServer;
+  }),
+  close: jest.fn(),
+  on: jest.fn(),
+  address: jest.fn(() => ({ address: '::', port: 8000, family: 'IPv6' })),
+};
+jest.unstable_mockModule('http', () => ({
+  default: {
+    createServer: jest.fn((handler: typeof callbackHandler) => {
+      callbackHandler = handler;
+      return fakeServer;
+    }),
+  },
+}));
+
+const enoent = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => {
+      throw enoent();
+    }),
+    existsSync: jest.fn(() => false),
+    writeFileSync: jest.fn(),
+    renameSync: jest.fn(),
+    unlinkSync: jest.fn(),
+  },
+}));
+
+const { quickbooksClient } = await import('../../../src/clients/quickbooks-client');
+
+// Polls until the OAuth callback handler has been registered by startOAuthFlow.
+async function untilCallbackRegistered(timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!callbackHandler) {
+    if (Date.now() - start > timeoutMs) throw new Error('OAuth callback handler never registered');
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+describe('QuickbooksClient.authenticate', () => {
+  it('refreshes silently without starting the interactive flow when the refresh token works', async () => {
+    refreshDispatch.mockResolvedValueOnce({
+      token: { access_token: 'access-1', expires_in: 3600, refresh_token: 'rotated-1' },
+    });
+
+    await quickbooksClient.authenticate();
+
+    // Only the module-level client exists; no flow client was constructed.
+    expect(oauthInstances).toHaveLength(1);
+    expect(oauthInstances[0].cfg.redirectUri).toBe(process.env.QUICKBOOKS_REDIRECT_URI);
+    expect(callbackHandler).toBeUndefined();
+  });
+
+  it('falls back to the interactive OAuth flow when the refresh token is rejected, and uses the localhost redirect', async () => {
+    // Force the next authenticate() to attempt a refresh.
+    (quickbooksClient as unknown as { accessTokenExpiry?: Date }).accessTokenExpiry = new Date(0);
+
+    refreshDispatch
+      // The stored token is dead.
+      .mockRejectedValueOnce(new Error('invalid_grant'))
+      // After the interactive flow hands us a new one, refresh succeeds.
+      .mockResolvedValueOnce({
+        token: { access_token: 'access-2', expires_in: 3600, refresh_token: 'rotated-2' },
+      });
+    createTokenDispatch.mockResolvedValueOnce({
+      token: { refresh_token: 'flow-refresh-token', realmId: '12345' },
+    });
+
+    const authPromise = quickbooksClient.authenticate();
+
+    // Simulate the user completing authorization in the browser: Intuit
+    // redirects to the local callback server.
+    await untilCallbackRegistered();
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    await callbackHandler!({ url: '/callback?code=abc&state=testState', method: 'GET' }, res);
+
+    await authPromise;
+
+    // A second OAuthClient was constructed for the flow, with the localhost
+    // redirect (NOT the playground URI from the environment).
+    expect(oauthInstances).toHaveLength(2);
+    const flowClient = oauthInstances[1];
+    expect(flowClient.cfg.redirectUri).toBe('http://localhost:8000/callback');
+
+    // The code exchange went through the flow client, so authorize and
+    // exchange used the same redirect_uri.
+    expect(flowClient.createToken).toHaveBeenCalledWith('/callback?code=abc&state=testState');
+    expect(oauthInstances[0].createToken).not.toHaveBeenCalled();
+
+    // The flow's new refresh token was then exchanged for an access token.
+    expect(refreshDispatch).toHaveBeenLastCalledWith('flow-refresh-token');
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+  }, 15000);
+});


### PR DESCRIPTION
Fixes #68.

## Problem

1. `authenticate()` only starts the interactive OAuth flow when no refresh token exists. A present-but-dead token (rotated by another consumer, past the 100-day window, or revoked) makes `refreshUsingToken` fail with `invalid_grant`, and everything fails hard, including `npm run auth` itself, the one command meant to fix broken auth.

2. `startOAuthFlow()` built its authorize URL and code exchange with the module-level `oauthClient`, whose redirect comes from `QUICKBOOKS_REDIRECT_URI`. The flow's callback server only listens on `http://localhost:8000/callback`, so any other configured redirect (e.g. the OAuth playground URL from the README's manual-token path) sends the browser away from the local server; Intuit also rejects an exchange whose `redirect_uri` differs from the authorize request.

## Fix

- `authenticate()` catches a failed refresh, clears the dead tokens, and re-runs `refreshAccessToken()`, which (having no token) starts the interactive flow and then exchanges the newly obtained refresh token.
- `startOAuthFlow()` constructs a dedicated `OAuthClient` pinned to `http://localhost:8000/callback` and uses it for both `authorizeUri` and `createToken`, so authorize and exchange always agree and always point at the server the flow actually runs.

## Tests

Adds the first behavioral tests for `QuickbooksClient` (`tests/unit/clients/quickbooks-client.auth.test.ts`), with `intuit-oauth`, `node-quickbooks`, `http`, `fs`, and `open` mocked:

- a working refresh token refreshes silently and never constructs a flow client;
- a rejected refresh falls back to the interactive flow, the flow client is pinned to the localhost redirect, the exchange goes through that same client, and the new refresh token is then used.

Note on coverage config: this file was previously invisible to the 100% global gate because no test ever imported it. The new per-path thresholds in `jest.config.js` reflect what the behavioral tests cover; Jest subtracts path-matched files from the global group, so the 100% gate is unchanged for everything else.

All 21 suites / 445 tests pass with `npm test`.