### PR TITLE
Add customer_memo, per-line service_date, sales_term_ref, bill_email to create_invoice

### DIFF
--- a/src/handlers/create-quickbooks-invoice.handler.ts
+++ b/src/handlers/create-quickbooks-invoice.handler.ts
@@ -10,6 +10,7 @@ export interface CreateInvoiceInput {
     unit_price: number;
     description?: string;
     tax_code_ref?: string; // TaxCode id (non-US) or TAX/NON (US)
+    service_date?: string; // YYYY-MM-DD, per-line ServiceDate
   }>;
   doc_number?: string;
   txn_date?: string; // YYYY-MM-DD
@@ -18,6 +19,9 @@ export interface CreateInvoiceInput {
     txn_type: string;
   }>;
   global_tax_calculation?: "TaxExcluded" | "TaxInclusive" | "NotApplicable";
+  customer_memo?: string; // CustomerMemo (customer-facing message)
+  sales_term_ref?: string; // SalesTerm id; falls back to customer default
+  bill_email?: string; // BillEmail address; falls back to customer default
 }
 
 // Primitive field type map (based on Quickbooks Invoice entity reference docs)
@@ -75,6 +79,7 @@ export async function createQuickbooksInvoice(data: CreateInvoiceInput): Promise
           Qty: l.qty,
           UnitPrice: l.unit_price,
           TaxCodeRef: l.tax_code_ref ? { value: l.tax_code_ref } : undefined,
+          ServiceDate: l.service_date || undefined,
         },
       })),
       DocNumber: data.doc_number,
@@ -85,6 +90,9 @@ export async function createQuickbooksInvoice(data: CreateInvoiceInput): Promise
           TxnType: lt.txn_type,
         })),
       }),
+      ...(data.customer_memo && { CustomerMemo: { value: data.customer_memo } }),
+      ...(data.sales_term_ref && { SalesTermRef: { value: data.sales_term_ref } }),
+      ...(data.bill_email && { BillEmail: { Address: data.bill_email } }),
     };
 
     if (data.global_tax_calculation) {

--- a/src/tools/create-invoice.tool.ts
+++ b/src/tools/create-invoice.tool.ts
@@ -17,6 +17,11 @@ const lineItemSchema = z.object({
     .describe(
       "Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"
     ),
+  service_date: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Date the service was performed (YYYY-MM-DD), shown per line on the invoice"),
 });
 
 const linkedTxnSchema = z.object({
@@ -34,6 +39,21 @@ const toolSchema = z.object({
     .enum(["TaxExcluded", "TaxInclusive", "NotApplicable"])
     .optional()
     .describe("Non-US companies only: whether unit prices exclude or include tax"),
+  customer_memo: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Customer-facing message printed on the invoice (QBO CustomerMemo)"),
+  sales_term_ref: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Sales term Id (use search_terms), e.g. Net 30. Falls back to the customer default if omitted"),
+  bill_email: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Billing email address (QBO BillEmail). Falls back to the customer default if omitted"),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/tests/unit/handlers/invoice-template-fields.handlers.test.ts
+++ b/tests/unit/handlers/invoice-template-fields.handlers.test.ts
@@ -1,0 +1,70 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+const { createQuickbooksInvoice } = await import('../../../src/handlers/create-quickbooks-invoice.handler');
+
+describe('Create Invoice Handler - template fields', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  it('should map customer_memo, sales_term_ref and bill_email to QBO properties', async () => {
+    const mockInvoice = { Id: '801', TotalAmt: 100 };
+    mockQuickBooksInstance.createInvoice.mockImplementation((_payload: any, cb: any) => cb(null, mockInvoice));
+
+    const result = await createQuickbooksInvoice({
+      customer_ref: '42',
+      line_items: [{ item_ref: '1', qty: 1, unit_price: 100 }],
+      customer_memo: 'Interest of 2% per month applies to overdue invoices.',
+      sales_term_ref: '3',
+      bill_email: 'billing@example.com',
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockQuickBooksInstance.createInvoice.mock.calls[0][0] as any;
+    expect(payload.CustomerMemo).toEqual({ value: 'Interest of 2% per month applies to overdue invoices.' });
+    expect(payload.SalesTermRef).toEqual({ value: '3' });
+    expect(payload.BillEmail).toEqual({ Address: 'billing@example.com' });
+  });
+
+  it('should map per-line service_date to SalesItemLineDetail.ServiceDate', async () => {
+    const mockInvoice = { Id: '802', TotalAmt: 200 };
+    mockQuickBooksInstance.createInvoice.mockImplementation((_payload: any, cb: any) => cb(null, mockInvoice));
+
+    const result = await createQuickbooksInvoice({
+      customer_ref: '42',
+      line_items: [
+        { item_ref: '1', qty: 1, unit_price: 100, service_date: '2026-06-16' },
+        { item_ref: '1', qty: 1, unit_price: 100, service_date: '2026-06-18' },
+      ],
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockQuickBooksInstance.createInvoice.mock.calls[0][0] as any;
+    expect(payload.Line[0].SalesItemLineDetail.ServiceDate).toBe('2026-06-16');
+    expect(payload.Line[1].SalesItemLineDetail.ServiceDate).toBe('2026-06-18');
+  });
+
+  it('should omit the template fields when not provided', async () => {
+    const mockInvoice = { Id: '803', TotalAmt: 100 };
+    mockQuickBooksInstance.createInvoice.mockImplementation((_payload: any, cb: any) => cb(null, mockInvoice));
+
+    const result = await createQuickbooksInvoice({
+      customer_ref: '42',
+      line_items: [{ item_ref: '1', qty: 1, unit_price: 100 }],
+    });
+
+    expect(result.isError).toBe(false);
+    const payload = mockQuickBooksInstance.createInvoice.mock.calls[0][0] as any;
+    expect(payload.CustomerMemo).toBeUndefined();
+    expect(payload.SalesTermRef).toBeUndefined();
+    expect(payload.BillEmail).toBeUndefined();
+    expect(payload.Line[0].SalesItemLineDetail.ServiceDate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`create_invoice` maps `item_ref`/`qty`/`unit_price`/`description`/`tax_code_ref` + `linked_txn`, but not `CustomerMemo`, per-line `ServiceDate`, `SalesTermRef`, or `BillEmail`. The QuickBooks UI pre-fills these from the customer when invoicing, but the v3 API does not — so invoices created through this tool silently omit them (no customer message, no service date on lines, no explicit term/email). This adds them as optional fields.

## Changes

- `create-invoice.tool.ts`: add optional `customer_memo`, `sales_term_ref`, `bill_email` (top-level) and `service_date` (per line item) to the Zod schema.
- `create-quickbooks-invoice.handler.ts`: map them to `CustomerMemo.value`, `SalesTermRef.value`, `BillEmail.Address`, and `SalesItemLineDetail.ServiceDate`.
- Tests: new `invoice-template-fields.handlers.test.ts` (maps the four fields, omits them when not provided). Full suite green (460 tests), invoice handler at 100% coverage.

## Compatibility

All fields optional; omitting them preserves current behaviour. When set, `sales_term_ref`/`bill_email` still fall back to the customer default if omitted.

Closes #91
