### PR TITLE
feat(vendor-credit): per-line tax code, class, billable status to par…

### DIFF
--- a/src/handlers/create-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/create-quickbooks-vendor-credit.handler.ts
@@ -2,16 +2,48 @@ import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
 
+export type BillableStatus = "Billable" | "NotBillable" | "HasBeenBilled";
+
+export interface VendorCreditLineItemInput {
+  amount: number;
+  description?: string;
+  account_ref?: string;
+  class_ref?: string;
+  tax_code_ref?: string;
+  billable_status?: BillableStatus;
+  customer_ref?: string;
+}
+
+export type GlobalTaxCalculation = "TaxExcluded" | "TaxInclusive" | "NotApplicable";
+
 export interface CreateVendorCreditInput {
   vendor_ref: string;
-  line_items: Array<{
-    amount: number;
-    description?: string;
-    account_ref?: string;
-  }>;
+  line_items: VendorCreditLineItemInput[];
   txn_date?: string;
   doc_number?: string;
   private_note?: string;
+  global_tax_calculation?: GlobalTaxCalculation;
+}
+
+// Build a QBO VendorCredit line the same way bill lines are shaped:
+// Line[].AccountBasedExpenseLineDetail carrying AccountRef, ClassRef,
+// TaxCodeRef, BillableStatus, and CustomerRef. With per-line TaxCodeRef and a
+// top-level GlobalTaxCalculation, QBO auto-calculates TxnTaxDetail — we never
+// hardcode a tax code. Shared with the update handler for full-line replacement.
+export function buildVendorCreditLine(l: VendorCreditLineItemInput, idx: number) {
+  const detail: Record<string, unknown> = {};
+  if (l.account_ref) detail.AccountRef = { value: l.account_ref };
+  if (l.class_ref) detail.ClassRef = { value: l.class_ref };
+  if (l.tax_code_ref) detail.TaxCodeRef = { value: l.tax_code_ref };
+  if (l.billable_status) detail.BillableStatus = l.billable_status;
+  if (l.customer_ref) detail.CustomerRef = { value: l.customer_ref };
+  return {
+    Id: `${idx + 1}`,
+    Amount: l.amount,
+    Description: l.description,
+    DetailType: "AccountBasedExpenseLineDetail",
+    AccountBasedExpenseLineDetail: detail,
+  };
 }
 
 export async function createQuickbooksVendorCredit(data: CreateVendorCreditInput): Promise<ToolResponse<any>> {
@@ -20,18 +52,13 @@ export async function createQuickbooksVendorCredit(data: CreateVendorCreditInput
 
     const payload: any = {
       VendorRef: { value: data.vendor_ref },
-      Line: data.line_items.map((l, idx) => ({
-        Id: `${idx + 1}`,
-        Amount: l.amount,
-        Description: l.description,
-        DetailType: "AccountBasedExpenseLineDetail",
-        AccountBasedExpenseLineDetail: l.account_ref ? { AccountRef: { value: l.account_ref } } : {},
-      })),
+      Line: data.line_items.map(buildVendorCreditLine),
     };
 
     if (data.txn_date) payload.TxnDate = data.txn_date;
     if (data.doc_number) payload.DocNumber = data.doc_number;
     if (data.private_note) payload.PrivateNote = data.private_note;
+    if (data.global_tax_calculation) payload.GlobalTaxCalculation = data.global_tax_calculation;
 
     return new Promise((resolve) => {
       (quickbooks as any).createVendorCredit(payload, (err: any, created: any) => {
@@ -43,4 +70,3 @@ export async function createQuickbooksVendorCredit(data: CreateVendorCreditInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
-

--- a/src/handlers/update-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/update-quickbooks-vendor-credit.handler.ts
@@ -1,20 +1,58 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import {
+  buildVendorCreditLine,
+  GlobalTaxCalculation,
+  VendorCreditLineItemInput,
+} from "./create-quickbooks-vendor-credit.handler.js";
 
 export interface UpdateVendorCreditInput {
   id: string;
   sync_token: string;
   vendor_ref?: string;
   private_note?: string;
+  line_items?: VendorCreditLineItemInput[];
+  global_tax_calculation?: GlobalTaxCalculation;
 }
 
 export async function updateQuickbooksVendorCredit(data: UpdateVendorCreditInput): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
-    const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
+
+    let payload: any;
+    if (data.line_items) {
+      // Replacing lines requires a FULL update: QBO rejects sparse updates
+      // that carry a Line array ("Required parameter VendorRef is missing",
+      // error 2020). Read the current entity and merge so every field the
+      // caller didn't override is preserved, then let QBO recompute
+      // TxnTaxDetail from the new lines' tax codes.
+      const existing: any = await new Promise((resolve, reject) => {
+        (quickbooks as any).getVendorCredit(data.id, (err: any, found: any) =>
+          err ? reject(err) : resolve(found)
+        );
+      });
+      const {
+        TxnTaxDetail: _txnTax, // recomputed by QBO from the new lines
+        TotalAmt: _totalAmt, // derived — recomputed by QBO
+        Balance: _balance, // derived — recomputed by QBO
+        MetaData: _metaData, // read-only
+        ...base
+      } = existing;
+      payload = {
+        ...base,
+        Id: data.id,
+        SyncToken: data.sync_token,
+        sparse: false,
+        Line: data.line_items.map(buildVendorCreditLine),
+      };
+    } else {
+      payload = { Id: data.id, SyncToken: data.sync_token, sparse: true };
+    }
+
     if (data.vendor_ref) payload.VendorRef = { value: data.vendor_ref };
     if (data.private_note) payload.PrivateNote = data.private_note;
+    if (data.global_tax_calculation) payload.GlobalTaxCalculation = data.global_tax_calculation;
 
     return new Promise((resolve) => {
       (quickbooks as any).updateVendorCredit(payload, (err: any, updated: any) => {
@@ -26,4 +64,3 @@ export async function updateQuickbooksVendorCredit(data: UpdateVendorCreditInput
     return { result: null, isError: true, error: formatError(error) };
   }
 }
-

--- a/src/tools/create-vendor-credit.tool.ts
+++ b/src/tools/create-vendor-credit.tool.ts
@@ -3,13 +3,44 @@ import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
 const toolName = "create_vendor_credit";
-const toolDescription = "Create a vendor credit in QuickBooks Online.";
+const toolDescription =
+  "Create a vendor credit in QuickBooks Online. Supports per-line sales tax (tax_code_ref) and class tracking (class_ref) the same way bills do — for companies using the global tax model (CA/UK/AU etc.), set each line's tax_code_ref and a top-level global_tax_calculation so QBO auto-calculates TxnTaxDetail.";
 
-const lineItemSchema = z.object({
-  amount: z.number().positive(),
-  description: z.string().optional(),
-  account_ref: z.string().optional(),
-});
+// Shared with update-vendor-credit.tool.ts so the two tools can never drift
+// in what line shapes they accept. Amount allows 0 so existing credits with
+// legitimate 0.00 lines can round-trip through update's full-line replacement.
+export const vendorCreditLineItemSchema = z
+  .object({
+    amount: z.number().nonnegative(),
+    description: z.string().optional(),
+    account_ref: z.string().optional().describe("Expense account ID"),
+    class_ref: z.string().optional().describe("Class ID for class tracking"),
+    tax_code_ref: z
+      .string()
+      .optional()
+      .describe("TaxCode ID for this line (e.g. an HST/GST code). Required for fiscally valid credits in non-US locales."),
+    billable_status: z
+      .enum(["Billable", "NotBillable", "HasBeenBilled"])
+      .optional()
+      .describe("Billable status of the line"),
+    customer_ref: z.string().optional().describe("Customer ID the line is billable to"),
+  })
+  .superRefine((l, ctx) => {
+    // QBO rejects Billable purchase lines without a customer — catch it locally.
+    if (l.billable_status === "Billable" && !l.customer_ref) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "customer_ref is required when billable_status is 'Billable'",
+        path: ["customer_ref"],
+      });
+    }
+  });
+
+export const globalTaxCalculationSchema = z
+  .enum(["TaxExcluded", "TaxInclusive", "NotApplicable"])
+  .describe("How line amounts relate to tax: TaxExcluded (tax added on top), TaxInclusive (tax within amounts), or NotApplicable. Use with per-line tax_code_ref.");
+
+const lineItemSchema = vendorCreditLineItemSchema;
 
 const toolSchema = z.object({
   vendor_ref: z.string().min(1).describe("Vendor ID"),
@@ -17,6 +48,7 @@ const toolSchema = z.object({
   txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
   doc_number: z.string().optional().describe("Document number"),
   private_note: z.string().optional().describe("Private note"),
+  global_tax_calculation: globalTaxCalculationSchema.optional(),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/src/tools/update-vendor-credit.tool.ts
+++ b/src/tools/update-vendor-credit.tool.ts
@@ -1,14 +1,23 @@
 import { updateQuickbooksVendorCredit } from "../handlers/update-quickbooks-vendor-credit.handler.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { globalTaxCalculationSchema, vendorCreditLineItemSchema } from "./create-vendor-credit.tool.js";
 
 const toolName = "update_vendor_credit";
-const toolDescription = "Update a vendor credit in QuickBooks Online.";
+const toolDescription =
+  "Update a vendor credit in QuickBooks Online. Providing line_items REPLACES the entire line array (fetch the current vendor credit first if you only want to modify one line); lines support per-line tax_code_ref and class_ref like bills.";
+
 const toolSchema = z.object({
   id: z.string().min(1).describe("Vendor Credit ID"),
-  sync_token: z.string().min(1).describe("Sync token"),
+  sync_token: z.string().min(1).describe("Sync token (from the latest read of this vendor credit)"),
   vendor_ref: z.string().optional().describe("Vendor ID"),
   private_note: z.string().optional().describe("Private note"),
+  line_items: z
+    .array(vendorCreditLineItemSchema)
+    .min(1)
+    .optional()
+    .describe("Full replacement set of line items (replaces ALL existing lines)"),
+  global_tax_calculation: globalTaxCalculationSchema.optional(),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
+++ b/tests/unit/handlers/refund-purchase-order-vendor-credit.handlers.test.ts
@@ -490,6 +490,72 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
       expect(result.isError).toBe(false);
     });
 
+    it('should map per-line tax code, class, billable status and global tax calculation like bills do', async () => {
+      // Modeled on the HST ON verification case: 6698.22 @ 13% -> QBO
+      // computes TotalTax 870.77 / TotalAmt 7568.99 from the line tax code.
+      let captured: any;
+      mockQuickBooksInstance.createVendorCredit.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, {
+          Id: '42',
+          TotalAmt: 7568.99,
+          GlobalTaxCalculation: 'TaxExcluded',
+          TxnTaxDetail: { TotalTax: 870.77 },
+          Line: payload.Line,
+        });
+      });
+
+      const result = await createQuickbooksVendorCredit({
+        vendor_ref: 'vendor-1',
+        line_items: [
+          {
+            amount: 6698.22,
+            description: 'Accrued liability reversal',
+            account_ref: 'acc-accrued-liabilities',
+            class_ref: 'class-7',
+            tax_code_ref: 'H',
+            billable_status: 'NotBillable',
+            customer_ref: 'cust-3',
+          },
+        ],
+        global_tax_calculation: 'TaxExcluded',
+      });
+
+      expect(result.isError).toBe(false);
+      const detail = captured.Line[0].AccountBasedExpenseLineDetail;
+      expect(detail.AccountRef).toEqual({ value: 'acc-accrued-liabilities' });
+      expect(detail.ClassRef).toEqual({ value: 'class-7' });
+      expect(detail.TaxCodeRef).toEqual({ value: 'H' });
+      expect(detail.BillableStatus).toBe('NotBillable');
+      expect(detail.CustomerRef).toEqual({ value: 'cust-3' });
+      expect(captured.GlobalTaxCalculation).toBe('TaxExcluded');
+      // TxnTaxDetail is left to QBO's tax engine — never hardcoded by us.
+      expect(captured.TxnTaxDetail).toBeUndefined();
+      // Read-back assertions per the verification case.
+      expect(result.result.TxnTaxDetail.TotalTax).toBeGreaterThan(0);
+      expect(result.result.TxnTaxDetail.TotalTax).toBe(870.77);
+      expect(result.result.TotalAmt).toBe(7568.99);
+      expect(result.result.GlobalTaxCalculation).toBe('TaxExcluded');
+      expect(result.result.Line[0].AccountBasedExpenseLineDetail.ClassRef).toEqual({ value: 'class-7' });
+    });
+
+    it('should keep legacy simple line items working (no tax/class fields)', async () => {
+      let captured: any;
+      mockQuickBooksInstance.createVendorCredit.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, { Id: '1' });
+      });
+
+      const result = await createQuickbooksVendorCredit({
+        vendor_ref: 'vendor-1',
+        line_items: [{ amount: 75, description: 'plain', account_ref: 'acc-1' }],
+      });
+
+      expect(result.isError).toBe(false);
+      expect(captured.Line[0].AccountBasedExpenseLineDetail).toEqual({ AccountRef: { value: 'acc-1' } });
+      expect(captured.GlobalTaxCalculation).toBeUndefined();
+    });
+
     it('should create a vendor credit - authentication error', async () => {
       (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
@@ -561,6 +627,109 @@ describe('Refund, PurchaseOrder, VendorCredit Handlers', () => {
       });
 
       expect(result.isError).toBe(false);
+    });
+
+    it('should replace lines via full update, preserving unrelated fields and SyncToken', async () => {
+      // QBO rejects sparse updates that replace lines (error 2020: VendorRef
+      // missing) — the handler must read-modify-write the full entity.
+      mockQuickBooksInstance.getVendorCredit.mockImplementation((_id: any, cb: any) =>
+        cb(null, {
+          Id: '42',
+          SyncToken: '2',
+          VendorRef: { value: 'vendor-9', name: 'Original Vendor' },
+          DocNumber: 'VC-9',
+          TxnDate: '2026-07-01',
+          GlobalTaxCalculation: 'TaxInclusive',
+          TxnTaxDetail: { TotalTax: 1.23 },
+          TotalAmt: 11.23,
+          Balance: 11.23,
+          MetaData: { CreateTime: 'x' },
+          Line: [{ Id: '1', Amount: 10, DetailType: 'AccountBasedExpenseLineDetail' }],
+        })
+      );
+      let captured: any;
+      mockQuickBooksInstance.updateVendorCredit.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, { Id: '42', SyncToken: '3' });
+      });
+
+      const result = await updateQuickbooksVendorCredit({
+        id: '42',
+        sync_token: '2',
+        line_items: [
+          { amount: 6698.22, account_ref: 'acc-accrued-liabilities', tax_code_ref: 'H', class_ref: 'class-7' },
+          { amount: 100, account_ref: 'acc-2' },
+        ],
+        global_tax_calculation: 'TaxExcluded',
+      });
+
+      expect(result.isError).toBe(false);
+      expect(captured.Id).toBe('42');
+      expect(captured.SyncToken).toBe('2'); // caller's token, not the fetched copy's
+      expect(captured.sparse).toBe(false); // full update
+      expect(captured.VendorRef).toEqual({ value: 'vendor-9', name: 'Original Vendor' }); // preserved
+      expect(captured.DocNumber).toBe('VC-9'); // preserved
+      expect(captured.TxnDate).toBe('2026-07-01'); // preserved
+      expect(captured.TxnTaxDetail).toBeUndefined(); // recomputed by QBO
+      expect(captured.TotalAmt).toBeUndefined(); // derived — stripped
+      expect(captured.MetaData).toBeUndefined(); // read-only — stripped
+      expect(captured.Line).toHaveLength(2);
+      expect(captured.Line[0].AccountBasedExpenseLineDetail.TaxCodeRef).toEqual({ value: 'H' });
+      expect(captured.Line[0].AccountBasedExpenseLineDetail.ClassRef).toEqual({ value: 'class-7' });
+      expect(captured.Line[1].AccountBasedExpenseLineDetail).toEqual({ AccountRef: { value: 'acc-2' } });
+      expect(captured.GlobalTaxCalculation).toBe('TaxExcluded'); // override wins over fetched TaxInclusive
+    });
+
+    it('should let vendor_ref override the fetched vendor on line replacement', async () => {
+      mockQuickBooksInstance.getVendorCredit.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '42', SyncToken: '2', VendorRef: { value: 'vendor-9' }, Line: [] })
+      );
+      let captured: any;
+      mockQuickBooksInstance.updateVendorCredit.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksVendorCredit({
+        id: '42',
+        sync_token: '2',
+        vendor_ref: 'vendor-10',
+        private_note: 'swapped vendor',
+        line_items: [{ amount: 5, account_ref: 'acc-1' }],
+      });
+
+      expect(result.isError).toBe(false);
+      expect(captured.VendorRef).toEqual({ value: 'vendor-10' });
+      expect(captured.PrivateNote).toBe('swapped vendor');
+    });
+
+    it('should surface a read failure during line replacement', async () => {
+      mockQuickBooksInstance.getVendorCredit.mockImplementation((_id: any, cb: any) =>
+        cb(new Error('Not found'), null)
+      );
+
+      const result = await updateQuickbooksVendorCredit({
+        id: '404',
+        sync_token: '0',
+        line_items: [{ amount: 5, account_ref: 'acc-1' }],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Not found');
+    });
+
+    it('should not touch Line when line_items is omitted on update', async () => {
+      let captured: any;
+      mockQuickBooksInstance.updateVendorCredit.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, {});
+      });
+
+      const result = await updateQuickbooksVendorCredit({ id: '1', sync_token: '0', private_note: 'note only' });
+
+      expect(result.isError).toBe(false);
+      expect(captured.Line).toBeUndefined();
+      expect(captured.GlobalTaxCalculation).toBeUndefined();
     });
 
     it('should update a vendor credit - authentication error', async () => {


### PR DESCRIPTION
…ity with bill

create_vendor_credit and update_vendor_credit line items now accept class_ref, tax_code_ref, billable_status, and customer_ref, plus a top-level global_tax_calculation (TaxExcluded/TaxInclusive/NotApplicable), mapped into Line[].AccountBasedExpenseLineDetail exactly as create-bill does. TxnTaxDetail is left to QBO's tax engine. Existing simple inputs are unchanged.

update_vendor_credit with line_items performs a read-modify-write full update (QBO rejects sparse line replacement with error 2020), preserving all fields the caller did not override and stripping derived/read-only fields so tax totals are recomputed from the new lines.

Verified against a live CA (global tax model) company: 6698.22 @ 13% HST returns TotalTax 870.77 / TotalAmt 7568.99 on create, and line replacement on update swaps ClassRef while recomputing identical totals.