### PR TITLE
fix: use configured redirect_uri for oauth flow instead of hardcoded localhost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,32 @@
-.qodo
+# Dependencies
+node_modules/
 
-node_modules
-dist
-coverage
+# Build & Coverage
+dist/
+coverage/
 
+# Environment & Sensitive Files
 .env
 .env.local
 .env.*.local
 tokens.json
-
-start.cmd
-
-# Local capture output (may contain real account balances)
 capture-*.txt
 
+# OS & System Files
+.DS_Store
+Thumbs.db
+Desktop.ini
+ehthumbs.db
+*.lnk
+
+# Editor & IDE Metadata
+.vscode/
+.idea/
+.qodo
+*.swp
+*.swo
+*~
+
+# Backups & Scripts
+start.cmd
+*.backup_*

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -116,7 +116,7 @@ export class QuickbooksClient {
       clientId: this.clientId,
       clientSecret: this.clientSecret,
       environment: this.environment,
-      redirectUri: `http://localhost:${port}/callback`,
+      redirectUri: this.redirectUri,
     });
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Problem
When attempting to complete the OAuth 2.0 handshake for a production QuickBooks Online environment, the authentication flow fails because Intuit's Developer Portal rejects non-secure HTTP or `localhost` redirect URIs in production mode. 

In `src/clients/quickbooks-client.ts`, the `flowClient` inside `startOAuthFlow()` was hardcoded to use `http://localhost:${port}/callback` as the redirect URI, rendering the `QUICKBOOKS_REDIRECT_URI` environment variable ineffective during the authentication step.

### Solution
This PR updates the `flowClient` configuration in `startOAuthFlow` to use `this.redirectUri` (which is loaded from the `QUICKBOOKS_REDIRECT_URI` environment variable) instead of the hardcoded localhost path. 

This enables developers to complete the OAuth handshake for production accounts using secure tunneling tools (like `ngrok`) or a reverse proxy.

### Verification
- Ran `npm run build` to verify the TypeScript project compiles successfully without type errors.
- Verified that configuring a secure `ngrok` redirect URI (e.g., `https://<subdomain>.ngrok-free.app/callback`) successfully routes the production handshake back to the local auth server, allowing the tokens to save correctly.
