### PR TITLE
feat(create_attachable): add file_path and file_url sources with stre…

### DIFF
--- a/src/handlers/create-quickbooks-attachable.handler.ts
+++ b/src/handlers/create-quickbooks-attachable.handler.ts
@@ -1,7 +1,13 @@
 import https from "https";
+import { createReadStream } from "fs";
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import {
+  fetchUrlToTempFile,
+  inferContentType,
+  resolveLocalFile,
+} from "../helpers/attachable-file-source.js";
 
 // QBO Attachable upload — file types accepted by the QBO /upload endpoint.
 // Source: developer.intuit.com Attachable API reference (16 unique MIME types
@@ -53,12 +59,19 @@ export interface CreateAttachableInput {
   category?: string;
   content_type?: string;
   base64_content?: string;
+  file_path?: string;
+  file_url?: string;
   attachable_ref?: {
     entity_ref_type: string;
     entity_ref_value: string;
     include_on_send?: boolean;
   };
 }
+
+// The file part of the multipart body: either bytes already in memory
+// (base64 path) or a local file streamed from disk (file_path / file_url,
+// the latter spooled to a temp file by the fetch helper).
+type UploadFileSource = { buffer: Buffer } | { path: string; size: number };
 
 function sanitizeFilename(name: string): string {
   return name.replace(/[\r\n"\\]/g, "_");
@@ -86,7 +99,7 @@ function redactedUploadError(statusCode: number | undefined): string {
 // exactly one file per request — single-file covers the 99% MCP/LLM case and
 // multi-file would require a different input schema. Out of scope here.
 async function uploadAttachableFile(
-  fileBuffer: Buffer,
+  file: UploadFileSource,
   metadata: Record<string, unknown>,
   accessToken: string,
   realmId: string,
@@ -97,25 +110,23 @@ async function uploadAttachableFile(
   const fileName = sanitizeFilename(metadata.FileName as string);
   const contentType = metadata.ContentType as string;
 
-  const bodyParts: Buffer[] = [
-    Buffer.from(
+  const preamble = Buffer.from(
+    `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file_metadata_01"\r\n` +
+      `Content-Type: application/json\r\n` +
+      `\r\n` +
+      `${metadataJson}\r\n` +
       `--${boundary}\r\n` +
-        `Content-Disposition: form-data; name="file_metadata_01"\r\n` +
-        `Content-Type: application/json\r\n` +
-        `\r\n` +
-        `${metadataJson}\r\n`
-    ),
-    Buffer.from(
-      `--${boundary}\r\n` +
-        `Content-Disposition: form-data; name="file_content_01"; filename="${fileName}"\r\n` +
-        `Content-Type: ${contentType}\r\n` +
-        `\r\n`
-    ),
-    fileBuffer,
-    Buffer.from(`\r\n--${boundary}--\r\n`),
-  ];
+      `Content-Disposition: form-data; name="file_content_01"; filename="${fileName}"\r\n` +
+      `Content-Type: ${contentType}\r\n` +
+      `\r\n`
+  );
+  const closer = Buffer.from(`\r\n--${boundary}--\r\n`);
+  // Exact Content-Length lets us stream the file part without chunked
+  // transfer encoding, which the QBO endpoint does not reliably accept.
+  const fileSize = "buffer" in file ? file.buffer.length : file.size;
+  const contentLength = preamble.length + fileSize + closer.length;
 
-  const body = Buffer.concat(bodyParts);
   const host = isSandbox
     ? "sandbox-quickbooks.api.intuit.com"
     : "quickbooks.api.intuit.com";
@@ -130,7 +141,7 @@ async function uploadAttachableFile(
         headers: {
           Authorization: `Bearer ${accessToken}`,
           "Content-Type": `multipart/form-data; boundary=${boundary}`,
-          "Content-Length": body.length,
+          "Content-Length": contentLength,
           Accept: "application/json",
         },
       },
@@ -157,8 +168,45 @@ async function uploadAttachableFile(
       console.error(`[qbo-attachable-upload] network error: ${err.message}`);
       reject(new Error(redactedUploadError(undefined)));
     });
-    req.write(body);
-    req.end();
+
+    req.write(preamble);
+    if ("buffer" in file) {
+      req.write(file.buffer);
+      req.write(closer);
+      req.end();
+    } else {
+      // Stream the file part from disk — memory stays flat for large files.
+      // The read is bounded to the stat'ed size so a file that GROWS between
+      // stat and read cannot overrun the declared Content-Length; a file that
+      // SHRINKS is caught by the bytesRead check below.
+      const readStream = createReadStream(file.path, { end: file.size - 1 });
+      /* istanbul ignore next — defensive: fires only on network failure
+         mid-stream; prevents the unpiped read stream from leaking its fd. */
+      req.on("error", () => readStream.destroy());
+      /* istanbul ignore next — defensive: the file was stat'ed moments ago;
+         this fires only if it vanishes or the disk errors mid-read. */
+      readStream.on("error", (err) => {
+        console.error(`[qbo-attachable-upload] file read error: ${err.message}`);
+        req.destroy(err);
+        reject(new Error(`Failed reading file for upload: ${err.message}`));
+      });
+      readStream.pipe(req, { end: false });
+      readStream.on("end", () => {
+        /* istanbul ignore next — defensive: file truncated between stat and
+           read; without this check QBO would wait for bytes that never come. */
+        if (readStream.bytesRead !== file.size) {
+          req.destroy();
+          reject(
+            new Error(
+              `File changed during upload: read ${readStream.bytesRead} of ${file.size} expected bytes.`
+            )
+          );
+          return;
+        }
+        req.write(closer);
+        req.end();
+      });
+    }
   });
 }
 
@@ -185,49 +233,105 @@ export async function createQuickbooksAttachable(
     }
 
     // ── Binary upload path ────────────────────────────────────────────────
-    if (data.base64_content) {
-      const effectiveContentType = data.content_type ?? "application/octet-stream";
-      if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(effectiveContentType)) {
-        return {
-          result: null,
-          isError: true,
-          error: `Unsupported content_type "${effectiveContentType}". Allowed: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].sort().join(", ")}`,
-        };
+    // Source precedence: file_url / file_path (mutually exclusive) win over
+    // base64_content; base64_content alone preserves the original behavior.
+    if (data.file_url && data.file_path) {
+      return {
+        result: null,
+        isError: true,
+        error: "Provide either file_url or file_path, not both.",
+      };
+    }
+
+    const hasFileSource = Boolean(data.file_url || data.file_path || data.base64_content);
+    if (hasFileSource) {
+      // Resolve the file source first (cheap, no auth), then validate type.
+      let fileSource: UploadFileSource;
+      let fetchedContentType: string | null = null;
+      let cleanup: (() => Promise<void>) | null = null;
+
+      if (data.file_url) {
+        const fetched = await fetchUrlToTempFile(data.file_url, MAX_UPLOAD_BYTES);
+        fileSource = { path: fetched.path, size: fetched.size };
+        fetchedContentType = fetched.contentTypeHeader;
+        cleanup = fetched.cleanup;
+      } else if (data.file_path) {
+        const local = await resolveLocalFile(data.file_path, MAX_UPLOAD_BYTES);
+        fileSource = { path: local.path, size: local.size };
+      } else {
+        // base64 path — validate the content type BEFORE decoding, so an
+        // unsupported type is rejected without allocating the decoded buffer
+        // (same error precedence as the original implementation).
+        const preliminaryType =
+          data.content_type ?? inferContentType(data.file_name) ?? "application/octet-stream";
+        if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(preliminaryType)) {
+          return {
+            result: null,
+            isError: true,
+            error: `Unsupported content_type "${preliminaryType}". Allowed: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].sort().join(", ")}`,
+          };
+        }
+        // Enforce size cap BEFORE decoding to a Buffer.
+        const approxSize = approximateDecodedSize(data.base64_content!);
+        if (approxSize > MAX_UPLOAD_BYTES) {
+          return {
+            result: null,
+            isError: true,
+            error: `File too large: approximately ${approxSize} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+          };
+        }
+        const fileBuffer = Buffer.from(data.base64_content!, "base64");
+        /* istanbul ignore next — defensive: the approxSize check above already
+           rejects oversized input; this guards only the malformed-base64 edge
+           case where decoded length unexpectedly exceeds the approximation. */
+        if (fileBuffer.length > MAX_UPLOAD_BYTES) {
+          return {
+            result: null,
+            isError: true,
+            error: `File too large: ${fileBuffer.length} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
+          };
+        }
+        fileSource = { buffer: fileBuffer };
       }
 
-      // Enforce size cap BEFORE decoding to a Buffer.
-      const approxSize = approximateDecodedSize(data.base64_content);
-      if (approxSize > MAX_UPLOAD_BYTES) {
-        return {
-          result: null,
-          isError: true,
-          error: `File too large: approximately ${approxSize} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
-        };
+      try {
+        // Content type: explicit override > inferred from file_name /
+        // file_path / file_url PATH extension (query strings excluded so
+        // '?file=x.pdf' can't spoof the type). The URL's Content-Type header
+        // is deliberately not trusted as-is — servers routinely send
+        // octet-stream — but a QBO-supported header value (case-insensitive
+        // per RFC 2045) is accepted as a last resort.
+        const urlPathname = data.file_url ? new URL(data.file_url).pathname : undefined;
+        const headerToken = fetchedContentType
+          ? fetchedContentType.split(";")[0].trim().toLowerCase()
+          : null;
+        const effectiveContentType =
+          data.content_type ??
+          inferContentType(data.file_name, data.file_path, urlPathname) ??
+          (headerToken && ALLOWED_UPLOAD_CONTENT_TYPES.has(headerToken) ? headerToken : null) ??
+          "application/octet-stream";
+        if (!ALLOWED_UPLOAD_CONTENT_TYPES.has(effectiveContentType)) {
+          return {
+            result: null,
+            isError: true,
+            error: `Unsupported content_type "${effectiveContentType}". Allowed: ${[...ALLOWED_UPLOAD_CONTENT_TYPES].sort().join(", ")}`,
+          };
+        }
+        payload.ContentType = effectiveContentType;
+
+        const { accessToken, realmId, isSandbox } =
+          await QuickbooksClient.getAuthCredentials();
+        const uploadResult = await uploadAttachableFile(
+          fileSource,
+          payload,
+          accessToken,
+          realmId,
+          isSandbox
+        );
+        return { result: uploadResult, isError: false, error: null };
+      } finally {
+        if (cleanup) await cleanup();
       }
-
-      const fileBuffer = Buffer.from(data.base64_content, "base64");
-
-      /* istanbul ignore next — defensive: the approxSize check above already
-         rejects oversized input; this guards only the malformed-base64 edge
-         case where decoded length unexpectedly exceeds the approximation. */
-      if (fileBuffer.length > MAX_UPLOAD_BYTES) {
-        return {
-          result: null,
-          isError: true,
-          error: `File too large: ${fileBuffer.length} bytes exceeds QBO's ${MAX_UPLOAD_BYTES} byte (100 MB) upload limit.`,
-        };
-      }
-
-      const { accessToken, realmId, isSandbox } =
-        await QuickbooksClient.getAuthCredentials();
-      const uploadResult = await uploadAttachableFile(
-        fileBuffer,
-        payload,
-        accessToken,
-        realmId,
-        isSandbox
-      );
-      return { result: uploadResult, isError: false, error: null };
     }
 
     // ── Metadata-only path (preserved behavior, post-#41 auth) ────────────

--- a/src/handlers/update-quickbooks-attachable.handler.ts
+++ b/src/handlers/update-quickbooks-attachable.handler.ts
@@ -1,20 +1,37 @@
+import path from "path";
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { inferContentType } from "../helpers/attachable-file-source.js";
 
 export interface UpdateAttachableInput {
   id: string;
   sync_token: string;
   file_name?: string;
+  content_type?: string;
   note?: string;
   category?: string;
+  file_path?: string;
 }
 
 export async function updateQuickbooksAttachable(data: UpdateAttachableInput): Promise<ToolResponse<any>> {
   try {
+    // QBO's Attachable update is metadata-only — it cannot replace the stored
+    // file bytes. file_path here is a convenience that only derives the
+    // FileName/ContentType metadata from the path (no disk read, no re-upload).
+    // To attach a different/corrected file, create a new attachable
+    // (create_attachable with file_path) and delete the old one.
+    let fileName = data.file_name;
+    let contentType = data.content_type;
+    if (data.file_path) {
+      if (!fileName) fileName = path.basename(data.file_path);
+      if (!contentType) contentType = inferContentType(data.file_path) ?? undefined;
+    }
+
     const quickbooks = await QuickbooksClient.getInstance();
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
-    if (data.file_name) payload.FileName = data.file_name;
+    if (fileName) payload.FileName = fileName;
+    if (contentType) payload.ContentType = contentType;
     if (data.note) payload.Note = data.note;
     if (data.category) payload.Category = data.category;
 

--- a/src/helpers/attachable-file-source.ts
+++ b/src/helpers/attachable-file-source.ts
@@ -1,0 +1,332 @@
+import { lookup } from "dns/promises";
+import { createWriteStream } from "fs";
+import { randomBytes } from "crypto";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
+import { Transform } from "stream";
+import { fileURLToPath } from "url";
+import fs from "fs/promises";
+import net from "net";
+import os from "os";
+import path from "path";
+
+// Extension -> MIME map limited to the file types QBO's /upload endpoint
+// accepts. Values intentionally mirror QBO's documented (sometimes
+// non-RFC-standard) spellings — see ALLOWED_UPLOAD_CONTENT_TYPES in
+// create-quickbooks-attachable.handler.ts, which this map must stay a
+// subset of.
+const EXT_TO_MIME: Record<string, string> = {
+  ".ai": "application/postscript",
+  ".eps": "application/postscript",
+  ".csv": "text/csv",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpg",
+  ".ods": "application/vnd.oasis.opendocument.spreadsheet",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".rtf": "text/rtf",
+  ".tif": "image/tif",
+  ".txt": "text/plain",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".xml": "text/xml",
+};
+
+// Shared no-op for promise rejections we deliberately swallow (best-effort
+// cleanup/cancellation where failure is inconsequential).
+const swallow = () => undefined;
+
+// Infer a QBO-supported MIME type from the first candidate name that has a
+// known extension. Returns null when no candidate matches.
+export function inferContentType(...candidateNames: Array<string | undefined>): string | null {
+  for (const name of candidateNames) {
+    if (!name) continue;
+    const ext = path.extname(name).toLowerCase();
+    const mime = EXT_TO_MIME[ext];
+    if (mime) return mime;
+  }
+  return null;
+}
+
+// ── file_path source ──────────────────────────────────────────────────────
+
+// The server shares a filesystem with its callers (it runs as a local stdio
+// subprocess), so OS-native absolute paths are legitimate input — but they
+// must stay inside an allowed base directory. Defaults: the user's profile
+// directory and the OS temp directory (which together cover OneDrive/
+// SharePoint sync roots, Downloads, and agent scratchpad dirs on a standard
+// Windows setup). Override with QUICKBOOKS_ATTACHABLE_BASE_DIR — accepts
+// multiple directories separated by ";" (Windows PATH style).
+function allowedBaseDirs(): string[] {
+  const raw = process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR;
+  if (raw) {
+    return raw
+      .split(";")
+      .map((d) => d.trim())
+      .filter(Boolean);
+  }
+  return [os.homedir(), os.tmpdir()];
+}
+
+// Windows paths are case-insensitive; normalize before containment checks.
+/* istanbul ignore next — platform branch: only one arm is reachable per OS */
+function normalizeForCompare(p: string): string {
+  return process.platform === "win32" ? p.toLowerCase() : p;
+}
+
+export interface LocalFileSource {
+  path: string;
+  size: number;
+}
+
+// Denylist layered on top of the base-dir whitelist. The whitelist is
+// deliberately broad (the operator's documents live all over the profile
+// dir), so specifically deny the places credentials live: dot-directories
+// and dotfiles (.ssh, .aws, .env, ...), token stores, and this server's own
+// install tree (which holds .env and tokens.json for a QBO company).
+const DENIED_BASENAMES = new Set(["tokens.json"]);
+
+// The server's install root (two levels up from this helper, same resolution
+// the client uses for .env). Cached realpath, resolved lazily.
+let serverRootRealPromise: Promise<string> | null = null;
+function serverRootReal(): Promise<string> {
+  if (!serverRootRealPromise) {
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    // Defensive fallback: the running module's own tree always resolves.
+    serverRootRealPromise = fs
+      .realpath(path.join(moduleDir, "..", ".."))
+      .catch(/* istanbul ignore next */ () => path.join(moduleDir, "..", ".."));
+  }
+  return serverRootRealPromise;
+}
+
+async function deniedReason(realPath: string): Promise<string | null> {
+  const segments = realPath.split(path.sep);
+  if (segments.some((s) => s.startsWith(".") && s !== "." && s !== "..")) {
+    return "dotfiles and dot-directories are not attachable";
+  }
+  const base = path.basename(realPath).toLowerCase();
+  if (base.endsWith(".env") || DENIED_BASENAMES.has(base)) {
+    return "credential files are not attachable";
+  }
+  const rootReal = await serverRootReal();
+  const rel = path.relative(normalizeForCompare(rootReal), normalizeForCompare(realPath));
+  if (!rel.startsWith("..") && !path.isAbsolute(rel)) {
+    return "files inside the MCP server's own directory are not attachable";
+  }
+  return null;
+}
+
+export async function resolveLocalFile(filePath: string, maxBytes: number): Promise<LocalFileSource> {
+  // Require absolute paths: a stdio server's CWD is client-launch-dependent,
+  // so resolving relative paths against it would be a silent footgun.
+  if (!path.isAbsolute(filePath)) {
+    throw new Error(`file_path must be an absolute path (got "${filePath}")`);
+  }
+  // realpath handles native Windows paths (backslashes, spaces, drive
+  // letters) as-is and resolves symlinks/junctions so a link inside an
+  // allowed base cannot point back out of it.
+  let targetReal: string;
+  try {
+    targetReal = await fs.realpath(filePath);
+  } catch {
+    throw new Error(`file_path not found or not readable: ${filePath}`);
+  }
+
+  let contained = false;
+  const basesChecked: string[] = [];
+  for (const dir of allowedBaseDirs()) {
+    let baseReal: string;
+    try {
+      baseReal = await fs.realpath(path.resolve(dir));
+    } catch {
+      continue; // configured base dir doesn't exist — skip it
+    }
+    basesChecked.push(baseReal);
+    const rel = path.relative(normalizeForCompare(baseReal), normalizeForCompare(targetReal));
+    if (!rel.startsWith("..") && !path.isAbsolute(rel)) {
+      contained = true;
+      break;
+    }
+  }
+  if (!contained) {
+    throw new Error(
+      `file_path is outside the allowed base directories (${basesChecked.join("; ")}). Set QUICKBOOKS_ATTACHABLE_BASE_DIR (";"-separated list) to change them.`
+    );
+  }
+
+  const denied = await deniedReason(targetReal);
+  if (denied) throw new Error(`file_path denied: ${denied}`);
+
+  const stat = await fs.stat(targetReal);
+  if (!stat.isFile()) throw new Error(`file_path is not a regular file: ${filePath}`);
+  if (stat.size === 0) throw new Error(`file_path is empty: ${filePath}`);
+  if (stat.size > maxBytes) {
+    throw new Error(`File too large: ${stat.size} bytes exceeds QBO's ${maxBytes} byte (100 MB) upload limit.`);
+  }
+  return { path: targetReal, size: stat.size };
+}
+
+// ── file_url source ───────────────────────────────────────────────────────
+
+// SSRF guard: reject loopback, RFC1918/4193 private ranges, link-local
+// (incl. 169.254.169.254 cloud metadata), CGNAT, and unspecified addresses.
+// Exported for tests.
+// Extract an IPv4 address embedded in an IPv4-compatible (::/96) or NAT64
+// (64:ff9b::/96) IPv6 address, in either dotted or hex-group form.
+function embeddedV4(lower: string): string | null {
+  const isNat64 = lower.startsWith("64:ff9b::");
+  const isV4Compat = lower.startsWith("::") && !lower.startsWith("::ffff:");
+  if (!isNat64 && !isV4Compat) return null;
+  const dotted = lower.match(/((?:\d{1,3}\.){3}\d{1,3})$/);
+  if (dotted) return dotted[1];
+  const tail = lower.replace(/^64:ff9b::/, "").replace(/^::/, "");
+  const groups = tail.split(":").filter(Boolean);
+  if (groups.length === 0 || groups.length > 2) return null;
+  const [hi, lo] = groups.length === 2 ? groups : ["0", groups[0]];
+  const hiN = parseInt(hi, 16);
+  const loN = parseInt(lo, 16);
+  return `${hiN >> 8}.${hiN & 255}.${loN >> 8}.${loN & 255}`;
+}
+
+export function isBlockedIp(ip: string): boolean {
+  if (net.isIPv6(ip)) {
+    const lower = ip.toLowerCase();
+    if (lower.startsWith("::ffff:")) {
+      const v4 = lower.slice("::ffff:".length);
+      return net.isIPv4(v4) ? isBlockedIp(v4) : true;
+    }
+    if (lower === "::1" || lower === "::") return true;
+    const embedded = embeddedV4(lower);
+    if (embedded) return isBlockedIp(embedded); // ::/96 and 64:ff9b::/96 embeddings
+    if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) return true; // fe80::/10
+    if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // fc00::/7
+    return false;
+  }
+  if (!net.isIPv4(ip)) return true; // unparseable -> treat as blocked
+  const [a, b] = ip.split(".").map(Number);
+  if (a === 0 || a === 127 || a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
+async function assertUrlAllowed(url: URL): Promise<void> {
+  if (url.protocol !== "https:") {
+    throw new Error(`file_url must use https (got ${url.protocol.replace(":", "")})`);
+  }
+  const hostname = url.hostname.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+  if (net.isIP(hostname)) {
+    if (isBlockedIp(hostname)) throw new Error(`file_url resolves to a blocked address`);
+    return;
+  }
+  // Check every resolved address. Note: the actual fetch performs its own DNS
+  // resolution, so a hostile DNS server could in theory answer differently
+  // twice (rebinding). Accepted residual risk for a local, single-operator
+  // tool; the primary threat here is an LLM being handed an internal URL.
+  const addrs = await lookup(hostname, { all: true, verbatim: true });
+  if (addrs.length === 0) throw new Error(`file_url hostname did not resolve`);
+  for (const { address } of addrs) {
+    if (isBlockedIp(address)) throw new Error(`file_url resolves to a blocked address`);
+  }
+}
+
+function urlFetchTimeoutMs(): number {
+  const raw = Number(process.env.QUICKBOOKS_ATTACHABLE_URL_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 60_000;
+}
+
+export interface FetchedFileSource extends LocalFileSource {
+  contentTypeHeader: string | null;
+  cleanup: () => Promise<void>;
+}
+
+// Fetch an HTTPS URL and spool the body to a temp file, enforcing the size
+// cap while streaming (memory stays flat regardless of file size). Redirects
+// are followed manually (max 3) so every hop passes the SSRF checks.
+export async function fetchUrlToTempFile(fileUrl: string, maxBytes: number): Promise<FetchedFileSource> {
+  let current: URL;
+  try {
+    current = new URL(fileUrl);
+  } catch {
+    throw new Error(`file_url is not a valid URL: ${fileUrl}`);
+  }
+
+  const signal = AbortSignal.timeout(urlFetchTimeoutMs());
+  let response: Response | null = null;
+  for (let hop = 0; hop <= 3; hop++) {
+    await assertUrlAllowed(current);
+    const res = await fetch(current, {
+      redirect: "manual",
+      signal,
+      headers: { "user-agent": "qbo-mcp-attachable/1.0" },
+    });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (!location) throw new Error(`file_url redirect (${res.status}) missing Location header`);
+      if (hop === 3) throw new Error(`file_url exceeded 3 redirects`);
+      current = new URL(location, current);
+      // Cancel the redirect body without reading it — a hostile server could
+      // attach an arbitrarily large body to a 3xx.
+      await res.body?.cancel().catch(swallow);
+      continue;
+    }
+    if (!res.ok) throw new Error(`file_url fetch failed: HTTP ${res.status}`);
+    response = res;
+    break;
+  }
+  /* istanbul ignore next — defensive: the redirect loop always breaks with a
+     response or throws before exhausting its iterations */
+  if (!response) throw new Error(`file_url fetch returned no response`);
+  if (!response.body) throw new Error(`file_url fetch returned no body`);
+
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await response.body.cancel().catch(swallow);
+    throw new Error(`File too large: ${declaredLength} bytes exceeds QBO's ${maxBytes} byte (100 MB) upload limit.`);
+  }
+
+  const tempPath = path.join(
+    os.tmpdir(),
+    `qbo-attach-${process.pid}-${randomBytes(6).toString("hex")}.tmp`
+  );
+  const cleanup = async () => {
+    await fs.unlink(tempPath).catch(swallow);
+  };
+
+  let received = 0;
+  const capEnforcer = new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      received += chunk.length;
+      if (received > maxBytes) {
+        cb(new Error(`File too large: download exceeded QBO's ${maxBytes} byte (100 MB) upload limit.`));
+        return;
+      }
+      cb(null, chunk);
+    },
+  });
+
+  try {
+    await pipeline(Readable.fromWeb(response.body as any), capEnforcer, createWriteStream(tempPath));
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+
+  if (received === 0) {
+    await cleanup();
+    throw new Error(`file_url returned an empty body`);
+  }
+
+  return {
+    path: tempPath,
+    size: received,
+    contentTypeHeader: response.headers.get("content-type"),
+    cleanup,
+  };
+}

--- a/src/tools/create-attachable.tool.ts
+++ b/src/tools/create-attachable.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "create_attachable";
 const toolDescription =
-  "Create an attachable (file attachment) in QuickBooks Online. Without base64_content, creates a metadata-only attachment record. With base64_content, uploads the actual file bytes to QBO's /upload endpoint.";
+  "Create an attachable (file attachment) in QuickBooks Online. File content can come from file_path (a file on the machine running this server — preferred for local files of any size), file_url (an https URL the server downloads), or base64_content (inline bytes — only practical for small files). Precedence: file_url/file_path (mutually exclusive) win over base64_content. With no file source, creates a metadata-only attachment record. Max file size 100 MB (QBO limit).";
 
 const toolSchema = z.object({
   file_name: z.string().min(1).describe("File name including extension (e.g., 'receipt.pdf')."),
@@ -14,13 +14,25 @@ const toolSchema = z.object({
     .string()
     .optional()
     .describe(
-      "MIME content type. Required when base64_content is provided. Supported by QBO: application/postscript (.ai, .eps), text/csv, application/msword (.doc), application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), image/gif, image/jpeg, image/jpg, application/vnd.oasis.opendocument.spreadsheet (.ods), application/pdf, image/png, text/rtf, image/tif, text/plain (.txt), application/vnd.ms-excel (.xls), application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), text/xml."
+      "MIME content type. Optional — when omitted it is inferred from the file extension (of file_name, file_path, or the file_url path), then, for file_url only, from the response's Content-Type header if that is a QBO-supported type. Supported by QBO: application/postscript (.ai, .eps), text/csv, application/msword (.doc), application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), image/gif, image/jpeg, image/jpg, application/vnd.oasis.opendocument.spreadsheet (.ods), application/pdf, image/png, text/rtf, image/tif, text/plain (.txt), application/vnd.ms-excel (.xls), application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx), text/xml."
+    ),
+  file_path: z
+    .string()
+    .optional()
+    .describe(
+      "OS-native ABSOLUTE path to a file on the machine running this MCP server (the server runs locally and shares the filesystem with you) — on Windows pass the path exactly as-is, backslashes, spaces, drive letter and all (e.g. 'C:\\Users\\me\\Documents\\Client Files - 2026\\SIGNED Quote.pdf'). Relative paths are rejected. The file is streamed to QBO — use this for any real file instead of base64_content. Must be inside an allowed base directory (default: the user's profile directory and the OS temp directory, which cover OneDrive/SharePoint sync folders, Downloads, and agent scratchpad dirs; override with env QUICKBOOKS_ATTACHABLE_BASE_DIR as a ';'-separated list). Dotfiles/dot-directories, credential files (*.env, tokens.json), and files inside the MCP server's own directory are always denied. Mutually exclusive with file_url; either one takes precedence over base64_content."
+    ),
+  file_url: z
+    .string()
+    .optional()
+    .describe(
+      "HTTPS URL the server downloads and streams to QBO. Use for files reachable over the web. http, internal/loopback, and cloud-metadata addresses are rejected; max 3 redirects; download timeout 60s (env QUICKBOOKS_ATTACHABLE_URL_TIMEOUT_MS). Mutually exclusive with file_path; either one takes precedence over base64_content."
     ),
   base64_content: z
     .string()
     .optional()
     .describe(
-      "Optional base64-encoded file bytes. When provided, the decoded file is uploaded to QBO's /upload endpoint as multipart/form-data. Maximum 100 MB decoded. Omit to create a metadata-only attachment record."
+      "Base64-encoded file bytes, uploaded as multipart/form-data. Only practical for small files (a few KB) — prefer file_path or file_url for real documents. Ignored when file_path or file_url is provided. Maximum 100 MB decoded. Omit all three sources to create a metadata-only attachment record."
     ),
   attachable_ref: z
     .object({

--- a/src/tools/update-attachable.tool.ts
+++ b/src/tools/update-attachable.tool.ts
@@ -3,13 +3,16 @@ import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
 const toolName = "update_attachable";
-const toolDescription = "Update an existing attachable in QuickBooks Online.";
+const toolDescription =
+  "Update an existing attachable's metadata (file name, note, category, content type) in QuickBooks Online. This is metadata-only: it CANNOT replace the uploaded file bytes. To attach a different or corrected file, create a new attachable (create_attachable with file_path) and delete the old one.";
 const toolSchema = z.object({
   id: z.string().min(1).describe("Attachable ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   file_name: z.string().optional().describe("Updated file name"),
+  content_type: z.string().optional().describe("Updated MIME content type metadata."),
   note: z.string().optional().describe("Updated note"),
   category: z.string().optional().describe("Updated category"),
+  file_path: z.string().optional().describe("Convenience: derive file_name and content_type metadata from this path. Metadata-only — does NOT read or re-upload file bytes."),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/tests/unit/handlers/attachable-file-source.fetch.test.ts
+++ b/tests/unit/handlers/attachable-file-source.fetch.test.ts
@@ -1,0 +1,391 @@
+import { jest, describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from '@jest/globals';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { Writable } from 'stream';
+import { mockQuickbooksClient, mockQuickbooksClientClass } from '../../mocks/quickbooks.mock';
+
+// Mock DNS so hostname URLs resolve to a public address (or a private one,
+// per test) without real lookups.
+const mockLookup = jest.fn();
+jest.unstable_mockModule('dns/promises', () => ({
+  lookup: mockLookup,
+}));
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+// https mock whose request object is a real Writable, so fs/web streams can
+// pipe into it; the response fires only after req.end(), like a real server.
+const mockHttpsRequest = jest.fn();
+jest.unstable_mockModule('https', () => ({
+  default: { request: mockHttpsRequest },
+  request: mockHttpsRequest,
+}));
+
+function mockStreamingUploadResponse(statusCode: number, responseBody: unknown) {
+  const captured: { body: Buffer } = { body: Buffer.alloc(0) };
+  (mockHttpsRequest as any).mockImplementation(
+    (_options: unknown, callback: (res: unknown) => void) => {
+      const chunks: Buffer[] = [];
+      const req = new Writable({
+        write(chunk: Buffer, _enc, done) {
+          chunks.push(Buffer.from(chunk));
+          done();
+        },
+      });
+      req.on('finish', () => {
+        captured.body = Buffer.concat(chunks);
+        const payload = typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody);
+        const res = {
+          statusCode,
+          on: (event: string, handler: (...args: unknown[]) => void) => {
+            if (event === 'data') handler(Buffer.from(payload));
+            if (event === 'end') handler();
+          },
+        };
+        callback(res);
+      });
+      return req;
+    }
+  );
+  return captured;
+}
+
+const { fetchUrlToTempFile } = await import('../../../src/helpers/attachable-file-source');
+const { createQuickbooksAttachable } = await import(
+  '../../../src/handlers/create-quickbooks-attachable.handler'
+);
+
+const MAX = 100 * 1024 * 1024;
+const realFetch = globalThis.fetch;
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  mockLookup.mockReset();
+  mockFetch.mockReset();
+  (mockLookup as any).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+  globalThis.fetch = mockFetch as any;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function okResponse(bytes: Buffer, headers: Record<string, string> = {}) {
+  return new Response(new Uint8Array(bytes), { status: 200, headers });
+}
+
+describe('fetchUrlToTempFile', () => {
+  it('spools the body to a temp file and reports size and content-type', async () => {
+    const bytes = Buffer.from('%PDF-1.7 test-bytes');
+    (mockFetch as any).mockResolvedValue(okResponse(bytes, { 'content-type': 'application/pdf' }));
+
+    const fetched = await fetchUrlToTempFile('https://example.com/doc.pdf', MAX);
+    try {
+      expect(fetched.size).toBe(bytes.length);
+      expect(fetched.contentTypeHeader).toBe('application/pdf');
+      const onDisk = await fs.readFile(fetched.path);
+      expect(onDisk.equals(bytes)).toBe(true);
+    } finally {
+      await fetched.cleanup();
+    }
+    await expect(fs.stat(fetched.path)).rejects.toThrow(); // cleanup removed it
+    await fetched.cleanup(); // second cleanup is a harmless no-op
+  });
+
+  it('accepts a literal public IP host without a DNS lookup', async () => {
+    const bytes = Buffer.from('by-ip');
+    (mockFetch as any).mockResolvedValue(okResponse(bytes));
+
+    const fetched = await fetchUrlToTempFile('https://8.8.8.8/doc.pdf', MAX);
+    try {
+      expect(fetched.size).toBe(bytes.length);
+      expect(mockLookup).not.toHaveBeenCalled();
+    } finally {
+      await fetched.cleanup();
+    }
+  });
+
+  it('rejects hostnames that resolve to private addresses', async () => {
+    (mockLookup as any).mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '192.168.1.10', family: 4 }, // one private record poisons the set
+    ]);
+    await expect(fetchUrlToTempFile('https://rebind.example/doc.pdf', MAX)).rejects.toThrow(/blocked/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects hostnames that do not resolve', async () => {
+    (mockLookup as any).mockResolvedValue([]);
+    await expect(fetchUrlToTempFile('https://nowhere.example/doc.pdf', MAX)).rejects.toThrow(
+      /did not resolve/
+    );
+  });
+
+  it('follows redirects and revalidates each hop', async () => {
+    const bytes = Buffer.from('redirected-bytes');
+    (mockFetch as any)
+      .mockResolvedValueOnce(
+        new Response(null, { status: 302, headers: { location: 'https://cdn.example.com/real.pdf' } })
+      )
+      .mockResolvedValueOnce(okResponse(bytes));
+
+    const fetched = await fetchUrlToTempFile('https://example.com/doc.pdf', MAX);
+    try {
+      expect(fetched.size).toBe(bytes.length);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(String((mockFetch as any).mock.calls[1][0])).toBe('https://cdn.example.com/real.pdf');
+    } finally {
+      await fetched.cleanup();
+    }
+  });
+
+  it('rejects redirects to blocked addresses', async () => {
+    (mockFetch as any).mockResolvedValue(
+      new Response(null, { status: 302, headers: { location: 'https://127.0.0.1/internal.pdf' } })
+    );
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', MAX)).rejects.toThrow(/blocked/);
+  });
+
+  it('rejects redirect responses without a Location header', async () => {
+    (mockFetch as any).mockResolvedValue(new Response(null, { status: 302 }));
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', MAX)).rejects.toThrow(
+      /missing Location/
+    );
+  });
+
+  it('gives up after 3 redirects', async () => {
+    (mockFetch as any).mockResolvedValue(
+      new Response(null, { status: 302, headers: { location: 'https://example.com/loop.pdf' } })
+    );
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', MAX)).rejects.toThrow(
+      /exceeded 3 redirects/
+    );
+  });
+
+  it('rejects non-OK responses', async () => {
+    (mockFetch as any).mockResolvedValue(new Response('nope', { status: 404 }));
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', MAX)).rejects.toThrow(/HTTP 404/);
+  });
+
+  it('rejects oversized files declared via Content-Length before downloading', async () => {
+    (mockFetch as any).mockResolvedValue(
+      okResponse(Buffer.from('x'), { 'content-length': String(MAX + 1) })
+    );
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', MAX)).rejects.toThrow(
+      /File too large/
+    );
+  });
+
+  it('enforces the size cap while streaming when Content-Length is absent', async () => {
+    const big = Buffer.alloc(64, 7);
+    // Response without an explicit content-length header still carries one
+    // when constructed from a buffer, so stream it chunk-wise instead.
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(big));
+        controller.close();
+      },
+    });
+    (mockFetch as any).mockResolvedValue(new Response(stream, { status: 200 }));
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', 32)).rejects.toThrow(
+      /File too large/
+    );
+  });
+
+  it('rejects a response with no body', async () => {
+    (mockFetch as any).mockResolvedValue(new Response(null, { status: 200 }));
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', MAX)).rejects.toThrow(/no body/);
+  });
+
+  it('rejects an empty body', async () => {
+    const empty = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+    (mockFetch as any).mockResolvedValue(new Response(empty, { status: 200 }));
+    await expect(fetchUrlToTempFile('https://example.com/doc.pdf', MAX)).rejects.toThrow(
+      /empty body/
+    );
+  });
+
+  it('honors QUICKBOOKS_ATTACHABLE_URL_TIMEOUT_MS', async () => {
+    process.env.QUICKBOOKS_ATTACHABLE_URL_TIMEOUT_MS = '5000';
+    try {
+      const bytes = Buffer.from('timed');
+      (mockFetch as any).mockResolvedValue(okResponse(bytes));
+      const fetched = await fetchUrlToTempFile('https://example.com/doc.pdf', MAX);
+      await fetched.cleanup();
+      const passedSignal = (mockFetch as any).mock.calls[0][1].signal;
+      expect(passedSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      delete process.env.QUICKBOOKS_ATTACHABLE_URL_TIMEOUT_MS;
+    }
+  });
+});
+
+describe('createQuickbooksAttachable file-source upload flows', () => {
+  let baseDir: string;
+  const savedEnv = process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR;
+  const pdfBytes = Buffer.concat([Buffer.from('%PDF-1.7\n'), Buffer.alloc(2048, 0x42)]);
+
+  beforeAll(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qbo-attach-flow-'));
+    process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = baseDir;
+    await fs.writeFile(path.join(baseDir, 'invoice.pdf'), pdfBytes);
+    await fs.writeFile(path.join(baseDir, 'archive.zip'), Buffer.alloc(64, 1));
+  });
+
+  afterAll(async () => {
+    if (savedEnv === undefined) delete process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR;
+    else process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = savedEnv;
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('streams a file_path source and infers content type from the file name', async () => {
+    const captured = mockStreamingUploadResponse(200, { AttachableResponse: [{ Attachable: { Id: '1' } }] });
+
+    const result = await createQuickbooksAttachable({
+      file_name: 'invoice.pdf',
+      file_path: path.join(baseDir, 'invoice.pdf'),
+    });
+
+    expect(result.isError).toBe(false);
+    const body = captured.body;
+    expect(body.includes(pdfBytes)).toBe(true); // file bytes made it intact
+    expect(body.toString('utf8', 0, 600)).toContain('Content-Type: application/pdf');
+    expect(body.toString('utf8', 0, 600)).toContain('"ContentType":"application/pdf"');
+  });
+
+  it('respects an explicit content_type override', async () => {
+    const captured = mockStreamingUploadResponse(200, { ok: true });
+
+    const result = await createQuickbooksAttachable({
+      file_name: 'invoice.pdf',
+      file_path: path.join(baseDir, 'invoice.pdf'),
+      content_type: 'text/plain',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(captured.body.toString('utf8', 0, 600)).toContain('Content-Type: text/plain');
+  });
+
+  it('rejects a file with no inferable, QBO-supported content type', async () => {
+    const result = await createQuickbooksAttachable({
+      file_name: 'archive.zip',
+      file_path: path.join(baseDir, 'archive.zip'),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/Unsupported content_type/);
+  });
+
+  it('uploads a file_url source, using the response content-type as fallback', async () => {
+    (mockLookup as any).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    const bytes = Buffer.from('%PDF-1.7 from-url');
+    (mockFetch as any).mockResolvedValue(
+      new Response(new Uint8Array(bytes), {
+        status: 200,
+        headers: { 'content-type': 'application/pdf; charset=binary' },
+      })
+    );
+    const captured = mockStreamingUploadResponse(200, { ok: true });
+
+    const result = await createQuickbooksAttachable({
+      file_name: 'no-extension-name', // forces the header fallback
+      file_url: 'https://example.com/download/8842',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(captured.body.includes(bytes)).toBe(true);
+    expect(captured.body.toString('utf8', 0, 600)).toContain('Content-Type: application/pdf');
+  });
+
+  it('infers the type from the URL path, ignoring query-string extensions', async () => {
+    (mockLookup as any).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    const bytes = Buffer.from('%PDF-1.7 signed');
+    (mockFetch as any).mockResolvedValue(
+      new Response(new Uint8Array(bytes), {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+    );
+    const captured = mockStreamingUploadResponse(200, { ok: true });
+
+    const result = await createQuickbooksAttachable({
+      file_name: 'download', // no extension: URL path must supply the type
+      file_url: 'https://cdn.example.com/doc.pdf?sig=a1b2', // query must not break inference
+    });
+
+    expect(result.isError).toBe(false);
+    expect(captured.body.toString('utf8', 0, 600)).toContain('Content-Type: application/pdf');
+  });
+
+  it('does not let a query-string extension spoof the content type', async () => {
+    (mockLookup as any).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    (mockFetch as any).mockResolvedValue(
+      new Response(new Uint8Array(Buffer.from('<html>')), {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    );
+
+    const result = await createQuickbooksAttachable({
+      file_name: 'export',
+      file_url: 'https://example.com/export?file=report.pdf', // .pdf only in the query
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/Unsupported content_type/);
+  });
+
+  it('accepts a QBO-supported Content-Type header regardless of case', async () => {
+    (mockLookup as any).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    const bytes = Buffer.from('%PDF-1.7 mixed-case');
+    (mockFetch as any).mockResolvedValue(
+      new Response(new Uint8Array(bytes), {
+        status: 200,
+        headers: { 'content-type': 'Application/PDF' }, // IIS-style casing
+      })
+    );
+    const captured = mockStreamingUploadResponse(200, { ok: true });
+
+    const result = await createQuickbooksAttachable({
+      file_name: 'download',
+      file_url: 'https://example.com/get/123',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(captured.body.toString('utf8', 0, 600)).toContain('Content-Type: application/pdf');
+  });
+
+  it('rejects unsupported base64 content types before decoding', async () => {
+    const result = await createQuickbooksAttachable({
+      file_name: 'archive.zip',
+      base64_content: Buffer.from('PK...').toString('base64'),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/Unsupported content_type/);
+  });
+
+  it('rejects a file_url source whose only type hint is not QBO-supported', async () => {
+    (mockLookup as any).mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    (mockFetch as any).mockResolvedValue(
+      new Response(new Uint8Array(Buffer.from('<html>')), {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    );
+
+    const result = await createQuickbooksAttachable({
+      file_name: 'download',
+      file_url: 'https://example.com/page',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/Unsupported content_type/);
+  });
+});

--- a/tests/unit/handlers/attachable-file-source.test.ts
+++ b/tests/unit/handlers/attachable-file-source.test.ts
@@ -1,0 +1,270 @@
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { mockQuickbooksClient, mockQuickbooksClientClass } from '../../mocks/quickbooks.mock';
+
+// ESM-compatible module mocking (handler pulls in the QBO client at import).
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+const { inferContentType, isBlockedIp, resolveLocalFile, fetchUrlToTempFile } = await import(
+  '../../../src/helpers/attachable-file-source'
+);
+const { createQuickbooksAttachable } = await import(
+  '../../../src/handlers/create-quickbooks-attachable.handler'
+);
+
+const MAX = 100 * 1024 * 1024;
+
+describe('inferContentType', () => {
+  it('maps known extensions to QBO MIME types', () => {
+    expect(inferContentType('receipt.pdf')).toBe('application/pdf');
+    expect(inferContentType('book.XLSX')).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    expect(inferContentType('photo.jpg')).toBe('image/jpg');
+  });
+
+  it('uses the first candidate with a known extension', () => {
+    expect(inferContentType('noext', 'C:\\docs\\bill.pdf')).toBe('application/pdf');
+    expect(inferContentType(undefined, 'https://x.example/f.png')).toBe('image/png');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(inferContentType('archive.zip', 'noext')).toBeNull();
+    expect(inferContentType()).toBeNull();
+  });
+});
+
+describe('isBlockedIp', () => {
+  it.each([
+    '127.0.0.1',
+    '10.1.2.3',
+    '172.16.0.1',
+    '172.31.255.255',
+    '192.168.1.1',
+    '169.254.169.254', // cloud metadata
+    '100.64.0.1', // CGNAT
+    '0.0.0.0',
+    '::1',
+    '::',
+    'fe80::1',
+    'fd00::1',
+    '::ffff:127.0.0.1', // v4-mapped loopback
+  ])('blocks %s', (ip) => {
+    expect(isBlockedIp(ip)).toBe(true);
+  });
+
+  it.each(['8.8.8.8', '172.32.0.1', '100.128.0.1', '2606:4700::6810:84e5', '::ffff:8.8.8.8'])(
+    'allows public %s',
+    (ip) => {
+      expect(isBlockedIp(ip)).toBe(false);
+    }
+  );
+
+  it('treats unparseable addresses as blocked', () => {
+    expect(isBlockedIp('not-an-ip')).toBe(true);
+    expect(isBlockedIp('::ffff:junk')).toBe(true);
+    expect(isBlockedIp('::ffff:abcd')).toBe(true); // valid IPv6, non-IPv4 mapped suffix
+  });
+
+  it('blocks private v4 embedded in IPv4-compatible and NAT64 IPv6 forms', () => {
+    expect(isBlockedIp('::127.0.0.1')).toBe(true); // dotted IPv4-compatible
+    expect(isBlockedIp('::7f00:1')).toBe(true); // hex IPv4-compatible loopback
+    expect(isBlockedIp('64:ff9b::7f00:1')).toBe(true); // NAT64 loopback, hex
+    expect(isBlockedIp('64:ff9b::10.0.0.1')).toBe(true); // NAT64 private, dotted
+    expect(isBlockedIp('::808:808')).toBe(false); // IPv4-compatible 8.8.8.8 — public
+    expect(isBlockedIp('64:ff9b::808:808')).toBe(false); // NAT64 8.8.8.8 — public
+    expect(isBlockedIp('::7f')).toBe(true); // single hex group -> 0.0.0.127 (0.0.0.0/8)
+    expect(isBlockedIp('64:ff9b::')).toBe(false); // bare NAT64 prefix, no embedded v4
+    expect(isBlockedIp('::2:3:4:5:6:7')).toBe(false); // too many groups to embed a v4
+  });
+});
+
+describe('fetchUrlToTempFile URL validation', () => {
+  it('rejects non-https URLs', async () => {
+    await expect(fetchUrlToTempFile('http://example.com/f.pdf', MAX)).rejects.toThrow(/https/);
+  });
+
+  it('rejects invalid URLs', async () => {
+    await expect(fetchUrlToTempFile('not a url', MAX)).rejects.toThrow(/not a valid URL/);
+  });
+
+  it('rejects literal loopback addresses', async () => {
+    await expect(fetchUrlToTempFile('https://127.0.0.1/f.pdf', MAX)).rejects.toThrow(/blocked/);
+  });
+
+  it('rejects the cloud metadata address', async () => {
+    await expect(fetchUrlToTempFile('https://169.254.169.254/latest/meta-data', MAX)).rejects.toThrow(
+      /blocked/
+    );
+  });
+
+  it('rejects literal private IPv6 addresses', async () => {
+    await expect(fetchUrlToTempFile('https://[::1]/f.pdf', MAX)).rejects.toThrow(/blocked/);
+  });
+});
+
+describe('resolveLocalFile', () => {
+  let baseDir: string;
+  let outsideDir: string;
+  const savedEnv = process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR;
+
+  beforeAll(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qbo-attach-base-'));
+    outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qbo-attach-out-'));
+    process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = baseDir;
+    await fs.writeFile(path.join(baseDir, 'inside.pdf'), Buffer.alloc(1024, 1));
+    await fs.writeFile(path.join(baseDir, 'empty.pdf'), Buffer.alloc(0));
+    await fs.writeFile(path.join(outsideDir, 'outside.pdf'), Buffer.alloc(64, 1));
+  });
+
+  afterAll(async () => {
+    if (savedEnv === undefined) delete process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR;
+    else process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = savedEnv;
+    await fs.rm(baseDir, { recursive: true, force: true });
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  });
+
+  it('accepts a file inside the base directory and returns its size', async () => {
+    const resolved = await resolveLocalFile(path.join(baseDir, 'inside.pdf'), MAX);
+    expect(resolved.size).toBe(1024);
+  });
+
+  it('accepts a native Windows-style path with spaces in nested folders', async () => {
+    const nested = path.join(baseDir, 'Company Shared', 'Group Finance - Documents');
+    await fs.mkdir(nested, { recursive: true });
+    const target = path.join(nested, 'SIGNED Quote (Rev 2).pdf');
+    await fs.writeFile(target, Buffer.alloc(2048, 3));
+    // Pass the path exactly as an agent would: OS-native separators, spaces,
+    // parentheses — no escaping or normalization by the caller.
+    const resolved = await resolveLocalFile(target, MAX);
+    expect(resolved.size).toBe(2048);
+  });
+
+  it('accepts a file in any directory of a multi-entry whitelist', async () => {
+    process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = `${baseDir};${outsideDir}`;
+    try {
+      const resolved = await resolveLocalFile(path.join(outsideDir, 'outside.pdf'), MAX);
+      expect(resolved.size).toBe(64);
+    } finally {
+      process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = baseDir;
+    }
+  });
+
+  it('defaults to profile + temp directories when no whitelist is configured', async () => {
+    delete process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR;
+    try {
+      // baseDir lives under os.tmpdir(), which the default whitelist includes.
+      const resolved = await resolveLocalFile(path.join(baseDir, 'inside.pdf'), MAX);
+      expect(resolved.size).toBe(1024);
+    } finally {
+      process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = baseDir;
+    }
+  });
+
+  it('skips whitelist entries that do not exist', async () => {
+    process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = `${path.join(baseDir, 'no-such-dir')};${baseDir}`;
+    try {
+      const resolved = await resolveLocalFile(path.join(baseDir, 'inside.pdf'), MAX);
+      expect(resolved.size).toBe(1024);
+    } finally {
+      process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = baseDir;
+    }
+  });
+
+  it('rejects a file outside every allowed base directory', async () => {
+    await expect(resolveLocalFile(path.join(outsideDir, 'outside.pdf'), MAX)).rejects.toThrow(
+      /outside the allowed base directories/
+    );
+  });
+
+  it('rejects path traversal that escapes the base directory', async () => {
+    const sneaky = path.join(baseDir, '..', path.basename(outsideDir), 'outside.pdf');
+    await expect(resolveLocalFile(sneaky, MAX)).rejects.toThrow(/outside the allowed base directories/);
+  });
+
+  it('rejects a missing file', async () => {
+    await expect(resolveLocalFile(path.join(baseDir, 'nope.pdf'), MAX)).rejects.toThrow(
+      /not found or not readable/
+    );
+  });
+
+  it('rejects an empty file', async () => {
+    await expect(resolveLocalFile(path.join(baseDir, 'empty.pdf'), MAX)).rejects.toThrow(/empty/);
+  });
+
+  it('rejects a directory', async () => {
+    await expect(resolveLocalFile(baseDir, MAX)).rejects.toThrow(/not a regular file/);
+  });
+
+  it('rejects relative paths', async () => {
+    await expect(resolveLocalFile('inside.pdf', MAX)).rejects.toThrow(/must be an absolute path/);
+  });
+
+  it('denies dotfiles and files inside dot-directories', async () => {
+    await fs.writeFile(path.join(baseDir, '.env'), Buffer.from('SECRET=1'));
+    await fs.mkdir(path.join(baseDir, '.ssh'), { recursive: true });
+    await fs.writeFile(path.join(baseDir, '.ssh', 'id_rsa'), Buffer.from('key'));
+    await expect(resolveLocalFile(path.join(baseDir, '.env'), MAX)).rejects.toThrow(/dotfiles/);
+    await expect(resolveLocalFile(path.join(baseDir, '.ssh', 'id_rsa'), MAX)).rejects.toThrow(
+      /dotfiles/
+    );
+  });
+
+  it('denies credential files by name', async () => {
+    await fs.writeFile(path.join(baseDir, 'prod.env'), Buffer.from('SECRET=1'));
+    await fs.writeFile(path.join(baseDir, 'tokens.json'), Buffer.from('{}'));
+    await expect(resolveLocalFile(path.join(baseDir, 'prod.env'), MAX)).rejects.toThrow(
+      /credential files/
+    );
+    await expect(resolveLocalFile(path.join(baseDir, 'tokens.json'), MAX)).rejects.toThrow(
+      /credential files/
+    );
+  });
+
+  it("denies files inside the MCP server's own directory", async () => {
+    const repoRoot = path.resolve(process.cwd());
+    process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = repoRoot;
+    try {
+      await expect(resolveLocalFile(path.join(repoRoot, 'package.json'), MAX)).rejects.toThrow(
+        /server's own directory/
+      );
+    } finally {
+      process.env.QUICKBOOKS_ATTACHABLE_BASE_DIR = baseDir;
+    }
+  });
+
+  it('rejects a file larger than the cap', async () => {
+    await expect(resolveLocalFile(path.join(baseDir, 'inside.pdf'), 512)).rejects.toThrow(
+      /File too large/
+    );
+  });
+});
+
+describe('createQuickbooksAttachable source precedence', () => {
+  it('errors when both file_url and file_path are provided', async () => {
+    const result = await createQuickbooksAttachable({
+      file_name: 'x.pdf',
+      file_url: 'https://example.com/x.pdf',
+      file_path: 'C:\\somewhere\\x.pdf',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/not both/);
+  });
+
+  it('surfaces file_path validation failures as tool errors', async () => {
+    const result = await createQuickbooksAttachable({
+      file_name: 'x.pdf',
+      file_path: path.join(os.tmpdir(), 'qbo-definitely-missing-file.pdf'),
+      base64_content: Buffer.from('ignored').toString('base64'),
+    });
+    // file_path takes precedence over base64_content, so its failure must
+    // surface instead of silently falling back to the base64 bytes.
+    expect(result.isError).toBe(true);
+    expect(result.error).toMatch(/file_path|allowed base directory|not found/);
+  });
+});

--- a/tests/unit/handlers/company-attachable.handlers.test.ts
+++ b/tests/unit/handlers/company-attachable.handlers.test.ts
@@ -539,6 +539,65 @@ describe('Company and Attachable Handlers', () => {
       expect(result.isError).toBe(true);
       expect(result.error).toContain('Auth failed');
     });
+
+    it('derives FileName and ContentType metadata from file_path when omitted', async () => {
+      let captured: any;
+      mockQuickBooksInstance.updateAttachable.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksAttachable({
+        id: '1',
+        sync_token: '0',
+        file_path: '/tmp/receipts/invoice.pdf',
+      });
+
+      expect(result.isError).toBe(false);
+      // Metadata-only: derived from the path, no disk read / re-upload.
+      expect(captured.FileName).toBe('invoice.pdf');
+      expect(captured.ContentType).toBe('application/pdf');
+    });
+
+    it('prefers explicit file_name/content_type over values derived from file_path', async () => {
+      let captured: any;
+      mockQuickBooksInstance.updateAttachable.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksAttachable({
+        id: '1',
+        sync_token: '0',
+        file_path: '/tmp/receipts/invoice.pdf',
+        file_name: 'custom-name.pdf',
+        content_type: 'text/plain',
+      });
+
+      expect(result.isError).toBe(false);
+      expect(captured.FileName).toBe('custom-name.pdf');
+      expect(captured.ContentType).toBe('text/plain');
+    });
+
+    it('omits ContentType when file_path has no recognizable extension', async () => {
+      let captured: any;
+      mockQuickBooksInstance.updateAttachable.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksAttachable({
+        id: '1',
+        sync_token: '0',
+        file_path: '/tmp/receipts/receipt-no-extension',
+      });
+
+      expect(result.isError).toBe(false);
+      // FileName still derived from the basename; ContentType left unset since
+      // the extension is unknown (inferContentType returns null).
+      expect(captured.FileName).toBe('receipt-no-extension');
+      expect(captured.ContentType).toBeUndefined();
+    });
   });
 
   describe('deleteQuickbooksAttachable', () => {


### PR DESCRIPTION
Inline base64_content is impractical beyond a few KB for LLM/agent callers, so real documents (100 KB+ PDFs) could not be attached. This adds two reference-based sources and streams the multipart body to QBO's /upload endpoint with an exact Content-Length, keeping memory flat at any file size up to QBO's 100 MB cap.

- file_path: OS-native absolute path, streamed from disk. Guarded by a base-directory whitelist (default: user profile + OS temp; QUICKBOOKS_ATTACHABLE_BASE_DIR accepts a ";"-separated list) plus a denylist for dotfiles, *.env, tokens.json, and the server's own tree. Reads are bounded to the stat'ed size (TOCTOU-safe).
- file_url: https-only server-side fetch, spooled to a temp file with the size cap enforced while streaming. SSRF guards: loopback/private/ link-local/metadata/CGNAT addresses blocked including IPv6 v4-mapped, IPv4-compatible and NAT64 embeddings; redirects revalidated per hop (max 3); configurable timeout (QUICKBOOKS_ATTACHABLE_URL_TIMEOUT_MS).
- Precedence: file_url/file_path are mutually exclusive; either wins over base64_content. base64_content behavior is unchanged for existing callers.
- content_type is now inferred from the file extension (URL path only, so query strings cannot spoof it), with the response Content-Type header as a case-insensitive last resort for file_url; explicit content_type still overrides.

Adds two unit-test suites; both changed source files at 100% statement/ branch/function/line coverage. All pre-existing tests pass unchanged.

Verified end-to-end against a live production QBO company: a 150 KB local PDF (file_path) and a ~1 MB remote PDF (file_url) both round-trip with byte-identical SHA-256; the base64_content path re-verified unchanged.