### PR TITLE
test(journal-entry): cover handler catch block to restore 100% coverage gate

### DIFF
--- a/tests/unit/tools/journal-entry.tool.test.ts
+++ b/tests/unit/tools/journal-entry.tool.test.ts
@@ -136,4 +136,24 @@ describe('journal entry tool handlers', () => {
 
     expect(result.content[0].text).toContain('Error updating journal entry');
   });
+
+  // Covers the handler's outer catch block: getInstance() itself throwing (e.g. auth
+  // failure) rather than the QBO callback returning an error.
+  it('create handler surfaces an error when getInstance rejects', async () => {
+    (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
+
+    const result = await createHandler({ params: { journalEntry: { Line: balancedLines } } });
+
+    expect(result.content[0].text).toContain('Error creating journal entry');
+    expect(result.content[0].text).toContain('Auth failed');
+  });
+
+  it('update handler surfaces an error when getInstance rejects', async () => {
+    (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
+
+    const result = await updateHandler({ params: { journalEntry: { Id: '5', SyncToken: '0' } } });
+
+    expect(result.content[0].text).toContain('Error updating journal entry');
+    expect(result.content[0].text).toContain('Auth failed');
+  });
 });


### PR DESCRIPTION
## Problem
The `journal-entry.tool.test.ts` tests (added with #80) import the tool modules, which pulls their **handlers** into coverage measurement. The handlers' outer `catch` block — reached when `getInstance()` throws (e.g. auth failure), not when the QBO callback returns an error — was never exercised. This left `create-quickbooks-journal-entry.handler.ts` and `update-quickbooks-journal-entry.handler.ts` at 87.5%, dropping the global coverage gate to 99.89% (below the required 100%).

## Fix
Add `getInstance()`-rejects tests for both journal handlers, covering the catch block. Both handlers return to 100%; global gate is green again.

## Verification
`npm run build` clean; `npm test` → 598 pass, 31 suites, coverage threshold met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)