### PR TITLE
feat(create_payment): support reference number and multicurrency fields

### DIFF
--- a/src/handlers/create-quickbooks-payment.handler.ts
+++ b/src/handlers/create-quickbooks-payment.handler.ts
@@ -9,6 +9,9 @@ export interface CreatePaymentInput {
   deposit_to_account_ref?: string;
   txn_date?: string;
   private_note?: string;
+  payment_ref_num?: string;
+  currency_ref?: string;
+  exchange_rate?: number;
   line?: Array<{
     amount: number;
     linked_txn: Array<{
@@ -38,6 +41,15 @@ export async function createQuickbooksPayment(data: CreatePaymentInput): Promise
     }
     if (data.private_note) {
       paymentPayload.PrivateNote = data.private_note;
+    }
+    if (data.payment_ref_num) {
+      paymentPayload.PaymentRefNum = data.payment_ref_num;
+    }
+    if (data.currency_ref) {
+      paymentPayload.CurrencyRef = { value: data.currency_ref };
+    }
+    if (data.exchange_rate !== undefined) {
+      paymentPayload.ExchangeRate = data.exchange_rate;
     }
     if (data.line) {
       paymentPayload.Line = data.line.map((l) => ({

--- a/src/tools/create-payment.tool.ts
+++ b/src/tools/create-payment.tool.ts
@@ -22,6 +22,9 @@ const toolSchema = z.object({
   deposit_to_account_ref: z.string().optional().describe("Account to deposit to"),
   txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
   private_note: z.string().optional().describe("Private note"),
+  payment_ref_num: z.string().optional().describe("Reference no. for the payment, e.g. a bank transfer/transaction number (PaymentRefNum)"),
+  currency_ref: z.string().optional().describe("Reference to the currency (e.g. USD, GBP) in which all amounts on the payment are expressed. Required if multicurrency is enabled for the company (CurrencyRef)"),
+  exchange_rate: z.number().positive().optional().describe("The number of home-currency units it takes to equal one unit of the currency specified by currency_ref. Applicable if multicurrency is enabled for the company (ExchangeRate)"),
   line: z.array(lineSchema).optional().describe("Line items linking to invoices"),
 });
 

--- a/tests/unit/handlers/payment.handlers.test.ts
+++ b/tests/unit/handlers/payment.handlers.test.ts
@@ -70,6 +70,52 @@ describe('Payment Handlers', () => {
       expect(result.isError).toBe(false);
       expect(result.result).toEqual(mockPayment);
     });
+
+    it('should map reference number and multicurrency fields onto the QBO payload', async () => {
+      // Capture the payload the handler builds so we can assert the new
+      // PaymentRefNum / CurrencyRef / ExchangeRate fields are wired through —
+      // these previously had no schema entry and were silently dropped.
+      let capturedPayload: any = null;
+      (mockQuickBooksInstance.createPayment as jest.Mock).mockImplementation(
+        (payload: any, cb: any) => {
+          capturedPayload = payload;
+          cb(null, { Id: '123' });
+        }
+      );
+
+      const result = await createQuickbooksPayment({
+        customer_ref: 'cust-1',
+        total_amt: 100,
+        payment_ref_num: '755182592',
+        currency_ref: 'GBP',
+        exchange_rate: 1.17,
+      });
+
+      expect(result.isError).toBe(false);
+      // PaymentRefNum is a plain string ("Reference no." in the QBO UI).
+      expect(capturedPayload.PaymentRefNum).toBe('755182592');
+      // CurrencyRef must be wrapped in { value } like the other *Ref fields.
+      expect(capturedPayload.CurrencyRef).toEqual({ value: 'GBP' });
+      expect(capturedPayload.ExchangeRate).toBe(1.17);
+    });
+
+    it('should omit reference number and multicurrency fields when not provided', async () => {
+      // Backward compatibility: existing single-currency callers must not get
+      // any of the new keys injected into their payload.
+      let capturedPayload: any = null;
+      (mockQuickBooksInstance.createPayment as jest.Mock).mockImplementation(
+        (payload: any, cb: any) => {
+          capturedPayload = payload;
+          cb(null, { Id: '123' });
+        }
+      );
+
+      await createQuickbooksPayment({ customer_ref: 'cust-1', total_amt: 100 });
+
+      expect(capturedPayload).not.toHaveProperty('PaymentRefNum');
+      expect(capturedPayload).not.toHaveProperty('CurrencyRef');
+      expect(capturedPayload).not.toHaveProperty('ExchangeRate');
+    });
   });
 
   describe('getQuickbooksPayment', () => {


### PR DESCRIPTION
Closes #75

## Summary

`create_payment` currently has no way to set a payment's **Reference no.** or its **currency / exchange rate**. As a result:

- The bank **reference number** (e.g. a transfer/transaction number) can only be smuggled into `private_note` (the memo), where it's invisible/unusable as the "Reference no." for reconciliation.
- A **foreign-currency receipt** can't carry its FX rate. In practice this was observed to book the receipt at an incorrect home-currency value (see #75).

The QBO `Payment` entity supports all three fields, and `CurrencyRef`/`ExchangeRate` are already exposed elsewhere in this codebase (e.g. `search-bills.tool.ts`) — they were just never wired into payment creation.

## Changes

Add three optional fields to the `create_payment` tool schema and map them in the handler. Field text and designations below follow the [QBO Payment API reference](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/payment):

| Tool param        | QBO `Payment` field   | API designation | Doc description |
|-------------------|-----------------------|-----------------|-----------------|
| `payment_ref_num` | `PaymentRefNum`       | Optional        | The reference number for the payment received (max 21 chars). |
| `currency_ref`    | `CurrencyRef.value`   | Conditionally required | Reference to the currency in which all amounts on the transaction are expressed. Required if multicurrency is enabled for the company. |
| `exchange_rate`   | `ExchangeRate`        | Optional        | The number of home-currency units it takes to equal one unit of `CurrencyRef`. Applicable if multicurrency is enabled for the company. |

- All three params are **optional in the tool**, so the change is **backward-compatible**; existing single-currency callers are unaffected.
- `exchange_rate` uses `z.number().positive()` — matching the existing `.positive()` guard on `total_amt` in the same schema — to reject zero/negative rates at the boundary.

## Tests

Added to `tests/unit/handlers/payment.handlers.test.ts`, following the existing payload-capture pattern used in `company-attachable.handlers.test.ts`:

- Maps `PaymentRefNum` / `CurrencyRef.value` / `ExchangeRate` onto the QBO payload.
- Omits all three keys when not provided (backward compatibility).

`npm test` → **445 tests pass, coverage remains at 100%**.

## Out of scope

`create_sales_receipt` and `update_payment` have the identical gap; left for a follow-up to keep this change focused.