### PR TITLE
fix(account): support re-parenting in update_account (ParentRef + sparse)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,16 @@ export default {
       lines: 70,
       statements: 70,
     },
+    // update_account's normalizePatch carries a scalar field-type-map switch
+    // whose `default` arm is unreachable (the map only ever maps to
+    // string/boolean/number). The behavioral tests cover every reachable path;
+    // this floor accounts for that one dead arm.
+    './src/handlers/update-quickbooks-account.handler.ts': {
+      branches: 89,
+      functions: 100,
+      lines: 97,
+      statements: 95,
+    },
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/src/handlers/update-quickbooks-account.handler.ts
+++ b/src/handlers/update-quickbooks-account.handler.ts
@@ -7,7 +7,12 @@ export interface UpdateAccountInput {
   patch: Record<string, any>;
 }
 
-// Reuse the same field-type map for normalization
+// Scalar field-type map for normalization. NOTE: ParentRef is intentionally
+// NOT listed here. ParentRef is a QBO nested reference object ({ value: "<id>" }),
+// not a scalar. Running it through String() yields the literal "[object Object]",
+// which QBO rejects with error code 2010 ("failed to parse json object; a
+// property specified is unsupported or invalid") — making it impossible to
+// re-parent (nest) an account. ParentRef is handled separately below.
 const updateFieldTypeMap: Record<string, "string" | "boolean" | "number"> = {
   Name: "string",
   AccountType: "string",
@@ -16,14 +21,29 @@ const updateFieldTypeMap: Record<string, "string" | "boolean" | "number"> = {
   Classification: "string",
   Active: "boolean",
   SubAccount: "boolean",
-  ParentRef: "string",
   CurrentBalance: "number",
 };
+
+// Coerce a caller-supplied parent reference into the QBO reference-object shape
+// { value: "<id>" }. Accepts { value: "5" } (canonical), "5" (bare string), or
+// 5 (number).
+function normalizeParentRef(value: any): { value: string } | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "object" && value.value !== undefined) {
+    return { value: String(value.value) };
+  }
+  return { value: String(value) };
+}
 
 function normalizePatch(patch: Record<string, any>): Record<string, any> {
   const normalized: Record<string, any> = {};
   Object.entries(patch).forEach(([key, value]) => {
     if (value === undefined) return;
+    if (key === "ParentRef") {
+      const ref = normalizeParentRef(value);
+      if (ref) normalized[key] = ref;
+      return;
+    }
     const expectedType = updateFieldTypeMap[key];
     if (!expectedType) {
       normalized[key] = value;
@@ -55,7 +75,13 @@ export async function updateQuickbooksAccount({ account_id, patch }: UpdateAccou
 
     // When merging existing with patch, normalize the patch first.
     const normalizedPatch = normalizePatch(patch);
-    const payload = { ...existing, ...normalizedPatch, Id: account_id, sparse: true };
+    // QBO's Account entity does NOT support sparse updates: a sparse:true body
+    // returns error 2020 ("Required parameter Name is missing"). We perform a
+    // full-object update by spreading the freshly-fetched existing account
+    // (which carries Name/AccountType/AccountSubType/Classification/SyncToken)
+    // and overlaying the caller's patch. sparse is intentionally not set.
+    const payload = { ...existing, ...normalizedPatch, Id: account_id };
+    delete (payload as any).sparse;
 
     return new Promise((resolve) => {
       (quickbooks as any).updateAccount(payload, (err: any, account: any) => {

--- a/tests/unit/handlers/account-reparent.handlers.test.ts
+++ b/tests/unit/handlers/account-reparent.handlers.test.ts
@@ -1,0 +1,127 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+const { updateQuickbooksAccount } = await import('../../../src/handlers/update-quickbooks-account.handler');
+
+describe('updateQuickbooksAccount re-parenting', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  it('sends ParentRef as a reference object (not "[object Object]") and omits sparse', async () => {
+    const existing = {
+      Id: '50',
+      Name: 'Child Account',
+      AccountType: 'Income',
+      AccountSubType: 'ServiceFeeIncome',
+      Classification: 'Revenue',
+      SubAccount: false,
+      SyncToken: '0',
+      sparse: false,
+    };
+    let captured: any;
+    mockQuickBooksInstance.getAccount.mockImplementation((_id: any, cb: any) => cb(null, existing));
+    mockQuickBooksInstance.updateAccount.mockImplementation((payload: any, cb: any) => {
+      captured = payload;
+      cb(null, { ...existing, SubAccount: true, ParentRef: { value: '40' }, SyncToken: '1' });
+    });
+
+    const result = await updateQuickbooksAccount({
+      account_id: '50',
+      patch: { SubAccount: true, ParentRef: { value: '40' } },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(captured.ParentRef).toEqual({ value: '40' });
+    expect(typeof captured.ParentRef).toBe('object');
+    expect(captured.SubAccount).toBe(true);
+    expect(captured.sparse).toBeUndefined();
+    // Full-object update carries existing Name/type through (required by QBO)
+    expect(captured.Name).toBe('Child Account');
+    expect(captured.AccountType).toBe('Income');
+  });
+
+  it('coerces a bare-string ParentRef into the { value } object shape', async () => {
+    const existing = { Id: '50', Name: 'X', AccountType: 'Income', SyncToken: '0' };
+    let captured: any;
+    mockQuickBooksInstance.getAccount.mockImplementation((_id: any, cb: any) => cb(null, existing));
+    mockQuickBooksInstance.updateAccount.mockImplementation((payload: any, cb: any) => {
+      captured = payload;
+      cb(null, existing);
+    });
+
+    await updateQuickbooksAccount({ account_id: '50', patch: { SubAccount: true, ParentRef: '40' } });
+
+    expect(captured.ParentRef).toEqual({ value: '40' });
+  });
+
+  it('normalizes scalar field types and passes unknown keys through', async () => {
+    const existing = { Id: '50', Name: 'X', SyncToken: '0' };
+    let captured: any;
+    mockQuickBooksInstance.getAccount.mockImplementation((_id: any, cb: any) => cb(null, existing));
+    mockQuickBooksInstance.updateAccount.mockImplementation((payload: any, cb: any) => {
+      captured = payload;
+      cb(null, existing);
+    });
+
+    await updateQuickbooksAccount({
+      account_id: '50',
+      patch: {
+        Name: 123,               // number -> string
+        Active: 'true',          // string -> boolean true
+        SubAccount: false,       // already boolean
+        CurrentBalance: '42',    // string -> number
+        Description: 7,          // already... number coerced via string arm
+        AcctNum: '4000',         // unknown -> passthrough
+        Skipped: undefined,      // undefined -> skipped
+      },
+    });
+
+    expect(captured.Name).toBe('123');
+    expect(captured.Active).toBe(true);
+    expect(captured.SubAccount).toBe(false);
+    expect(captured.CurrentBalance).toBe(42);
+    expect(captured.AcctNum).toBe('4000');
+    expect('Skipped' in captured).toBe(false);
+  });
+
+  it('coerces non-"true" string Active to false and already-number balance', async () => {
+    const existing = { Id: '50', Name: 'X', SyncToken: '0' };
+    let captured: any;
+    mockQuickBooksInstance.getAccount.mockImplementation((_id: any, cb: any) => cb(null, existing));
+    mockQuickBooksInstance.updateAccount.mockImplementation((payload: any, cb: any) => {
+      captured = payload;
+      cb(null, existing);
+    });
+
+    await updateQuickbooksAccount({ account_id: '50', patch: { Active: 'no', CurrentBalance: 100 } });
+
+    expect(captured.Active).toBe(false);
+    expect(captured.CurrentBalance).toBe(100);
+  });
+
+  it('returns isError when getAccount fails', async () => {
+    mockQuickBooksInstance.getAccount.mockImplementation((_id: any, cb: any) => cb(new Error('not found'), null));
+    const result = await updateQuickbooksAccount({ account_id: '999', patch: { Name: 'Y' } });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError when updateAccount fails', async () => {
+    const existing = { Id: '50', Name: 'X', SyncToken: '0' };
+    mockQuickBooksInstance.getAccount.mockImplementation((_id: any, cb: any) => cb(null, existing));
+    mockQuickBooksInstance.updateAccount.mockImplementation((_p: any, cb: any) => cb(new Error('stale'), null));
+    const result = await updateQuickbooksAccount({ account_id: '50', patch: { Name: 'Y' } });
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns isError when the client cannot be obtained', async () => {
+    mockQuickbooksClientClass.getInstance.mockRejectedValueOnce(new Error('no client') as never);
+    const result = await updateQuickbooksAccount({ account_id: '50', patch: { Name: 'Y' } });
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`update_account` cannot move an account under a new parent (turn a top-level account into a sub-account, or re-parent an existing one). Two bugs combine:

1. **`ParentRef` is stringified.** `normalizePatch` runs every mapped field through a scalar field-type map in which `ParentRef` is typed `"string"`. When a caller passes the correct QBO nested reference object `ParentRef: { value: "5" }`, it is run through `String(...)` and becomes the literal `"[object Object]"`. QBO rejects this with:

   ```
   code 2010 — "failed to parse json object; a property specified is unsupported or invalid"
   ```

   Passing a bare-string `ParentRef: "5"` also fails, because QBO requires the `{ value }` object shape.

2. **`sparse: true` on Account.** The request sets `sparse: true`, but QBO's Account entity does not support sparse updates — a sparse body returns:

   ```
   code 2020 — "Required parameter Name is missing in the request"
   ```

   (Account differs from Invoice/Bill/JournalEntry here.) The handler already spreads the freshly-fetched existing account, so the full object is present; dropping `sparse` makes it a correct full-object update.

## Fix

- Remove `ParentRef` from the scalar field-type map.
- Add a small `normalizeParentRef()` that coerces `{ value }`, a bare string, or a number into the canonical `{ value: "<id>" }` reference object.
- Stop sending `sparse: true` on account updates (full-object update via the already-fetched existing account).

## Repro (before this PR)

1. Have a top-level account, e.g. id `50`, and a parent account id `40` of the **same `AccountType`** (QBO requires the sub-account's type to match its parent).
2. Call `update_account` with `account_id: "50"`, `patch: { SubAccount: true, ParentRef: { value: "40" } }`.
3. Observe error code `2010`.

After this PR the same call succeeds and the account's `FullyQualifiedName` reflects the new hierarchy (`Parent:Child`).

## Tests

Adds `tests/unit/handlers/account-reparent.handlers.test.ts` covering: re-parent sends `ParentRef` as an object (regression guard for `"[object Object]"`), `sparse` is never set, bare-string `ParentRef` coercion, scalar field coercion, and error propagation. A per-file coverage floor accounts for one structurally-unreachable `default` switch arm (matching the existing precedent for `quickbooks-client.ts`).