### PR TITLE
fix(auth): resilient token refresh — rotation-race recovery and produ…

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -13,12 +13,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // This matters when the MCP server is spawned by a host (e.g. Claude Desktop,
 // Claude Code, Cursor) whose working directory is not the project root —
 // without this, dotenv silently finds nothing and startup fails.
-//
+const ENV_PATH = path.join(__dirname, '..', '..', '.env');
+
 // Use override: true so that values from .env always win over any empty-string
 // placeholders a host app (e.g. Claude Desktop) may inject via its env config.
 // This prevents the server from starting with blank REFRESH_TOKEN / REALM_ID
 // even when the host config has those keys set to "".
-dotenv.config({ path: path.join(__dirname, '..', '..', '.env'), override: true });
+dotenv.config({ path: ENV_PATH, override: true });
 
 // Register once at module level — registering inside startOAuthFlow() would
 // accumulate duplicate handlers on every OAuth call.
@@ -99,7 +100,139 @@ export class QuickbooksClient {
     return this.accessTokenExpiry <= new Date(Date.now() + QuickbooksClient.TOKEN_REFRESH_BUFFER_MS);
   }
 
+  // Read the refresh token currently persisted in .env. Used to pick up a
+  // rotation performed by a SIBLING process before we attempt our own refresh:
+  // a host may spawn this server more than once against the same .env (e.g.
+  // Claude Desktop and Claude Code simultaneously), and Intuit invalidates the
+  // previous refresh token on every rotation — so a token loaded into memory at
+  // startup can be silently superseded on disk by another process.
+  private readPersistedRefreshToken(): string | undefined {
+    try {
+      // Parse with dotenv itself so the value is normalized identically to how
+      // the in-memory token was loaded at startup — surrounding quotes stripped,
+      // inline comments removed, optional `export ` prefix handled. A naive
+      // slice would keep quotes/comments and could poison a valid token with a
+      // value that only looks different.
+      const parsed = dotenv.parse(fs.readFileSync(ENV_PATH));
+      const value = parsed.QUICKBOOKS_REFRESH_TOKEN?.trim();
+      return value || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Distinguish a genuinely dead refresh token (revoked, expired, or rotated
+  // out — Intuit answers HTTP 400 invalid_grant, or 401) from a transient
+  // failure (5xx, 429, network timeout). Only the former warrants telling the
+  // operator to re-authorize; a transient failure must stay retryable so it
+  // self-heals. Conservative: anything not clearly an auth-invalidation is
+  // treated as transient, so an outage never produces a false "re-authorize"
+  // alarm.
+  //
+  // NOTE on shape: intuit-oauth 4.x does NOT surface invalid_grant in a tidy
+  // field. Verified empirically against v4.2.1 — on a rejected refresh token
+  // the error's message/error is the axios string "Request failed with status
+  // code 400", error_description is "", authResponse.response is "" and
+  // authResponse.status is a function returning undefined. So the reliably
+  // available signal is the HTTP status embedded in that message; we also check
+  // any structured fields in case a future version populates them.
+  private isAuthInvalidation(error: unknown): boolean {
+    // Walk the error's cause chain (bounded) so a wrapped error still classifies
+    // correctly regardless of how many layers deep the real signal sits — our
+    // own wrapper adds one level, and some axios versions attach a `cause`.
+    let cur: unknown = error;
+    for (let depth = 0; depth < 4 && cur != null; depth++) {
+      if (this.classifyOneError(cur)) return true;
+      cur = (cur as { cause?: unknown }).cause;
+    }
+    return false;
+  }
+
+  // Classify a SINGLE error object (no cause traversal — the caller walks the
+  // chain). Returns true only for a genuine auth-invalidation.
+  private classifyOneError(raw: unknown): boolean {
+    const asObj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
+
+    // Explicit OAuth error fields, when populated.
+    const errField = String(asObj?.error ?? "").toLowerCase();
+    const errDesc = String(asObj?.error_description ?? "").toLowerCase();
+    if (errField.includes("invalid_grant") || errDesc.includes("invalid_grant")) return true;
+
+    // Numeric HTTP status from whichever field carries it (incl. intuit-oauth's
+    // authResponse.status() accessor).
+    let status: number | undefined;
+    const ar = asObj?.authResponse as { status?: unknown; response?: { status?: unknown } } | undefined;
+    if (ar) {
+      if (typeof ar.status === "function") {
+        try {
+          const s = Number((ar.status as () => unknown)());
+          if (!Number.isNaN(s)) status = s;
+        } catch {
+          /* accessor threw — fall through to message parsing */
+        }
+      } else if (typeof ar.status === "number") {
+        status = ar.status;
+      }
+      if (status === undefined && ar.response && typeof ar.response.status === "number") {
+        status = ar.response.status;
+      }
+    }
+    if (status === undefined && typeof asObj?.status === "number") status = asObj.status as number;
+
+    // Fallback: parse the axios-style message ("Request failed with status code
+    // NNN") — the only signal intuit-oauth 4.x reliably exposes on invalid_grant
+    // (its response body is discarded). The \b prevents a 4-digit number from
+    // matching its 3-digit prefix.
+    const message = (raw instanceof Error ? raw.message : String(raw ?? "")).toLowerCase();
+    if (message.includes("invalid_grant")) return true;
+    if (status === undefined) {
+      const m = message.match(/status code (\d{3})\b/);
+      if (m) status = Number(m[1]);
+    }
+
+    return status === 400 || status === 401;
+  }
+
+  // Single refresh network call. Returns the widened token object — the
+  // intuit-oauth type declarations omit refresh_token, x_refresh_token_expires_in,
+  // token_type, realmId, etc.
+  private async performRefresh(refreshToken: string): Promise<{
+    access_token: string;
+    expires_in?: number;
+    refresh_token?: string;
+    x_refresh_token_expires_in?: number;
+  }> {
+    const authResponse = await this.oauthClient.refreshUsingToken(refreshToken);
+    return authResponse.token as unknown as {
+      access_token: string;
+      expires_in?: number;
+      refresh_token?: string;
+      x_refresh_token_expires_in?: number;
+    };
+  }
+
+  // The actionable error surfaced when a production server's refresh token is
+  // dead. The interactive localhost flow cannot recover it — Intuit rejects the
+  // localhost redirect for production apps, and no human is present to complete
+  // a browser login in a host-spawned stdio subprocess — so we fail with
+  // instructions instead of opening a browser window that can never succeed.
+  private reauthError(cause?: string): Error {
+    const msg =
+      'QuickBooks authorization is invalid or expired and cannot be renewed automatically in ' +
+      'production. Re-authorize this company using a public HTTPS redirect (see the "Production ' +
+      'Setup" section of the README), then restart the server.';
+    return new Error(cause ? `${msg} (cause: ${cause})` : msg);
+  }
+
   private async startOAuthFlow(): Promise<void> {
+    // The interactive flow below binds a localhost callback server, but Intuit
+    // rejects localhost redirect URIs for production apps — so this can only
+    // ever succeed in sandbox. Fail fast with guidance rather than opening a
+    // doomed browser window on a production server.
+    if (this.environment === 'production') {
+      throw this.reauthError();
+    }
+
     if (this.isAuthenticating) {
       return;
     }
@@ -248,7 +381,7 @@ export class QuickbooksClient {
   }
 
   private saveTokensToEnv(): void {
-    const tokenPath = path.join(__dirname, '..', '..', '.env');
+    const tokenPath = ENV_PATH;
     const envContent = fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath, 'utf-8') : '';
     const envLines = envContent.split('\n');
 
@@ -334,18 +467,36 @@ export class QuickbooksClient {
 
     this.refreshInFlight = (async () => {
       try {
-        // At this point we know refreshToken is not undefined
-        const authResponse = await this.oauthClient.refreshUsingToken(this.refreshToken!);
-
-        // The intuit-oauth type declarations are incomplete — the runtime
-        // token object also contains refresh_token, x_refresh_token_expires_in,
-        // token_type, realmId, etc. Widen the type to reach those fields.
-        const token = authResponse.token as unknown as {
-          access_token: string;
-          expires_in?: number;
-          refresh_token?: string;
-          x_refresh_token_expires_in?: number;
-        };
+        // Multi-process rotation-race fix. We refresh with our in-memory token
+        // first and only consult .env AFTER it is rejected — so a valid token,
+        // including one this process just rotated but could not persist, is
+        // never proactively discarded. A sibling process sharing this .env may
+        // have rotated the token (Intuit invalidates the prior one on
+        // rotation); if the freshly-persisted disk value differs, retry once
+        // with it, turning a concurrent-rotation loss into a success rather
+        // than a spurious "token dead".
+        let token;
+        try {
+          token = await this.performRefresh(this.refreshToken!);
+        } catch (firstErr) {
+          // Only consult disk when OUR token was actually rejected: a rejection
+          // (invalid_grant/400/401) may mean a sibling rotated it, so the disk
+          // value is worth a retry. A transient error (5xx/429/network) says
+          // nothing about token validity — swapping the in-memory token for a
+          // possibly-stale disk value on a mere blip could discard a valid
+          // (e.g. rotated-but-unpersisted) token, so rethrow and let the caller
+          // retry with the token intact.
+          if (!this.isAuthInvalidation(firstErr)) {
+            throw firstErr;
+          }
+          const latest = this.readPersistedRefreshToken();
+          if (latest && latest !== this.refreshToken) {
+            this.refreshToken = latest;
+            token = await this.performRefresh(latest);
+          } else {
+            throw firstErr;
+          }
+        }
 
         this.accessToken = token.access_token;
 
@@ -373,7 +524,7 @@ export class QuickbooksClient {
         const refreshExpiresIn = token.x_refresh_token_expires_in;
         if (typeof refreshExpiresIn === 'number' && refreshExpiresIn < 14 * 24 * 3600) {
           const days = Math.round(refreshExpiresIn / 86400);
-          console.error(`[qbo-client] WARNING: refresh token expires in ~${days} day(s). Re-run \`npm run auth\` before it expires.`);
+          console.error(`[qbo-client] WARNING: refresh token expires in ~${days} day(s). Re-authorize before it expires (see README "Production Setup").`);
         }
 
         return {
@@ -382,7 +533,13 @@ export class QuickbooksClient {
         };
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to refresh Quickbooks token: ${message}`);
+        // Preserve the original error as `cause` so the caller can classify it
+        // (auth-invalidation vs transient) without re-parsing the message.
+        // Assigned rather than passed to the constructor so this compiles
+        // regardless of the configured TS lib target.
+        const wrapped = new Error(`Failed to refresh Quickbooks token: ${message}`);
+        (wrapped as Error & { cause?: unknown }).cause = error;
+        throw wrapped;
       } finally {
         this.refreshInFlight = undefined;
       }
@@ -412,11 +569,25 @@ export class QuickbooksClient {
           try {
             await this.refreshAccessToken();
           } catch (error) {
-            // A dead refresh token (rotated by another consumer, past the
-            // 100-day window, or revoked) is recoverable: fall back to the
-            // interactive OAuth flow instead of failing hard.
             const message = error instanceof Error ? error.message : String(error);
-            console.error(`[qbo-client] Token refresh failed (${message}); falling back to interactive OAuth`);
+            // A transient failure (Intuit 5xx/429, network blip) says nothing
+            // about token validity. In BOTH environments, rethrow it as-is so
+            // the caller sees a retryable error and the preserved in-memory
+            // token self-heals on the next request. Never discard a valid token
+            // or launch a browser flow over a temporary outage.
+            if (!this.isAuthInvalidation(error)) {
+              throw error;
+            }
+            // Past here the refresh token is genuinely dead (revoked, expired
+            // past the 100-day window, or rotated out).
+            if (this.environment === 'production') {
+              // The interactive fallback cannot help (localhost redirect is
+              // rejected, and nobody is watching a host-spawned subprocess to
+              // complete a browser login). Surface an actionable error.
+              throw this.reauthError(message);
+            }
+            // Sandbox: recoverable via the localhost interactive OAuth flow.
+            console.error(`[qbo-client] Refresh token rejected (${message}); falling back to interactive OAuth`);
             this.refreshToken = undefined;
             this.accessToken = undefined;
             this.accessTokenExpiry = undefined;

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -221,7 +221,9 @@ export class QuickbooksClient {
     const msg =
       'QuickBooks authorization is invalid or expired and cannot be renewed automatically in ' +
       'production. Re-authorize this company using a public HTTPS redirect (see the "Production ' +
-      'Setup" section of the README), then restart the server.';
+      'Setup" section of the README), then restart the server. Note: an HTTP 401 from the token ' +
+      'endpoint usually means invalid_client — verify QUICKBOOKS_CLIENT_ID and ' +
+      'QUICKBOOKS_CLIENT_SECRET before re-authorizing.';
     return new Error(cause ? `${msg} (cause: ${cause})` : msg);
   }
 
@@ -544,7 +546,10 @@ export class QuickbooksClient {
         const refreshExpiresIn = token.x_refresh_token_expires_in;
         if (typeof refreshExpiresIn === 'number' && refreshExpiresIn < 14 * 24 * 3600) {
           const days = Math.round(refreshExpiresIn / 86400);
-          console.error(`[qbo-client] WARNING: refresh token expires in ~${days} day(s). Re-authorize before it expires (see README "Production Setup").`);
+          const renewHint = this.environment === 'production'
+            ? 'Re-authorize before it expires (see README "Production Setup").'
+            : 'Re-run `npm run auth` before it expires.';
+          console.error(`[qbo-client] WARNING: refresh token expires in ~${days} day(s). ${renewHint}`);
         }
 
         return {

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -25,6 +25,12 @@ process.env.QUICKBOOKS_REALM_ID = '12345';
 process.env.QUICKBOOKS_ENVIRONMENT = 'sandbox';
 process.env.QUICKBOOKS_REDIRECT_URI = 'https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl';
 
+// Mock dotenv to a no-op so the module under test never loads the real .env.
+// dotenv's internal CommonJS require('fs') bypasses the ESM fs mock below, so
+// without this dotenv.config({override:true}) would clobber the env values set
+// above with whatever the real .env holds (e.g. QUICKBOOKS_ENVIRONMENT).
+jest.unstable_mockModule('dotenv', () => ({ default: { config: jest.fn(), parse: jest.fn(() => ({})) } }));
+
 // Track every OAuthClient the module constructs so tests can tell the
 // module-level client (env redirect) apart from the flow client (localhost).
 type MockOAuth = {

--- a/tests/unit/clients/quickbooks-client.resilience.test.ts
+++ b/tests/unit/clients/quickbooks-client.resilience.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Resilience tests for QuickbooksClient token handling.
+ *
+ * Covers two failure modes behind a production outage:
+ *
+ * 1. Multi-process refresh-token rotation race. A host may spawn this server
+ *    more than once against the same .env (Claude Desktop + Claude Code), and
+ *    Intuit invalidates the previous refresh token on every rotation. The
+ *    client refreshes with its in-memory token first and only consults .env
+ *    AFTER that token is rejected, retrying once with a sibling's freshly
+ *    persisted token — so a valid in-memory token (including one just rotated
+ *    but not yet persisted) is never discarded.
+ * 2. In production, a genuinely dead refresh token fails with an actionable
+ *    "re-authorize" error rather than opening the interactive localhost OAuth
+ *    flow (Intuit rejects localhost redirects for production apps). A TRANSIENT
+ *    failure (5xx/429/network) must instead stay retryable and self-heal.
+ */
+import { jest } from '@jest/globals';
+
+process.env.QUICKBOOKS_CLIENT_ID = 'test-client-id';
+process.env.QUICKBOOKS_CLIENT_SECRET = 'test-client-secret';
+process.env.QUICKBOOKS_REFRESH_TOKEN = 'seed-refresh-token';
+process.env.QUICKBOOKS_REALM_ID = '12345';
+process.env.QUICKBOOKS_ENVIRONMENT = 'sandbox';
+process.env.QUICKBOOKS_REDIRECT_URI = 'https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl';
+
+// No-op dotenv config so the real .env is never read (see auth test), plus a
+// realistic parse() that mirrors dotenv's quote/inline-comment/export handling
+// so readPersistedRefreshToken() is exercised against true dotenv semantics.
+jest.unstable_mockModule('dotenv', () => ({
+  default: {
+    config: jest.fn(),
+    parse: (src: Buffer | string) => {
+      const out: Record<string, string> = {};
+      for (const line of String(src).split(/\r?\n/)) {
+        const m = line.match(/^\s*(?:export\s+)?([\w.-]+)\s*=\s*(.*)$/);
+        if (!m) continue;
+        let v = (m[2] ?? '').trim();
+        // A quoted value at the start wins; trailing content (e.g. a comment
+        // after the closing quote) is ignored — matching dotenv.
+        const quoted = v.match(/^(['"`])((?:\\.|[^\\])*?)\1/);
+        if (quoted) v = quoted[2];
+        else v = v.split(' #')[0].trim(); // strip inline comment (unquoted only)
+        out[m[1]] = v;
+      }
+      return out;
+    },
+  },
+}));
+
+const refreshDispatch = jest.fn<(token: string) => Promise<unknown>>();
+const openMock = jest.fn(async () => undefined);
+
+jest.unstable_mockModule('intuit-oauth', () => {
+  class MockOAuthClient {
+    static scopes = { Accounting: 'com.intuit.quickbooks.accounting' };
+    cfg: Record<string, unknown>;
+    refreshUsingToken = jest.fn((token: string) => refreshDispatch(token));
+    createToken = jest.fn();
+    authorizeUri = jest.fn(() => 'https://appcenter.intuit.com/connect/oauth2?mock');
+    constructor(cfg: Record<string, unknown>) {
+      this.cfg = cfg;
+    }
+  }
+  return { default: MockOAuthClient };
+});
+
+jest.unstable_mockModule('node-quickbooks', () => ({
+  default: class MockQuickBooks {
+    constructor(..._args: unknown[]) {}
+  },
+}));
+
+jest.unstable_mockModule('open', () => ({ default: openMock }));
+
+// http.createServer must never be reached in these tests (production throws
+// before it; the rotation tests never fall back). If it is, serverCreated flips
+// so we can assert "no doomed browser flow was started".
+let serverCreated = false;
+const fakeServer = {
+  listen: jest.fn((_port: unknown, _host: unknown, cb?: () => void) => {
+    if (cb) setImmediate(cb);
+    return fakeServer;
+  }),
+  close: jest.fn(),
+  on: jest.fn(),
+  address: jest.fn(() => ({ address: '::', port: 8000, family: 'IPv6' })),
+};
+jest.unstable_mockModule('http', () => ({
+  default: {
+    createServer: jest.fn(() => {
+      serverCreated = true;
+      return fakeServer;
+    }),
+  },
+}));
+
+// Controllable fs mock: readFileSync drives readPersistedRefreshToken().
+const fsReadFileSync = jest.fn<(...args: unknown[]) => string>();
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: fsReadFileSync,
+    existsSync: jest.fn(() => false),
+    writeFileSync: jest.fn(),
+    renameSync: jest.fn(),
+    unlinkSync: jest.fn(),
+  },
+}));
+
+const { QuickbooksClient } = await import('../../../src/clients/quickbooks-client');
+
+function makeClient(overrides: Partial<{ environment: string; refreshToken: string }> = {}) {
+  return new QuickbooksClient({
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    refreshToken: overrides.refreshToken ?? 'in-memory-token',
+    realmId: '12345',
+    environment: overrides.environment ?? 'sandbox',
+    redirectUri: 'https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl',
+  });
+}
+const tokenOf = (client: unknown) => (client as { refreshToken?: string }).refreshToken;
+const envWithToken = (t: string) => `QUICKBOOKS_CLIENT_ID=x\nQUICKBOOKS_REFRESH_TOKEN=${t}\nQUICKBOOKS_REALM_ID=12345\n`;
+
+// Error fixtures mirroring intuit-oauth 4.2.1's REAL shapes, captured
+// empirically against the live library:
+//  - a rejected refresh token surfaces ONLY as the axios message
+//    "Request failed with status code 400"; error_description is "",
+//    authResponse.response is "", authResponse.status is a function -> undefined.
+//  - transient failures carry a 5xx/429 status code or a network error message.
+const deadTokenError = (code = 400) =>
+  Object.assign(new Error(`Request failed with status code ${code}`), {
+    error: `Request failed with status code ${code}`,
+    error_description: '',
+    intuit_tid: 'tid-abc',
+    authResponse: { token: {}, response: '', body: '', json: null, status: () => undefined, intuit_tid: 'tid-abc' },
+  });
+const transientError = (code?: number) =>
+  code === undefined
+    ? new Error('getaddrinfo ETIMEDOUT oauth.platform.intuit.com')
+    : Object.assign(new Error(`Request failed with status code ${code}`), {
+        error: `Request failed with status code ${code}`,
+        authResponse: { response: '', status: () => undefined },
+      });
+
+async function messageOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+    return '';
+  } catch (e) {
+    return (e as Error).message;
+  }
+}
+
+beforeEach(() => {
+  refreshDispatch.mockReset();
+  fsReadFileSync.mockReset();
+  openMock.mockClear();
+  serverCreated = false;
+  fsReadFileSync.mockImplementation(() => {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  });
+});
+
+describe('multi-process rotation race', () => {
+  it('does not consult .env when the in-memory token is valid (never discards a good token)', async () => {
+    // Regression guard: disk holds a STALE token (a prior persist failed), but
+    // the in-memory token is valid. The refresh must use memory and not touch
+    // disk — the pre-review bug adopted disk unconditionally and locked out a
+    // company whose valid token was in memory.
+    const client = makeClient({ refreshToken: 'valid-in-memory-T2' });
+    fsReadFileSync.mockReturnValue(envWithToken('stale-disk-T1'));
+    refreshDispatch.mockResolvedValueOnce({ token: { access_token: 'a1', expires_in: 3600 } });
+
+    await client.refreshAccessToken();
+
+    expect(refreshDispatch).toHaveBeenCalledTimes(1);
+    expect(refreshDispatch).toHaveBeenCalledWith('valid-in-memory-T2');
+    expect(fsReadFileSync).not.toHaveBeenCalled(); // disk only consulted on failure
+  });
+
+  it('retries with a sibling-rotated disk token after the in-memory token is REJECTED', async () => {
+    const client = makeClient({ refreshToken: 'stale-A' });
+    fsReadFileSync.mockReturnValue(envWithToken('fresh-B')); // sibling rotated & persisted
+    refreshDispatch
+      .mockRejectedValueOnce(deadTokenError(400)) // stale-A rejected (real shape)
+      .mockResolvedValueOnce({ token: { access_token: 'a2', expires_in: 3600 } }); // fresh-B works
+
+    await client.refreshAccessToken();
+
+    expect(refreshDispatch.mock.calls).toEqual([['stale-A'], ['fresh-B']]);
+  });
+
+  it('does NOT swap the in-memory token on a TRANSIENT first error (never discards a valid token)', async () => {
+    // Regression guard for the second-pass blocker: a transient blip must not
+    // cause a disk re-read that could replace a valid (rotated-but-unpersisted)
+    // in-memory token with a stale disk one.
+    const client = makeClient({ refreshToken: 'valid-T3' });
+    fsReadFileSync.mockReturnValue(envWithToken('stale-disk-T2'));
+    refreshDispatch.mockRejectedValueOnce(transientError(503));
+
+    await expect(client.refreshAccessToken()).rejects.toThrow(/Failed to refresh Quickbooks token/);
+    expect(refreshDispatch).toHaveBeenCalledTimes(1); // no retry
+    expect(fsReadFileSync).not.toHaveBeenCalled(); // disk never consulted on a transient error
+    expect(tokenOf(client)).toBe('valid-T3'); // token preserved
+  });
+
+  it('parses a quoted disk token like dotenv when falling back', async () => {
+    const client = makeClient({ refreshToken: 'dead-A' });
+    fsReadFileSync.mockReturnValue('QUICKBOOKS_REFRESH_TOKEN="fresh-B" # rotated\n'); // quoted + comment
+    refreshDispatch
+      .mockRejectedValueOnce(deadTokenError(400))
+      .mockResolvedValueOnce({ token: { access_token: 'a', expires_in: 3600 } });
+
+    await client.refreshAccessToken();
+
+    // Quotes and inline comment stripped: retry uses fresh-B, not '"fresh-B"...'.
+    expect(refreshDispatch).toHaveBeenLastCalledWith('fresh-B');
+  });
+
+  it('gives up when the disk token is unchanged after a rejection (token genuinely dead)', async () => {
+    const client = makeClient({ refreshToken: 'dead-token' });
+    fsReadFileSync.mockReturnValue(envWithToken('dead-token')); // no sibling rotation
+    refreshDispatch.mockRejectedValue(deadTokenError(400));
+
+    await expect(client.refreshAccessToken()).rejects.toThrow(/Failed to refresh Quickbooks token/);
+    expect(refreshDispatch).toHaveBeenCalledTimes(1); // no pointless retry with the same token
+  });
+});
+
+describe('production dead-token handling', () => {
+  it('throws an actionable error and never opens a browser on a real HTTP-400 dead token', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'dead-prod' });
+    fsReadFileSync.mockReturnValue(envWithToken('dead-prod'));
+    refreshDispatch.mockRejectedValue(deadTokenError(400)); // real intuit-oauth shape
+
+    await expect(client.authenticate()).rejects.toThrow(/cannot be renewed automatically in production/);
+    expect(serverCreated).toBe(false);
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a 401 as a dead token', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'revoked' });
+    fsReadFileSync.mockReturnValue(envWithToken('revoked'));
+    refreshDispatch.mockRejectedValue(deadTokenError(401));
+
+    await expect(client.authenticate()).rejects.toThrow(/cannot be renewed automatically in production/);
+  });
+
+  it('treats an explicit invalid_grant error_description as a dead token', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'dead2' });
+    fsReadFileSync.mockReturnValue(envWithToken('dead2'));
+    refreshDispatch.mockRejectedValue(
+      Object.assign(new Error('Request failed with status code 400'), {
+        error: 'invalid_grant',
+        error_description: 'Token invalid or expired',
+      })
+    );
+
+    await expect(client.authenticate()).rejects.toThrow(/cannot be renewed automatically in production/);
+  });
+
+  it('throws the same actionable error when a production server starts with no refresh token', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: '' });
+    (client as unknown as { refreshToken?: string }).refreshToken = undefined;
+
+    await expect(client.authenticate()).rejects.toThrow(/cannot be renewed automatically in production/);
+    expect(serverCreated).toBe(false);
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT report reauth for a transient error in production, and preserves the token', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'good-but-blip' });
+    fsReadFileSync.mockReturnValue(envWithToken('good-but-blip'));
+    refreshDispatch.mockRejectedValue(new Error('getaddrinfo ETIMEDOUT api.intuit.com'));
+
+    const msg = await messageOf(client.authenticate());
+    expect(msg).toMatch(/Failed to refresh Quickbooks token/);
+    expect(msg).not.toMatch(/re-authorize|renewed automatically in production/);
+    // In-memory token is NOT cleared, so the next call self-heals.
+    expect(tokenOf(client)).toBe('good-but-blip');
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a 503 as transient, not a dead token', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'fine' });
+    fsReadFileSync.mockReturnValue(envWithToken('fine'));
+    refreshDispatch.mockRejectedValue(transientError(503));
+
+    const msg = await messageOf(client.authenticate());
+    expect(msg).not.toMatch(/renewed automatically in production/);
+    expect(tokenOf(client)).toBe('fine');
+  });
+
+  it('treats a 429 rate-limit as transient, not a dead token', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'fine429' });
+    fsReadFileSync.mockReturnValue(envWithToken('fine429'));
+    refreshDispatch.mockRejectedValue(transientError(429));
+
+    const msg = await messageOf(client.authenticate());
+    expect(msg).not.toMatch(/renewed automatically in production/);
+    expect(tokenOf(client)).toBe('fine429');
+  });
+
+  it('still succeeds in production when the refresh token is valid', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'good-prod-token' });
+    fsReadFileSync.mockReturnValue(envWithToken('good-prod-token'));
+    refreshDispatch.mockResolvedValueOnce({ token: { access_token: 'a3', expires_in: 3600 } });
+
+    await expect(client.authenticate()).resolves.toBeDefined();
+    expect(serverCreated).toBe(false);
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('classifies a dead token carried deep in the error cause chain', async () => {
+    const client = makeClient({ environment: 'production', refreshToken: 'dead-deep' });
+    fsReadFileSync.mockReturnValue(envWithToken('dead-deep'));
+    // Real signal is two cause-levels down under generic wrappers.
+    const outer = Object.assign(new Error('transport wrapper'), {
+      cause: Object.assign(new Error('adapter wrapper'), { cause: deadTokenError(400) }),
+    });
+    refreshDispatch.mockRejectedValue(outer);
+
+    await expect(client.authenticate()).rejects.toThrow(/cannot be renewed automatically in production/);
+  });
+});
+
+describe('sandbox transient handling', () => {
+  it('does NOT launch interactive OAuth on a transient error in sandbox (preserves token)', async () => {
+    const client = makeClient({ environment: 'sandbox', refreshToken: 'valid-sbx' });
+    fsReadFileSync.mockReturnValue(envWithToken('valid-sbx'));
+    refreshDispatch.mockRejectedValue(transientError(503));
+
+    const msg = await messageOf(client.authenticate());
+    expect(msg).toMatch(/Failed to refresh Quickbooks token/);
+    expect(serverCreated).toBe(false); // no doomed/​spurious browser flow
+    expect(openMock).not.toHaveBeenCalled();
+    expect(tokenOf(client)).toBe('valid-sbx'); // token NOT discarded
+  });
+
+  it('DOES fall back to interactive OAuth on a genuine dead token in sandbox', async () => {
+    const client = makeClient({ environment: 'sandbox', refreshToken: 'dead-sbx' });
+    fsReadFileSync.mockReturnValue(envWithToken('dead-sbx'));
+    refreshDispatch.mockRejectedValue(deadTokenError(400));
+
+    // The localhost callback never completes in this harness, so the flow hangs;
+    // asserting the server was created proves the dead-token path was taken.
+    const authPromise = client.authenticate();
+    const started = await Promise.race([
+      (async () => {
+        for (let i = 0; i < 50 && !serverCreated; i++) await new Promise((r) => setImmediate(r));
+        return serverCreated;
+      })(),
+      authPromise.then(() => true).catch(() => true),
+    ]);
+    expect(started).toBe(true);
+    expect(serverCreated).toBe(true);
+  });
+});


### PR DESCRIPTION
fix(auth): resilient token refresh — rotation-race recovery and production fail-fast

Two failure modes could take a production server down until someone hand-edited .env:

1. Multi-process refresh-token rotation race. A host may spawn this server more than once against the same .env (e.g. Claude Desktop + Claude Code), and Intuit invalidates the prior refresh token on every ~24h rotation, so an instance holding a superseded in-memory token would fail to refresh. Fix: on a refresh REJECTION (not a transient error), re-read the token from .env — parsed via dotenv so quotes/comments/export match startup — and retry once if a sibling has since persisted a newer one. The in-memory token is consulted first and only replaced after it is actually rejected, so a valid (even rotated-but-unpersisted) token is never discarded.

2. Doomed interactive fallback in production. On a dead token the client opened a localhost OAuth flow that Intuit rejects for production apps (and that nobody can complete in a host-spawned subprocess). Fix: in production, fail fast with an actionable "re-authorize" error. A transient failure (5xx/429/network) is rethrown as retryable in BOTH environments so the preserved token self-heals — only a genuine auth-invalidation triggers the reauth error (production) or the interactive flow (sandbox).

Auth-invalidation is detected from the fields intuit-oauth 4.x actually exposes: verified empirically that a rejected refresh token surfaces only as the axios message "Request failed with status code 400" (empty body, authResponse.status() -> undefined), so the classifier parses that status, checks any structured error/error_description, and walks the cause chain.

Adds a resilience test suite (rotation recovery, transient-no-discard, production reauth vs transient, real-error-shape classification). All tests pass; no change to the happy path.

The error-shape handling was verified empirically against intuit-oauth 4.2.1: a rejected refresh token surfaces only as the axios message "Request failed with status code 400" (empty response body, authResponse.status() returns undefined), which the classifier parses. No change to the happy path; the added resilience test suite passes alongside the existing tests.