### PR TITLE
feat(attachable): add file_path upload to create_attachable + shared MIME helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the QuickBooks Online MCP Server are documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`create_attachable` now accepts a `file_path`.** When provided, the server
+  reads the file directly from its own disk, streams the bytes to QBO's
+  `/upload` endpoint, and infers `content_type` from the extension and
+  `file_name` from the basename when those are omitted. This avoids routing
+  large binaries through the model context as `base64_content` (which remains
+  supported and is now mutually exclusive with `file_path`). A leading `~/` in
+  the path is expanded; files are size-checked against QBO's 100 MB cap from
+  filesystem metadata before being read into memory.
+- **`update_attachable` gains `content_type` and a convenience `file_path`.**
+  `file_path` derives `file_name`/`content_type` metadata from the path (no disk
+  read). Note: QBO's Attachable update is metadata-only and cannot replace the
+  stored file bytes — to swap the file, create a new attachable and delete the
+  old one.
+
+### Internal
+
+- Extracted the accepted-MIME set and a new extension→MIME map into
+  `src/helpers/attachable-mime.ts`, shared by the create/update attachable
+  handlers.
+
 ## [0.0.1] - 2024-01-13
 
 ### Summary

--- a/src/handlers/create-quickbooks-attachable.handler.ts
+++ b/src/handlers/create-quickbooks-attachable.handler.ts
@@ -1,39 +1,15 @@
 import https from "https";
+import fs from "fs";
+import os from "os";
+import path from "path";
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
-
-// QBO Attachable upload — file types accepted by the QBO /upload endpoint.
-// Source: developer.intuit.com Attachable API reference (16 unique MIME types
-// covering 17 documented file extensions; .ai and .eps both map to
-// application/postscript).
-//
-// Two entries deviate from RFC standards but match QBO's documented spec
-// literally — keep them so payloads round-trip without QBO rejecting them:
-//   - image/jpg  (RFC standard is image/jpeg; QBO accepts both)
-//   - image/tif  (RFC standard is image/tiff; QBO accepts both)
-//
-// One entry is corrected from a documentation typo:
-//   - QBO docs list application/vnd/ms-excel for .xls. A forward slash in a
-//     MIME subtype is invalid per RFC 6838. We use the correct form here.
-const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
-  "application/postscript",          // .ai, .eps
-  "text/csv",                        // .csv
-  "application/msword",              // .doc
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
-  "image/gif",                       // .gif
-  "image/jpeg",                      // .jpeg
-  "image/jpg",                       // .jpg
-  "application/vnd.oasis.opendocument.spreadsheet", // .ods
-  "application/pdf",                 // .pdf
-  "image/png",                       // .png
-  "text/rtf",                        // .rtf
-  "image/tif",                       // .tif
-  "text/plain",                      // .txt
-  "application/vnd.ms-excel",        // .xls
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
-  "text/xml",                        // .xml
-]);
+import {
+  ALLOWED_UPLOAD_CONTENT_TYPES,
+  allowedContentTypesList,
+  inferContentTypeFromExtension,
+} from "../helpers/attachable-mime.js";
 
 // QBO documents a 100 MB per-request cap on /upload. We enforce client-side
 // BEFORE allocating Buffer.from(base64) so an unbounded base64 string cannot
@@ -48,7 +24,8 @@ function approximateDecodedSize(base64: string): number {
 }
 
 export interface CreateAttachableInput {
-  file_name: string;
+  file_name?: string;
+  file_path?: string;
   note?: string;
   category?: string;
   content_type?: string;
@@ -62,6 +39,21 @@ export interface CreateAttachableInput {
 
 function sanitizeFilename(name: string): string {
   return name.replace(/[\r\n"\\]/g, "_");
+}
+
+// Expand a leading "~"/"~/" to the user's home directory, then resolve to an
+// absolute path. The server is a local stdio process launched by a host (Claude
+// Desktop/Code) whose working directory is not guaranteed, so relative paths are
+// resolved against wherever that process was started — callers should prefer
+// absolute paths.
+function resolveUserPath(inputPath: string): string {
+  let expanded = inputPath;
+  if (expanded === "~") {
+    expanded = os.homedir();
+  } else if (expanded.startsWith("~/")) {
+    expanded = path.join(os.homedir(), expanded.slice(2));
+  }
+  return path.resolve(expanded);
 }
 
 // Map a status code to a user-safe error message. The raw QBO response body
@@ -166,11 +158,120 @@ export async function createQuickbooksAttachable(
   data: CreateAttachableInput
 ): Promise<ToolResponse<any>> {
   try {
+    if (data.file_path && data.base64_content) {
+      return {
+        result: null,
+        isError: true,
+        error: "Provide either file_path or base64_content, not both.",
+      };
+    }
+
+    // Resolve the binary source (if any) into a Buffer. Two ways to supply
+    // bytes: file_path (server reads from disk — preferred for anything beyond
+    // a few KB) or base64_content (bytes inlined by the caller). When neither is
+    // given we fall through to the metadata-only path.
+    //
+    // file_name and content_type may be derived from file_path when the caller
+    // omits them, so track resolved values separately from the raw input.
+    let fileBuffer: Buffer | undefined;
+    let resolvedFileName = data.file_name;
+    let resolvedContentType = data.content_type;
+
+    // ── Source A: read the file from disk (file_path) ─────────────────────
+    if (data.file_path) {
+      const resolvedPath = resolveUserPath(data.file_path);
+
+      let stats: fs.Stats;
+      try {
+        stats = await fs.promises.stat(resolvedPath);
+      } catch (err: any) {
+        /* istanbul ignore next — Node fs errors always carry a .code; the
+           .message / "unknown error" fallbacks guard a non-standard throw. */
+        const detail = err?.code ?? err?.message ?? "unknown error";
+        return {
+          result: null,
+          isError: true,
+          error: `Cannot read file at "${resolvedPath}": ${detail}.`,
+        };
+      }
+      if (!stats.isFile()) {
+        return {
+          result: null,
+          isError: true,
+          error: `Path "${resolvedPath}" is not a regular file.`,
+        };
+      }
+      if (stats.size === 0) {
+        return {
+          result: null,
+          isError: true,
+          error: `File "${resolvedPath}" is empty (0 bytes).`,
+        };
+      }
+      // Enforce the size cap from the filesystem metadata, BEFORE reading the
+      // whole file into memory.
+      if (stats.size > MAX_UPLOAD_BYTES) {
+        return {
+          result: null,
+          isError: true,
+          error: `File too large: ${stats.size} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+        };
+      }
+
+      resolvedFileName = resolvedFileName ?? path.basename(resolvedPath);
+      if (!resolvedContentType) {
+        resolvedContentType = inferContentTypeFromExtension(resolvedPath);
+        if (!resolvedContentType) {
+          return {
+            result: null,
+            isError: true,
+            error: `Could not infer content_type from extension "${path.extname(resolvedPath) || "(none)"}" of "${resolvedPath}". Pass content_type explicitly. Allowed: ${allowedContentTypesList()}`,
+          };
+        }
+      }
+
+      fileBuffer = await fs.promises.readFile(resolvedPath);
+    } else if (data.base64_content) {
+      // ── Source B: bytes inlined as base64 ───────────────────────────────
+      // Enforce size cap BEFORE decoding to a Buffer.
+      const approxSize = approximateDecodedSize(data.base64_content);
+      if (approxSize > MAX_UPLOAD_BYTES) {
+        return {
+          result: null,
+          isError: true,
+          error: `File too large: approximately ${approxSize} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+        };
+      }
+
+      fileBuffer = Buffer.from(data.base64_content, "base64");
+
+      /* istanbul ignore next — defensive: the approxSize check above already
+         rejects oversized input; this guards only the malformed-base64 edge
+         case where decoded length unexpectedly exceeds the approximation. */
+      if (fileBuffer.length > MAX_UPLOAD_BYTES) {
+        return {
+          result: null,
+          isError: true,
+          error: `File too large: ${fileBuffer.length} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+        };
+      }
+    }
+
+    // QBO requires a FileName on every Attachable. It's optional in the input
+    // only because file_path can supply it.
+    if (!resolvedFileName) {
+      return {
+        result: null,
+        isError: true,
+        error: "file_name is required (or provide file_path to derive it from the file's basename).",
+      };
+    }
+
     // Build payload — same shape whether or not we're uploading binary content.
-    const payload: Record<string, unknown> = { FileName: data.file_name };
+    const payload: Record<string, unknown> = { FileName: resolvedFileName };
     if (data.note) payload.Note = data.note;
     if (data.category) payload.Category = data.category;
-    if (data.content_type) payload.ContentType = data.content_type;
+    if (resolvedContentType) payload.ContentType = resolvedContentType;
     if (data.attachable_ref) {
       const entityRef: Record<string, unknown> = {
         EntityRef: {
@@ -184,37 +285,14 @@ export async function createQuickbooksAttachable(
       payload.AttachableRef = [entityRef];
     }
 
-    // ── Binary upload path ────────────────────────────────────────────────
-    if (data.base64_content) {
-      const effectiveContentType = data.content_type ?? "application/octet-stream";
+    // ── Binary upload path (file_path or base64_content) ──────────────────
+    if (fileBuffer) {
+      const effectiveContentType = resolvedContentType ?? "application/octet-stream";
       if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(effectiveContentType)) {
         return {
           result: null,
           isError: true,
-          error: `Unsupported content_type "${effectiveContentType}". Allowed: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].sort().join(", ")}`,
-        };
-      }
-
-      // Enforce size cap BEFORE decoding to a Buffer.
-      const approxSize = approximateDecodedSize(data.base64_content);
-      if (approxSize > MAX_UPLOAD_BYTES) {
-        return {
-          result: null,
-          isError: true,
-          error: `File too large: approximately ${approxSize} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
-        };
-      }
-
-      const fileBuffer = Buffer.from(data.base64_content, "base64");
-
-      /* istanbul ignore next — defensive: the approxSize check above already
-         rejects oversized input; this guards only the malformed-base64 edge
-         case where decoded length unexpectedly exceeds the approximation. */
-      if (fileBuffer.length > MAX_UPLOAD_BYTES) {
-        return {
-          result: null,
-          isError: true,
-          error: `File too large: ${fileBuffer.length} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+          error: `Unsupported content_type "${effectiveContentType}". Allowed: ${allowedContentTypesList()}`,
         };
       }
 

--- a/src/handlers/update-quickbooks-attachable.handler.ts
+++ b/src/handlers/update-quickbooks-attachable.handler.ts
@@ -1,20 +1,37 @@
+import path from "path";
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { inferContentTypeFromExtension } from "../helpers/attachable-mime.js";
 
 export interface UpdateAttachableInput {
   id: string;
   sync_token: string;
   file_name?: string;
+  content_type?: string;
   note?: string;
   category?: string;
+  file_path?: string;
 }
 
 export async function updateQuickbooksAttachable(data: UpdateAttachableInput): Promise<ToolResponse<any>> {
   try {
+    // NOTE: QBO's Attachable update is metadata-only — it cannot replace the
+    // stored file bytes. file_path is a convenience that only derives the
+    // FileName/ContentType metadata from the path (no disk read, no re-upload).
+    // To attach a different/corrected file, create a new attachable
+    // (create_attachable with file_path) and delete the old one.
+    let fileName = data.file_name;
+    let contentType = data.content_type;
+    if (data.file_path) {
+      if (!fileName) fileName = path.basename(data.file_path);
+      if (!contentType) contentType = inferContentTypeFromExtension(data.file_path);
+    }
+
     const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
-    if (data.file_name) payload.FileName = data.file_name;
+    if (fileName) payload.FileName = fileName;
+    if (contentType) payload.ContentType = contentType;
     if (data.note) payload.Note = data.note;
     if (data.category) payload.Category = data.category;
 

--- a/src/helpers/attachable-mime.ts
+++ b/src/helpers/attachable-mime.ts
@@ -1,0 +1,77 @@
+import path from "path";
+
+// Shared MIME-type knowledge for the QBO Attachable /upload endpoint. Used by
+// both the create and update attachable handlers so the accepted-type list and
+// the extension→type mapping live in exactly one place.
+//
+// Source: developer.intuit.com Attachable API reference (16 unique MIME types
+// covering 17 documented file extensions; .ai and .eps both map to
+// application/postscript).
+//
+// Two entries deviate from RFC standards but match QBO's documented spec
+// literally — keep them so payloads round-trip without QBO rejecting them:
+//   - image/jpg  (RFC standard is image/jpeg; QBO accepts both)
+//   - image/tif  (RFC standard is image/tiff; QBO accepts both)
+//
+// One entry is corrected from a documentation typo:
+//   - QBO docs list application/vnd/ms-excel for .xls. A forward slash in a
+//     MIME subtype is invalid per RFC 6838. We use the correct form here.
+export const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
+  "application/postscript",          // .ai, .eps
+  "text/csv",                        // .csv
+  "application/msword",              // .doc
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+  "image/gif",                       // .gif
+  "image/jpeg",                      // .jpeg
+  "image/jpg",                       // .jpg
+  "application/vnd.oasis.opendocument.spreadsheet", // .ods
+  "application/pdf",                 // .pdf
+  "image/png",                       // .png
+  "text/rtf",                        // .rtf
+  "image/tif",                       // .tif
+  "text/plain",                      // .txt
+  "application/vnd.ms-excel",        // .xls
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+  "text/xml",                        // .xml
+]);
+
+// Map a lowercase file extension (including the leading dot) to the QBO-accepted
+// MIME type. Lets callers pass a file_path without also specifying content_type.
+// Every value here is a member of ALLOWED_UPLOAD_CONTENT_TYPES above. .jpg maps
+// to image/jpeg (the RFC-standard form; QBO also accepts image/jpg) and .tiff is
+// included alongside .tif for convenience.
+export const EXTENSION_TO_CONTENT_TYPE: Record<string, string> = {
+  ".ai": "application/postscript",
+  ".eps": "application/postscript",
+  ".csv": "text/csv",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".ods": "application/vnd.oasis.opendocument.spreadsheet",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".rtf": "text/rtf",
+  ".tif": "image/tif",
+  ".tiff": "image/tif",
+  ".txt": "text/plain",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".xml": "text/xml",
+};
+
+// Comma-separated, sorted list of accepted content types — for error messages.
+export function allowedContentTypesList(): string {
+  return [...ALLOWED_UPLOAD_CONTENT_TYPES].sort().join(", ");
+}
+
+// Infer a QBO-accepted content type from a file name or path's extension.
+// Returns undefined when the extension is absent or not recognized. Uses
+// path.extname so a dot in a parent directory name (e.g. "/a.b/file") does not
+// get mistaken for the file's extension, and dotfiles (".env") yield "".
+export function inferContentTypeFromExtension(fileNameOrPath: string): string | undefined {
+  const ext = path.extname(fileNameOrPath).toLowerCase();
+  if (!ext) return undefined;
+  return EXTENSION_TO_CONTENT_TYPE[ext];
+}

--- a/src/tools/create-attachable.tool.ts
+++ b/src/tools/create-attachable.tool.ts
@@ -4,23 +4,36 @@ import { z } from "zod";
 
 const toolName = "create_attachable";
 const toolDescription =
-  "Create an attachable (file attachment) in QuickBooks Online. Without base64_content, creates a metadata-only attachment record. With base64_content, uploads the actual file bytes to QBO's /upload endpoint.";
+  "Create an attachable (file attachment) in QuickBooks Online. Supply file bytes one of two ways: file_path (the server reads the file from its own disk — preferred; use for anything beyond a few KB so bytes never pass through the model) or base64_content (bytes inlined by the caller). With either, the file is uploaded to QBO's /upload endpoint. With neither, a metadata-only attachment record is created.";
 
 const toolSchema = z.object({
-  file_name: z.string().min(1).describe("File name including extension (e.g., 'receipt.pdf')."),
+  file_name: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "File name including extension (e.g., 'receipt.pdf'). Optional when file_path is given (defaults to that file's basename); otherwise required."
+    ),
+  file_path: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Absolute path to a local file the server reads directly from disk, then uploads to QBO's /upload endpoint. Preferred over base64_content for real files — the bytes are read and encoded server-side and never travel through the model context. content_type is auto-detected from the extension when omitted; file_name defaults to the basename. A leading '~/' is expanded to the home directory. Mutually exclusive with base64_content. Max 100 MB."
+    ),
   note: z.string().optional().describe("Optional note describing the attachment."),
   category: z.string().optional().describe("Optional QBO attachment category."),
   content_type: z
     .string()
     .optional()
     .describe(
-      "MIME content type. Required when base64_content is provided. Supported by QBO: application/postscript (.ai, .eps), text/csv, application/msword (.doc), application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), image/gif, image/jpeg, image/jpg, application/vnd.oasis.opendocument.spreadsheet (.ods), application/pdf, image/png, text/rtf, image/tif, text/plain (.txt), application/vnd.ms-excel (.xls), application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), text/xml."
+      "MIME content type. Required with base64_content; optional with file_path (auto-detected from the extension). Supported by QBO: application/postscript (.ai, .eps), text/csv, application/msword (.doc), application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), image/gif, image/jpeg, image/jpg, application/vnd.oasis.opendocument.spreadsheet (.ods), application/pdf, image/png, text/rtf, image/tif, text/plain (.txt), application/vnd.ms-excel (.xls), application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), text/xml."
     ),
   base64_content: z
     .string()
     .optional()
     .describe(
-      "Optional base64-encoded file bytes. When provided, the decoded file is uploaded to QBO's /upload endpoint as multipart/form-data. Maximum 100 MB decoded. Omit to create a metadata-only attachment record."
+      "Optional base64-encoded file bytes. When provided, the decoded file is uploaded to QBO's /upload endpoint as multipart/form-data. Maximum 100 MB decoded. Prefer file_path for anything larger than a few KB. Mutually exclusive with file_path. Omit both to create a metadata-only attachment record."
     ),
   attachable_ref: z
     .object({

--- a/src/tools/update-attachable.tool.ts
+++ b/src/tools/update-attachable.tool.ts
@@ -3,13 +3,21 @@ import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
 const toolName = "update_attachable";
-const toolDescription = "Update an existing attachable in QuickBooks Online.";
+const toolDescription =
+  "Update an existing attachable's metadata (file name, note, category, content type) in QuickBooks Online. This is metadata-only: it CANNOT replace the uploaded file bytes. To attach a different or corrected file, create a new attachable (create_attachable with file_path) and delete the old one.";
 const toolSchema = z.object({
   id: z.string().min(1).describe("Attachable ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   file_name: z.string().optional().describe("Updated file name"),
+  content_type: z.string().optional().describe("Updated MIME content type metadata."),
   note: z.string().optional().describe("Updated note"),
   category: z.string().optional().describe("Updated category"),
+  file_path: z
+    .string()
+    .optional()
+    .describe(
+      "Convenience: derive file_name (basename) and content_type (from the extension) from this path for the metadata update. Does NOT read the file or replace the stored bytes — QBO's update endpoint is metadata-only. Explicit file_name/content_type take precedence."
+    ),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/tests/unit/handlers/company-attachable.handlers.test.ts
+++ b/tests/unit/handlers/company-attachable.handlers.test.ts
@@ -1,4 +1,7 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, truncateSync, rmSync } from 'fs';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
 import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
 
 // ESM-compatible module mocking
@@ -42,6 +45,33 @@ function mockHttpsUploadNetworkError(err: Error) {
     }),
   };
   (mockHttpsRequest as any).mockImplementation((_options: unknown, _callback: unknown) => mockReq);
+}
+
+// Like mockHttpsUploadResponse but also captures the multipart body written to
+// the request, so tests can assert the FileName/ContentType the handler derived.
+function mockHttpsUploadResponseCapturing(statusCode: number, responseBody: unknown) {
+  const chunks: Buffer[] = [];
+  const mockReq = {
+    write: jest.fn((chunk: Buffer) => { chunks.push(Buffer.from(chunk)); }),
+    end: jest.fn(),
+    on: jest.fn(),
+  };
+  (mockHttpsRequest as any).mockImplementation((_options: unknown, callback: (res: unknown) => void) => {
+    const mockRes = {
+      statusCode,
+      on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'data') {
+          const payload = typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody);
+          handler(Buffer.from(payload));
+        } else if (event === 'end') {
+          handler();
+        }
+      }),
+    };
+    callback(mockRes);
+    return mockReq;
+  });
+  return () => Buffer.concat(chunks).toString('utf-8');
 }
 
 // Dynamic imports after mock setup
@@ -474,6 +504,190 @@ describe('Company and Attachable Handlers', () => {
       expect(result.isError).toBe(false);
       expect(mockHttpsRequest).not.toHaveBeenCalled();
     });
+
+    it('should reject when neither file_name nor file_path is provided', async () => {
+      const result = await createQuickbooksAttachable({});
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('file_name is required');
+      expect(mockQuickBooksInstance.createAttachable).not.toHaveBeenCalled();
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createQuickbooksAttachable — file_path upload', () => {
+    let tmpDir: string;
+
+    beforeAll(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'qbo-attachable-test-'));
+    });
+
+    afterAll(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should read a file from disk and upload it, deriving file_name and content_type', async () => {
+      const filePath = join(tmpDir, '2026-05-13_Adobe_3456406703.pdf');
+      writeFileSync(filePath, Buffer.from('%PDF-1.4 fake pdf bytes'));
+      const getBody = mockHttpsUploadResponseCapturing(200, {
+        AttachableResponse: [{ Attachable: { Id: '99', FileName: '2026-05-13_Adobe_3456406703.pdf' }, responseStatus: '200' }],
+      });
+
+      const result = await createQuickbooksAttachable({
+        file_path: filePath,
+        attachable_ref: { entity_ref_type: 'Purchase', entity_ref_value: '184' },
+      });
+
+      expect(result.isError).toBe(false);
+      expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+      const [[reqOptions]] = (mockHttpsRequest as jest.Mock).mock.calls as any[][];
+      expect(reqOptions.method).toBe('POST');
+      expect(reqOptions.path).toBe('/v3/company/mock-realm-id/upload');
+
+      // The multipart body carries the derived filename + content type.
+      const body = getBody();
+      expect(body).toContain('"FileName":"2026-05-13_Adobe_3456406703.pdf"');
+      expect(body).toContain('"ContentType":"application/pdf"');
+      expect(body).toContain('filename="2026-05-13_Adobe_3456406703.pdf"');
+      expect(body).toContain('Content-Type: application/pdf');
+      // Bytes read from disk are present in the multipart body.
+      expect(body).toContain('%PDF-1.4 fake pdf bytes');
+    });
+
+    it('should honor explicit file_name and content_type over path-derived values', async () => {
+      const filePath = join(tmpDir, 'raw.bin');
+      writeFileSync(filePath, Buffer.from('bytes'));
+      const getBody = mockHttpsUploadResponseCapturing(200, { AttachableResponse: [] });
+
+      const result = await createQuickbooksAttachable({
+        file_path: filePath,
+        file_name: 'invoice.pdf',
+        content_type: 'application/pdf',
+      });
+
+      expect(result.isError).toBe(false);
+      const body = getBody();
+      expect(body).toContain('"FileName":"invoice.pdf"');
+      expect(body).toContain('"ContentType":"application/pdf"');
+    });
+
+    it('should reject when file_path and base64_content are both provided', async () => {
+      const result = await createQuickbooksAttachable({
+        file_path: join(tmpDir, 'whatever.pdf'),
+        base64_content: Buffer.from('x').toString('base64'),
+        content_type: 'application/pdf',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('not both');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should error when the file does not exist', async () => {
+      const result = await createQuickbooksAttachable({
+        file_path: join(tmpDir, 'does-not-exist.pdf'),
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Cannot read file');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should error when the path is a directory, not a file', async () => {
+      const subDir = join(tmpDir, 'a-directory.pdf');
+      mkdirSync(subDir);
+
+      const result = await createQuickbooksAttachable({ file_path: subDir });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('not a regular file');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should error on an empty (0-byte) file', async () => {
+      const filePath = join(tmpDir, 'empty.pdf');
+      writeFileSync(filePath, Buffer.alloc(0));
+
+      const result = await createQuickbooksAttachable({ file_path: filePath });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('empty');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should reject a file larger than the 100 MB cap before reading it', async () => {
+      // Sparse file: truncate reports the large size via stat without writing
+      // 100 MB of real bytes to disk.
+      const filePath = join(tmpDir, 'huge.pdf');
+      writeFileSync(filePath, Buffer.from('seed'));
+      truncateSync(filePath, 100 * 1024 * 1024 + 1);
+
+      const result = await createQuickbooksAttachable({ file_path: filePath });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('File too large');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should error when content_type cannot be inferred from an unknown extension', async () => {
+      const filePath = join(tmpDir, 'mystery.zzz');
+      writeFileSync(filePath, Buffer.from('data'));
+
+      const result = await createQuickbooksAttachable({ file_path: filePath });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Could not infer content_type');
+      expect(result.error).toContain('.zzz');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should error when the file has no extension and no content_type', async () => {
+      const filePath = join(tmpDir, 'README');
+      writeFileSync(filePath, Buffer.from('data'));
+
+      const result = await createQuickbooksAttachable({ file_path: filePath });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Could not infer content_type');
+      expect(result.error).toContain('(none)');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should reject an explicit content_type that QBO does not accept', async () => {
+      const filePath = join(tmpDir, 'sketch.pdf');
+      writeFileSync(filePath, Buffer.from('data'));
+
+      const result = await createQuickbooksAttachable({
+        file_path: filePath,
+        content_type: 'image/vnd.adobe.photoshop',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Unsupported content_type');
+      expect(mockHttpsRequest).not.toHaveBeenCalled();
+    });
+
+    it('should expand a leading ~/ in file_path', async () => {
+      // Point at a path under the home dir that almost certainly does not
+      // exist; the error message proves the ~ was expanded to the home dir.
+      const result = await createQuickbooksAttachable({
+        file_path: '~/qbo-mcp-nonexistent-xyzzy.pdf',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Cannot read file');
+      expect(result.error).toContain(homedir());
+      expect(result.error).not.toContain('~');
+    });
+
+    it('should expand a bare ~ in file_path to the home directory', async () => {
+      // "~" resolves to the home directory, which is a directory, not a file.
+      const result = await createQuickbooksAttachable({ file_path: '~' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('not a regular file');
+      expect(result.error).toContain(homedir());
+    });
   });
 
   describe('getQuickbooksAttachable', () => {
@@ -519,6 +733,62 @@ describe('Company and Attachable Handlers', () => {
       });
 
       expect(result.isError).toBe(false);
+    });
+
+    it('should derive file_name and content_type from file_path', async () => {
+      let capturedPayload: any = null;
+      mockQuickBooksInstance.updateAttachable.mockImplementation((payload: any, cb: any) => {
+        capturedPayload = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksAttachable({
+        id: '1',
+        sync_token: '0',
+        file_path: '/some/dir/2026-05-13_Adobe_3456406703.pdf',
+      });
+
+      expect(result.isError).toBe(false);
+      expect(capturedPayload.FileName).toBe('2026-05-13_Adobe_3456406703.pdf');
+      expect(capturedPayload.ContentType).toBe('application/pdf');
+    });
+
+    it('should let explicit file_name and content_type override file_path', async () => {
+      let capturedPayload: any = null;
+      mockQuickBooksInstance.updateAttachable.mockImplementation((payload: any, cb: any) => {
+        capturedPayload = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksAttachable({
+        id: '1',
+        sync_token: '0',
+        file_path: '/some/dir/derived.pdf',
+        file_name: 'explicit.pdf',
+        content_type: 'text/csv',
+      });
+
+      expect(result.isError).toBe(false);
+      expect(capturedPayload.FileName).toBe('explicit.pdf');
+      expect(capturedPayload.ContentType).toBe('text/csv');
+    });
+
+    it('should omit ContentType when file_path has an unrecognized extension', async () => {
+      let capturedPayload: any = null;
+      mockQuickBooksInstance.updateAttachable.mockImplementation((payload: any, cb: any) => {
+        capturedPayload = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksAttachable({
+        id: '1',
+        sync_token: '0',
+        file_path: '/some/dir/archive.zzz',
+      });
+
+      expect(result.isError).toBe(false);
+      expect(capturedPayload.FileName).toBe('archive.zzz');
+      expect(capturedPayload.ContentType).toBeUndefined();
     });
 
     it('should handle API errors', async () => {


### PR DESCRIPTION
## Summary

Adds a `file_path` input to `create_attachable` so the server can upload a document to QuickBooks directly from its own filesystem, instead of requiring the bytes to be passed inline as `base64_content` (which routes large binaries through the model/context window). Also adds a small shared MIME helper and a convenience `file_path` on `update_attachable`.

## Motivation

For an MCP server driving QBO, attaching a receipt/invoice PDF is a common action. Today the only path is `base64_content`, so the whole file must be base64-encoded into the tool call — expensive and size-limited when a model is in the loop. When the file already exists on the server's disk, `file_path` lets the server read and stream it directly.

## Changes

- **`create_attachable`**: new optional `file_path`. When provided, the server reads the file from disk, streams the bytes to QBO's `/upload` endpoint, and:
  - infers `content_type` from the file extension when omitted (via the new helper),
  - infers `file_name` from the basename when omitted,
  - expands a leading `~/`,
  - size-checks against QBO's 100 MB cap from filesystem metadata **before** reading into memory.
  - `file_path` and `base64_content` are mutually exclusive; `base64_content` is unchanged and still supported.
- **`update_attachable`**: adds `content_type`, plus a convenience `file_path` that derives `file_name`/`content_type` metadata from the path (no disk read). QBO's Attachable update is metadata-only and cannot replace stored bytes — noted in the tool description.
- **`src/helpers/attachable-mime.ts`** (new): extracts the accepted-MIME set and an extension→MIME map, shared by the create/update handlers so the list lives in one place. Documents QBO's non-RFC quirks (`image/jpg`, `image/tif`) and corrects a docs typo (`application/vnd/ms-excel` → `application/vnd.ms-excel`).
- CHANGELOG updated under **[Unreleased]**.

## Testing

- `npm test`: **473 tests pass** (23 suites). The changed attachable handlers and `attachable-mime.ts` are at **100%** statements/branches/functions/lines; global coverage thresholds met.
- `npm run build` and `tsc --noEmit -p tsconfig.test.json` are clean.
- ~272 lines of unit tests added covering extension→MIME inference, basename/`~` handling, the 100 MB size guard, `file_path` ⊕ `base64_content` mutual exclusion, and error/auth paths.
