### PR TITLE
fix(auth): ignore duplicate OAuth callback to prevent token revocation

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -120,6 +120,14 @@ export class QuickbooksClient {
     });
 
     return new Promise((resolve, reject) => {
+      // Guard against duplicate /callback requests for the same authorization
+      // code. Browsers resolve `localhost` to both 127.0.0.1 and ::1, and the
+      // server binds dual-stack (`::`), so the redirect frequently lands twice.
+      // Exchanging a one-time auth code a second time trips Intuit's replay
+      // protection, which REVOKES the tokens issued by the first exchange
+      // (RFC 6749 §4.1.2). Only the first callback may exchange the code.
+      let codeExchangeStarted = false;
+
       // Create temporary server for OAuth callback
       const server = http.createServer(async (req, res) => {
         console.log(`[auth-server] ${req.method} ${req.url}`);
@@ -131,6 +139,17 @@ export class QuickbooksClient {
           res.end('Not Found. Waiting for QuickBooks OAuth callback at /callback');
           return;
         }
+
+        // A duplicate callback for the same code must NOT be exchanged again, or
+        // Intuit revokes the token minted by the first hit. `codeExchangeStarted`
+        // is set synchronously before the first `await`, so the second request's
+        // handler observes it and bails out here.
+        if (codeExchangeStarted) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body style="font-family:Arial;text-align:center;margin-top:20vh"><h2>Processing… you can close this window.</h2></body></html>');
+          return;
+        }
+        codeExchangeStarted = true;
 
         {
           try {


### PR DESCRIPTION
Closes #78

## Summary

`npm run auth` intermittently produces a refresh token that is **already invalid** by the time it's first used, forcing users into an endless re-auth loop. The root cause is that the local OAuth callback server exchanges the authorization code on **every** `GET /callback` request. Because browsers commonly fire that callback twice (`localhost` resolves to both IPv4 and IPv6, and the server binds dual-stack), the one-time code gets exchanged twice, and Intuit's replay protection **revokes the tokens issued by the first exchange** (RFC 6749 §4.1.2). This PR makes the callback handler exchange the code exactly once and acknowledge any duplicate without re-exchanging.

## Symptoms

- `npm run auth` prints `✓ Successfully authenticated`, but the next API call (or `refreshUsingToken`) fails with:
  ```
  400 {"error":"invalid_grant","error_description":"Incorrect or invalid refresh token"}
  ```
- The MCP server then falls back to interactive OAuth on every request, so every tool returns `Request failed with status code 400`.
- Re-running `npm run auth` reproduces the same dead-token result.

## Root cause

`startOAuthFlow()` calls `flowClient.createToken(req.url)` for any path starting with `/callback`, with no guard against repeats. The callback lands **twice** in practice — the server binds dual-stack (`Listening on :::8000`) and `localhost` resolves to both `127.0.0.1` and `::1`, so the redirect is delivered twice with the **same** `code`:

```
[auth-server] GET /callback?code=XAB...&state=testState&realmId=93414573...
[auth-server] GET /callback?code=XAB...&state=testState&realmId=93414573...
```

Per RFC 6749 §4.1.2, reusing an authorization code SHOULD revoke all tokens already issued from it. Intuit enforces this: the first `createToken` mints a refresh token; the second reuses the code and Intuit revokes the just-issued token. The result is timing-dependent, which is what makes it look intermittent and hard to diagnose.

## Fix

Add a one-shot `codeExchangeStarted` guard so only the first `/callback` exchanges the code; duplicates get a friendly `200` without calling `createToken` again. The flag is set synchronously before the first `await`, so the second request's handler reliably observes it.

## Verification

- **Before:** `npm run auth` → authorize → the saved refresh token returns `invalid_grant` on first use. Log shows two identical `/callback` lines.
- **After:** `npm run auth` → log still shows two `/callback` hits, but only one `createToken` runs, authentication succeeds, and the token exchanges cleanly:
  ```
  SANDBOX: SUCCESS -> CompanyName="Sandbox Company US ####"  Country=US
  ```

## Files changed

- `src/clients/quickbooks-client.ts` — add `codeExchangeStarted` guard in `startOAuthFlow()`'s callback handler.

## Optional follow-up

Binding the callback server to a single loopback address (`server.listen(port, '127.0.0.1', ...)`) and using that host in the redirect URI would prevent the dual-stack double-delivery at the source. The guard here fixes the symptom regardless of why the duplicate arrives, so it's the minimal, robust change.