### PR TITLE
Add get_preferences tool for company settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **A comprehensive Model Context Protocol (MCP) server for QuickBooks Online**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Tools](https://img.shields.io/badge/Tools-144-green.svg)](#available-tools)
+[![Tools](https://img.shields.io/badge/Tools-145-green.svg)](#available-tools)
 [![Entities](https://img.shields.io/badge/Entities-29-orange.svg)](#entities)
 [![Reports](https://img.shields.io/badge/Reports-11-purple.svg)](#reports)
 [![Coverage](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg)](#testing)
@@ -23,7 +23,7 @@ This MCP server provides complete QuickBooks Online API integration for Claude C
 
 ### Key Features
 
-- **144 Total Tools** - Complete coverage of QuickBooks Online API
+- **145 Total Tools** - Complete coverage of QuickBooks Online API
 - **29 Entity Types** - Full CRUD operations (Create, Read, Update, Delete, Search)
 - **11 Financial Reports** - Balance Sheet, P&L, Cash Flow, and more
 - **OAuth 2.0 Authentication** - Secure token-based authentication
@@ -326,6 +326,7 @@ Complete CRUD operations are available for all entity types:
 | `get_payment_method` | Get payment method by ID |
 | `update_payment_method` | Update payment method |
 | `search_payment_methods` | Search payment methods |
+| `get_preferences` | Get company accounting and feature preferences |
 
 </details>
 

--- a/src/handlers/get-quickbooks-preferences.handler.ts
+++ b/src/handlers/get-quickbooks-preferences.handler.ts
@@ -1,0 +1,18 @@
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
+import { formatError } from "../helpers/format-error.js";
+import { ToolResponse } from "../types/tool-response.js";
+
+export async function getQuickbooksPreferences(): Promise<ToolResponse<any>> {
+  try {
+    const quickbooks = await QuickbooksClient.getInstance();
+
+    return new Promise((resolve) => {
+      (quickbooks as any).getPreferences((err: any, preferences: any) => {
+        if (err) resolve({ result: null, isError: true, error: formatError(err) });
+        else resolve({ result: preferences, isError: false, error: null });
+      });
+    });
+  } catch (error) {
+    return { result: null, isError: true, error: formatError(error) };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,9 @@ import { SearchTaxAgenciesTool } from "./tools/search-tax-agencies.tool.js";
 import { GetCompanyInfoTool } from "./tools/get-company-info.tool.js";
 import { UpdateCompanyInfoTool } from "./tools/update-company-info.tool.js";
 
+// Preferences tools
+import { GetPreferencesTool } from "./tools/get-preferences.tool.js";
+
 // Attachable tools
 import { CreateAttachableTool } from "./tools/create-attachable.tool.js";
 import { GetAttachableTool } from "./tools/get-attachable.tool.js";
@@ -403,6 +406,9 @@ const main = async () => {
   // Add tools for company info
   RegisterTool(server, GetCompanyInfoTool);
   RegisterTool(server, UpdateCompanyInfoTool);
+
+  // Add tools for preferences
+  RegisterTool(server, GetPreferencesTool);
 
   // Add tools for attachables
   RegisterTool(server, CreateAttachableTool);

--- a/src/tools/get-preferences.tool.ts
+++ b/src/tools/get-preferences.tool.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { getQuickbooksPreferences } from "../handlers/get-quickbooks-preferences.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+
+const toolName = "get_preferences";
+const toolDescription =
+  "Retrieve company preferences from QuickBooks Online, including accounting method, class and department tracking, and purchase order settings.";
+const toolSchema = z.object({});
+
+const toolHandler = async () => {
+  const response = await getQuickbooksPreferences();
+  if (response.isError) return { content: [{ type: "text" as const, text: `Error: ${response.error}` }] };
+  return { content: [{ type: "text" as const, text: JSON.stringify(response.result, null, 2) }] };
+};
+
+export const GetPreferencesTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/tests/unit/handlers/preferences.handler-tool.test.ts
+++ b/tests/unit/handlers/preferences.handler-tool.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  mockQuickbooksClient,
+  mockQuickbooksClientClass,
+  mockQuickBooksInstance,
+  resetAllMocks,
+} from '../../mocks/quickbooks.mock';
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+const { getQuickbooksPreferences } = await import('../../../src/handlers/get-quickbooks-preferences.handler');
+const { GetPreferencesTool } = await import('../../../src/tools/get-preferences.tool');
+
+describe('Preferences handler and tool', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  it('returns the complete company preferences payload', async () => {
+    const preferences = {
+      AccountingInfoPrefs: { ClassTrackingPerTxn: true },
+      ProductAndServicesPrefs: { ForPurchase: true },
+      SalesFormsPrefs: { ETransactionPaymentEnabled: false },
+    };
+    mockQuickBooksInstance.getPreferences.mockImplementation((cb: any) => cb(null, preferences));
+
+    const result = await getQuickbooksPreferences();
+
+    expect(mockQuickBooksInstance.getPreferences).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ result: preferences, isError: false, error: null });
+  });
+
+  it('returns a formatted QuickBooks API error', async () => {
+    mockQuickBooksInstance.getPreferences.mockImplementation((cb: any) =>
+      cb(new Error('Preferences read failed'), null)
+    );
+
+    const result = await getQuickbooksPreferences();
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('Preferences read failed');
+  });
+
+  it('returns a formatted authentication error', async () => {
+    (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
+
+    const result = await getQuickbooksPreferences();
+
+    expect(result.isError).toBe(true);
+    expect(result.error).toContain('Auth failed');
+  });
+
+  it('exposes a parameterless read tool and serializes successful responses', async () => {
+    const preferences = { AccountingInfoPrefs: { DefaultTaxRateRef: { value: '2' } } };
+    mockQuickBooksInstance.getPreferences.mockImplementation((cb: any) => cb(null, preferences));
+
+    const result = await GetPreferencesTool.handler({ params: {} } as any, {} as any);
+
+    expect(GetPreferencesTool.name).toBe('get_preferences');
+    expect(GetPreferencesTool.schema.parse({})).toEqual({});
+    expect(result).toEqual({
+      content: [{ type: 'text', text: JSON.stringify(preferences, null, 2) }],
+    });
+  });
+
+  it('serializes handler errors for MCP clients', async () => {
+    mockQuickBooksInstance.getPreferences.mockImplementation((cb: any) =>
+      cb(new Error('Not authorized'), null)
+    );
+
+    const result = await GetPreferencesTool.handler({ params: {} } as any, {} as any);
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: Error: Not authorized' }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a read-only `get_preferences` MCP tool backed by the existing QuickBooks `getPreferences` API
- register the tool and document the updated 145-tool surface
- cover successful responses, QuickBooks API errors, authentication errors, and MCP response serialization

## Why

This completes the remaining Preferences scope in #89. The returned QBO Preferences payload exposes the accounting method and company feature settings used for class, department, and purchase-order workflows.

Closes #89

## Validation

- `npm run build`
- `npm test -- --runInBand` (33 suites, 609 tests passed)
- focused Preferences suite (5 tests passed)
- `git diff --check`

`npm run lint` currently cannot start because the repository uses ESLint 9 but does not contain an `eslint.config.js`, `eslint.config.mjs`, or `eslint.config.cjs` file.
