### PR TITLE
fix: forward tax fields on create tools; read-merge-write update sema…

### DIFF
--- a/src/handlers/create-quickbooks-bill.handler.ts
+++ b/src/handlers/create-quickbooks-bill.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { normalizePayloadGlobalTax } from "../helpers/global-tax.js";
 
 /**
  * Create a bill in QuickBooks Online
@@ -8,6 +9,11 @@ import { formatError } from "../helpers/format-error.js";
 export async function createQuickbooksBill(bill: any): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
+
+    // Normalize GlobalTaxCalculation (maps the common "TaxExclusive"
+    // misspelling to "TaxExcluded"; rejects unknown values with a clear error
+    // instead of QBO's opaque parse fault).
+    normalizePayloadGlobalTax(bill);
 
     // Auto-nest flat line items into QBO's expected nested structure.
     // If caller sends AccountRef at line level (legacy shape), move it under AccountBasedExpenseLineDetail.

--- a/src/handlers/create-quickbooks-purchase.handler.ts
+++ b/src/handlers/create-quickbooks-purchase.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { normalizePayloadGlobalTax } from "../helpers/global-tax.js";
 
 /**
  * Create a purchase in QuickBooks Online
@@ -9,6 +10,11 @@ import { formatError } from "../helpers/format-error.js";
 export async function createQuickbooksPurchase(purchaseData: any): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
+
+    // Forward GlobalTaxCalculation verbatim after normalizing the common
+    // "TaxExclusive" misspelling — an invalid enum reaching QBO fails the
+    // whole request with an opaque "Failed to parse json object" fault.
+    normalizePayloadGlobalTax(purchaseData ?? {});
 
     return new Promise((resolve) => {
       quickbooks.createPurchase(purchaseData, (err: any, purchase: any) => {

--- a/src/handlers/update-quickbooks-bill-payment.handler.ts
+++ b/src/handlers/update-quickbooks-bill-payment.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 /**
  * Update a bill payment in QuickBooks Online
@@ -10,8 +11,14 @@ export async function updateQuickbooksBillPayment(billPaymentData: any): Promise
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
+    // Read-merge-write: QBO's full-update semantics null omitted fields and
+    // sparse updates are unreliable. Fetch the current entity, merge the
+    // caller's changes over it, and send a complete payload.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getBillPayment"), billPaymentData);
+
     return new Promise((resolve) => {
-      quickbooks.updateBillPayment(billPaymentData, (err: any, billPayment: any) => {
+      quickbooks.updateBillPayment(merged, (err: any, billPayment: any) => {
         if (err) {
           resolve({
             result: null,

--- a/src/handlers/update-quickbooks-class.handler.ts
+++ b/src/handlers/update-quickbooks-class.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateClassInput {
   id: string;
@@ -16,8 +17,14 @@ export async function updateQuickbooksClass(data: UpdateClassInput): Promise<Too
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getClass"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateClass(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateClass(merged, (err: any, updated: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
         else resolve({ result: updated, isError: false, error: null });
       });

--- a/src/handlers/update-quickbooks-credit-memo.handler.ts
+++ b/src/handlers/update-quickbooks-credit-memo.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateCreditMemoInput {
   id: string;
@@ -30,8 +31,14 @@ export async function updateQuickbooksCreditMemo(data: UpdateCreditMemoInput): P
       payload.DocNumber = data.doc_number;
     }
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getCreditMemo"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateCreditMemo(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateCreditMemo(merged, (err: any, updated: any) => {
         if (err) {
           resolve({ result: null, isError: true, error: formatError(err) });
         } else {

--- a/src/handlers/update-quickbooks-customer.handler.ts
+++ b/src/handlers/update-quickbooks-customer.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 /**
  * Update an existing customer in QuickBooks Online
@@ -10,8 +11,14 @@ export async function updateQuickbooksCustomer(customerData: any): Promise<ToolR
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
+    // Read-merge-write: QBO's full-update semantics null omitted fields and
+    // sparse updates are unreliable. Fetch the current entity, merge the
+    // caller's changes over it, and send a complete payload.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getCustomer"), customerData);
+
     return new Promise((resolve) => {
-      quickbooks.updateCustomer(customerData, (err: any, customer: any) => {
+      quickbooks.updateCustomer(merged, (err: any, customer: any) => {
         if (err) {
           resolve({
             result: null,

--- a/src/handlers/update-quickbooks-department.handler.ts
+++ b/src/handlers/update-quickbooks-department.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateDepartmentInput {
   id: string;
@@ -16,8 +17,14 @@ export async function updateQuickbooksDepartment(data: UpdateDepartmentInput): P
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getDepartment"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateDepartment(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateDepartment(merged, (err: any, updated: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
         else resolve({ result: updated, isError: false, error: null });
       });

--- a/src/handlers/update-quickbooks-deposit.handler.ts
+++ b/src/handlers/update-quickbooks-deposit.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateDepositInput {
   id: string;
@@ -14,8 +15,14 @@ export async function updateQuickbooksDeposit(data: UpdateDepositInput): Promise
     const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
     if (data.private_note) payload.PrivateNote = data.private_note;
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getDeposit"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateDeposit(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateDeposit(merged, (err: any, updated: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
         else resolve({ result: updated, isError: false, error: null });
       });

--- a/src/handlers/update-quickbooks-employee.handler.ts
+++ b/src/handlers/update-quickbooks-employee.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 /**
  * Update an employee in QuickBooks Online
@@ -10,8 +11,14 @@ export async function updateQuickbooksEmployee(employeeData: any): Promise<ToolR
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
+    // Read-merge-write: QBO's full-update semantics null omitted fields and
+    // sparse updates are unreliable. Fetch the current entity, merge the
+    // caller's changes over it, and send a complete payload.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getEmployee"), employeeData);
+
     return new Promise((resolve) => {
-      quickbooks.updateEmployee(employeeData, (err: any, employee: any) => {
+      quickbooks.updateEmployee(merged, (err: any, employee: any) => {
         if (err) {
           resolve({
             result: null,

--- a/src/handlers/update-quickbooks-estimate.handler.ts
+++ b/src/handlers/update-quickbooks-estimate.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 /**
  * Update an estimate in QuickBooks Online (must include Id and SyncToken)
@@ -9,8 +10,14 @@ export async function updateQuickbooksEstimate(estimateData: any): Promise<ToolR
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
+    // Read-merge-write: QBO's full-update semantics null omitted fields and
+    // sparse updates are unreliable. Fetch the current entity, merge the
+    // caller's changes over it, and send a complete payload.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getEstimate"), estimateData);
+
     return new Promise((resolve) => {
-      quickbooks.updateEstimate(estimateData, (err: any, estimate: any) => {
+      quickbooks.updateEstimate(merged, (err: any, estimate: any) => {
         if (err) {
           resolve({
             result: null,

--- a/src/handlers/update-quickbooks-invoice.handler.ts
+++ b/src/handlers/update-quickbooks-invoice.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateInvoiceInput {
   invoice_id: string;
@@ -18,8 +19,14 @@ export async function updateQuickbooksInvoice({ invoice_id, patch }: UpdateInvoi
 
     const updatePayload = { ...existing, ...patch, Id: invoice_id, sparse: true };
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getInvoice"), updatePayload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateInvoice(updatePayload, (err: any, updated: any) => {
+      (quickbooks as any).updateInvoice(merged, (err: any, updated: any) => {
         if (err) {
           resolve({ result: null, isError: true, error: formatError(err) });
         } else {

--- a/src/handlers/update-quickbooks-item.handler.ts
+++ b/src/handlers/update-quickbooks-item.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateItemInput {
   item_id: string;
@@ -18,8 +19,14 @@ export async function updateQuickbooksItem({ item_id, patch }: UpdateItemInput):
 
     const payload = { ...existing, ...patch, Id: item_id, sparse: true };
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getItem"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateItem(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateItem(merged, (err: any, updated: any) => {
         if (err) {
           resolve({ result: null, isError: true, error: formatError(err) });
         } else {

--- a/src/handlers/update-quickbooks-journal-entry.handler.ts
+++ b/src/handlers/update-quickbooks-journal-entry.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 /**
  * Update a journal entry in QuickBooks Online
@@ -10,8 +11,14 @@ export async function updateQuickbooksJournalEntry(journalEntryData: any): Promi
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
+    // Read-merge-write: QBO's full-update semantics null omitted fields and
+    // sparse updates are unreliable. Fetch the current entity, merge the
+    // caller's changes over it, and send a complete payload.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getJournalEntry"), journalEntryData);
+
     return new Promise((resolve) => {
-      quickbooks.updateJournalEntry(journalEntryData, (err: any, journalEntry: any) => {
+      quickbooks.updateJournalEntry(merged, (err: any, journalEntry: any) => {
         if (err) {
           resolve({
             result: null,

--- a/src/handlers/update-quickbooks-payment-method.handler.ts
+++ b/src/handlers/update-quickbooks-payment-method.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdatePaymentMethodInput {
   id: string;
@@ -16,8 +17,14 @@ export async function updateQuickbooksPaymentMethod(data: UpdatePaymentMethodInp
     if (data.name) payload.Name = data.name;
     if (data.active !== undefined) payload.Active = data.active;
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getPaymentMethod"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updatePaymentMethod(payload, (err: any, updated: any) => {
+      (quickbooks as any).updatePaymentMethod(merged, (err: any, updated: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
         else resolve({ result: updated, isError: false, error: null });
       });

--- a/src/handlers/update-quickbooks-payment.handler.ts
+++ b/src/handlers/update-quickbooks-payment.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdatePaymentInput {
   id: string;
@@ -9,6 +10,7 @@ export interface UpdatePaymentInput {
   total_amt?: number;
   payment_method_ref?: string;
   private_note?: string;
+  deposit_to_account_ref?: string;
 }
 
 export async function updateQuickbooksPayment(data: UpdatePaymentInput): Promise<ToolResponse<any>> {
@@ -33,9 +35,20 @@ export async function updateQuickbooksPayment(data: UpdatePaymentInput): Promise
     if (data.private_note) {
       paymentPayload.PrivateNote = data.private_note;
     }
+    // Payment.DepositToAccountRef is writable — previously accepted by the
+    // tool but silently dropped here (defect #8).
+    if (data.deposit_to_account_ref) {
+      paymentPayload.DepositToAccountRef = { value: data.deposit_to_account_ref };
+    }
+
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getPayment"), paymentPayload);
 
     return new Promise((resolve) => {
-      (quickbooks as any).updatePayment(paymentPayload, (err: any, updated: any) => {
+      (quickbooks as any).updatePayment(merged, (err: any, updated: any) => {
         if (err) {
           resolve({ result: null, isError: true, error: formatError(err) });
         } else {

--- a/src/handlers/update-quickbooks-payment.handler.ts
+++ b/src/handlers/update-quickbooks-payment.handler.ts
@@ -11,6 +11,13 @@ export interface UpdatePaymentInput {
   payment_method_ref?: string;
   private_note?: string;
   deposit_to_account_ref?: string;
+  line?: Array<{
+    amount: number;
+    linked_txn: Array<{
+      txn_id: string;
+      txn_type: string;
+    }>;
+  }>;
 }
 
 export async function updateQuickbooksPayment(data: UpdatePaymentInput): Promise<ToolResponse<any>> {
@@ -40,12 +47,32 @@ export async function updateQuickbooksPayment(data: UpdatePaymentInput): Promise
     if (data.deposit_to_account_ref) {
       paymentPayload.DepositToAccountRef = { value: data.deposit_to_account_ref };
     }
+    // Applications (Payment.Line[].LinkedTxn) — same mapping as create_payment,
+    // so an unapplied payment can be settled against an invoice. QBO treats the
+    // Line array as authoritative, so this REPLACES existing applications; the
+    // tool description tells callers to re-send any they want to keep.
+    if (data.line) {
+      paymentPayload.Line = data.line.map((l) => ({
+        Amount: l.amount,
+        LinkedTxn: l.linked_txn.map((lt) => ({
+          TxnId: lt.txn_id,
+          TxnType: lt.txn_type,
+        })),
+      }));
+    }
 
     // Read-merge-write: QBO sparse updates are unreliable (omitted fields
     // can be nulled; line-bearing sparse updates are rejected). Fetch the
     // current entity, merge changes over it, send a full update.
 
-    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getPayment"), paymentPayload);
+    // TotalAmt is kept from the fetched payment: for a Payment it is the money
+    // actually received, not a derived total. Dropping it (the default for
+    // amount fields) would let QBO re-derive it from the lines, so applying a
+    // partial amount could silently rewrite the payment's value. A caller who
+    // passes total_amt still overrides it.
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getPayment"), paymentPayload, {
+      keepFromCurrent: ["TotalAmt"],
+    });
 
     return new Promise((resolve) => {
       (quickbooks as any).updatePayment(merged, (err: any, updated: any) => {

--- a/src/handlers/update-quickbooks-purchase-order.handler.ts
+++ b/src/handlers/update-quickbooks-purchase-order.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdatePurchaseOrderInput {
   id: string;
@@ -24,8 +25,14 @@ export async function updateQuickbooksPurchaseOrder(data: UpdatePurchaseOrderInp
     if (data.private_note) payload.PrivateNote = data.private_note;
     if (data.doc_number) payload.DocNumber = data.doc_number;
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getPurchaseOrder"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updatePurchaseOrder(payload, (err: any, updated: any) => {
+      (quickbooks as any).updatePurchaseOrder(merged, (err: any, updated: any) => {
         if (err) {
           resolve({ result: null, isError: true, error: formatError(err) });
         } else {

--- a/src/handlers/update-quickbooks-purchase.handler.ts
+++ b/src/handlers/update-quickbooks-purchase.handler.ts
@@ -1,6 +1,8 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { normalizePayloadGlobalTax } from "../helpers/global-tax.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 /**
  * Update a purchase in QuickBooks Online
@@ -9,9 +11,16 @@ import { formatError } from "../helpers/format-error.js";
 export async function updateQuickbooksPurchase(purchaseData: any): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
+    normalizePayloadGlobalTax(purchaseData ?? {});
+
+    // Read-merge-write: QBO's full-update semantics null omitted fields and
+    // sparse updates are unreliable. Fetch the current entity, merge the
+    // caller's changes over it, and send a complete payload.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getPurchase"), purchaseData);
 
     return new Promise((resolve) => {
-      quickbooks.updatePurchase(purchaseData, (err: any, purchase: any) => {
+      quickbooks.updatePurchase(merged, (err: any, purchase: any) => {
         if (err) {
           resolve({
             result: null,

--- a/src/handlers/update-quickbooks-refund-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-refund-receipt.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateRefundReceiptInput {
   id: string;
@@ -30,8 +31,14 @@ export async function updateQuickbooksRefundReceipt(data: UpdateRefundReceiptInp
       payload.DocNumber = data.doc_number;
     }
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getRefundReceipt"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateRefundReceipt(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateRefundReceipt(merged, (err: any, updated: any) => {
         if (err) {
           resolve({ result: null, isError: true, error: formatError(err) });
         } else {

--- a/src/handlers/update-quickbooks-sales-receipt.handler.ts
+++ b/src/handlers/update-quickbooks-sales-receipt.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateSalesReceiptInput {
   id: string;
@@ -30,8 +31,14 @@ export async function updateQuickbooksSalesReceipt(data: UpdateSalesReceiptInput
       payload.DocNumber = data.doc_number;
     }
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getSalesReceipt"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateSalesReceipt(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateSalesReceipt(merged, (err: any, updated: any) => {
         if (err) {
           resolve({ result: null, isError: true, error: formatError(err) });
         } else {

--- a/src/handlers/update-quickbooks-term.handler.ts
+++ b/src/handlers/update-quickbooks-term.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateTermInput {
   id: string;
@@ -22,8 +23,14 @@ export async function updateQuickbooksTerm(data: UpdateTermInput): Promise<ToolR
     if (data.discount_days !== undefined) payload.DiscountDays = data.discount_days;
     if (data.discount_percent !== undefined) payload.DiscountPercent = data.discount_percent;
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getTerm"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateTerm(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateTerm(merged, (err: any, updated: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
         else resolve({ result: updated, isError: false, error: null });
       });

--- a/src/handlers/update-quickbooks-time-activity.handler.ts
+++ b/src/handlers/update-quickbooks-time-activity.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateTimeActivityInput {
   id: string;
@@ -22,8 +23,14 @@ export async function updateQuickbooksTimeActivity(data: UpdateTimeActivityInput
     if (data.billable_status) payload.BillableStatus = data.billable_status;
     if (data.item_ref) payload.ItemRef = { value: data.item_ref };
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getTimeActivity"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateTimeActivity(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateTimeActivity(merged, (err: any, updated: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
         else resolve({ result: updated, isError: false, error: null });
       });

--- a/src/handlers/update-quickbooks-transfer.handler.ts
+++ b/src/handlers/update-quickbooks-transfer.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateTransferInput {
   id: string;
@@ -20,8 +21,14 @@ export async function updateQuickbooksTransfer(data: UpdateTransferInput): Promi
     if (data.amount !== undefined) payload.Amount = data.amount;
     if (data.private_note) payload.PrivateNote = data.private_note;
 
+    // Read-merge-write: QBO sparse updates are unreliable (omitted fields
+    // can be nulled; line-bearing sparse updates are rejected). Fetch the
+    // current entity, merge changes over it, send a full update.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getTransfer"), payload);
+
     return new Promise((resolve) => {
-      (quickbooks as any).updateTransfer(payload, (err: any, updated: any) => {
+      (quickbooks as any).updateTransfer(merged, (err: any, updated: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
         else resolve({ result: updated, isError: false, error: null });
       });

--- a/src/handlers/update-quickbooks-vendor-credit.handler.ts
+++ b/src/handlers/update-quickbooks-vendor-credit.handler.ts
@@ -6,6 +6,7 @@ import {
   GlobalTaxCalculation,
   VendorCreditLineItemInput,
 } from "./create-quickbooks-vendor-credit.handler.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 export interface UpdateVendorCreditInput {
   id: string;
@@ -20,39 +21,17 @@ export async function updateQuickbooksVendorCredit(data: UpdateVendorCreditInput
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
-    let payload: any;
-    if (data.line_items) {
-      // Replacing lines requires a FULL update: QBO rejects sparse updates
-      // that carry a Line array ("Required parameter VendorRef is missing",
-      // error 2020). Read the current entity and merge so every field the
-      // caller didn't override is preserved, then let QBO recompute
-      // TxnTaxDetail from the new lines' tax codes.
-      const existing: any = await new Promise((resolve, reject) => {
-        (quickbooks as any).getVendorCredit(data.id, (err: any, found: any) =>
-          err ? reject(err) : resolve(found)
-        );
-      });
-      const {
-        TxnTaxDetail: _txnTax, // recomputed by QBO from the new lines
-        TotalAmt: _totalAmt, // derived — recomputed by QBO
-        Balance: _balance, // derived — recomputed by QBO
-        MetaData: _metaData, // read-only
-        ...base
-      } = existing;
-      payload = {
-        ...base,
-        Id: data.id,
-        SyncToken: data.sync_token,
-        sparse: false,
-        Line: data.line_items.map(buildVendorCreditLine),
-      };
-    } else {
-      payload = { Id: data.id, SyncToken: data.sync_token, sparse: true };
-    }
-
-    if (data.vendor_ref) payload.VendorRef = { value: data.vendor_ref };
-    if (data.private_note) payload.PrivateNote = data.private_note;
-    if (data.global_tax_calculation) payload.GlobalTaxCalculation = data.global_tax_calculation;
+    // Read-merge-write for EVERY update (line-replacing or not): QBO rejects
+    // sparse updates that carry a Line array (error 2020), and sparse
+    // semantics proved unreliable for other fields too. Fetch the current
+    // entity, merge changes over it, send a full payload; QBO recomputes
+    // TxnTaxDetail from the merged lines' tax codes.
+    const changes: any = { Id: data.id, SyncToken: data.sync_token };
+    if (data.line_items) changes.Line = data.line_items.map(buildVendorCreditLine);
+    if (data.vendor_ref) changes.VendorRef = { value: data.vendor_ref };
+    if (data.private_note) changes.PrivateNote = data.private_note;
+    if (data.global_tax_calculation) changes.GlobalTaxCalculation = data.global_tax_calculation;
+    const payload = await mergeForFullUpdate(promisifyGetter(quickbooks, "getVendorCredit"), changes);
 
     return new Promise((resolve) => {
       (quickbooks as any).updateVendorCredit(payload, (err: any, updated: any) => {

--- a/src/handlers/update-quickbooks-vendor.handler.ts
+++ b/src/handlers/update-quickbooks-vendor.handler.ts
@@ -1,6 +1,7 @@
 import { QuickbooksClient } from "../clients/quickbooks-client.js";
 import { ToolResponse } from "../types/tool-response.js";
 import { formatError } from "../helpers/format-error.js";
+import { mergeForFullUpdate, promisifyGetter } from "../helpers/read-merge-write.js";
 
 /**
  * Update a vendor in QuickBooks Online
@@ -9,8 +10,14 @@ export async function updateQuickbooksVendor(vendor: any): Promise<ToolResponse<
   try {
     const quickbooks = await QuickbooksClient.getInstance();
 
+    // Read-merge-write: QBO's full-update semantics null omitted fields and
+    // sparse updates are unreliable. Fetch the current entity, merge the
+    // caller's changes over it, and send a complete payload.
+
+    const merged = await mergeForFullUpdate(promisifyGetter(quickbooks, "getVendor"), vendor);
+
     return new Promise((resolve) => {
-      quickbooks.updateVendor(vendor, (err: any, updatedVendor: any) => {
+      quickbooks.updateVendor(merged, (err: any, updatedVendor: any) => {
         if (err) {
           resolve({
             result: null,

--- a/src/helpers/global-tax.ts
+++ b/src/helpers/global-tax.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+// QBO's real GlobalTaxCalculation enum. "TaxExclusive" is a common misspelling
+// of "TaxExcluded" — QBO rejects it with an opaque HTTP-400 "Failed to parse
+// json object" Fault (the request never posts), so we normalize it client-side
+// and fail anything else with an actionable message instead.
+export const QBO_GLOBAL_TAX_VALUES = ["TaxExcluded", "TaxInclusive", "NotApplicable"] as const;
+export type QboGlobalTaxCalculation = (typeof QBO_GLOBAL_TAX_VALUES)[number];
+
+const ALIASES: Record<string, QboGlobalTaxCalculation> = {
+  taxexclusive: "TaxExcluded", // the misspelling QBO chokes on
+  taxexcluded: "TaxExcluded",
+  taxinclusive: "TaxInclusive",
+  notapplicable: "NotApplicable",
+};
+
+// Schema for tool inputs: advertises the three real values plus the known
+// misspelling so callers get client-side validation rather than a QBO parse
+// fault. Handlers MUST pass the accepted value through
+// normalizeGlobalTaxCalculation before forwarding.
+export const globalTaxCalculationInputSchema = z
+  .enum([...QBO_GLOBAL_TAX_VALUES, "TaxExclusive"])
+  .describe(
+    "How line amounts relate to tax: TaxExcluded (tax added on top), TaxInclusive (tax contained within amounts), or NotApplicable. 'TaxExclusive' is accepted as an alias and normalized to 'TaxExcluded'."
+  );
+
+/**
+ * Normalize a GlobalTaxCalculation value to QBO's exact enum spelling.
+ * Returns undefined for undefined/null input. Throws an Error with a clear,
+ * actionable message for anything unrecognized — never let an invalid value
+ * reach QBO, whose response is an opaque parse fault.
+ */
+export function normalizeGlobalTaxCalculation(value: unknown): QboGlobalTaxCalculation | undefined {
+  if (value === undefined || value === null) return undefined;
+  const normalized = ALIASES[String(value).toLowerCase()];
+  if (!normalized) {
+    throw new Error(
+      `Invalid GlobalTaxCalculation "${String(value)}". Valid values: ${QBO_GLOBAL_TAX_VALUES.join(", ")} ` +
+        `("TaxExclusive" is also accepted and mapped to "TaxExcluded").`
+    );
+  }
+  return normalized;
+}
+
+/**
+ * In-place normalization for QBO-shaped payload objects (create-bill,
+ * create_purchase, ...) that carry GlobalTaxCalculation verbatim.
+ */
+export function normalizePayloadGlobalTax<T extends { GlobalTaxCalculation?: unknown }>(payload: T): T {
+  if (payload && payload.GlobalTaxCalculation !== undefined) {
+    payload.GlobalTaxCalculation = normalizeGlobalTaxCalculation(payload.GlobalTaxCalculation);
+  }
+  return payload;
+}

--- a/src/helpers/read-merge-write.ts
+++ b/src/helpers/read-merge-write.ts
@@ -1,0 +1,59 @@
+// Generic read-merge-write for QBO entity updates.
+//
+// QBO's "sparse" update semantics proved unreliable in production: for several
+// transaction entities a partial payload silently nulls omitted fields, and
+// sparse updates that replace Line arrays are rejected outright (error 2020).
+// The deterministic pattern is: GET the current entity, merge the caller's
+// changes over it, and send a FULL update — so every field the caller did not
+// touch is preserved exactly, and every field they did touch is forwarded.
+
+// Fields never sent back on update: derived amounts QBO recomputes, and
+// read-only metadata. TxnTaxDetail is stripped from the FETCHED entity (so tax
+// is recomputed from the merged lines' TaxCodeRefs) but honored when the
+// CALLER supplies it explicitly — per-invoice exact-tax overrides depend on
+// that (PercentBased:false TaxLine overrides).
+const STRIP_FROM_CURRENT = [
+  "TxnTaxDetail",
+  "TotalAmt",
+  "HomeTotalAmt",
+  "Balance",
+  "HomeBalance",
+  "MetaData",
+  "domain",
+  "sparse",
+  "SyncToken", // the caller's token wins — stale-copy writes must 409, not succeed
+] as const;
+
+export interface ReadMergeWriteOptions {
+  /** Additional fields to strip from the fetched entity before merging. */
+  extraStrip?: string[];
+}
+
+/**
+ * Fetch the current entity, merge `changes` over it, and return the full
+ * payload to send as a non-sparse update. `getFn` is the promisified getter.
+ */
+export async function mergeForFullUpdate(
+  getFn: (id: string) => Promise<any>,
+  changes: Record<string, any>,
+  options: ReadMergeWriteOptions = {}
+): Promise<Record<string, any>> {
+  const id = changes.Id;
+  if (!id) throw new Error("read-merge-write update requires Id");
+  const current = await getFn(String(id));
+  const base: Record<string, any> = { ...(current ?? {}) };
+  for (const field of STRIP_FROM_CURRENT) delete base[field];
+  for (const field of options.extraStrip ?? []) delete base[field];
+  return { ...base, ...changes, Id: String(id), sparse: false };
+}
+
+/** Promisify a node-quickbooks getter method (getBill, getPurchase, ...). */
+export function promisifyGetter(quickbooks: any, getterName: string): (id: string) => Promise<any> {
+  if (typeof quickbooks?.[getterName] !== "function") {
+    throw new Error(`QuickBooks client has no ${getterName} method`);
+  }
+  return (id: string) =>
+    new Promise((resolve, reject) => {
+      quickbooks[getterName](id, (err: any, found: any) => (err ? reject(err) : resolve(found)));
+    });
+}

--- a/src/helpers/read-merge-write.ts
+++ b/src/helpers/read-merge-write.ts
@@ -27,6 +27,15 @@ const STRIP_FROM_CURRENT = [
 export interface ReadMergeWriteOptions {
   /** Additional fields to strip from the fetched entity before merging. */
   extraStrip?: string[];
+  /**
+   * Fields to KEEP from the fetched entity that STRIP_FROM_CURRENT would
+   * otherwise drop. For entities where an "amount" is an input rather than a
+   * derived total — Payment.TotalAmt is the money actually received, not a sum
+   * QBO should recompute — dropping it either fails the update or lets QBO
+   * re-derive it from the lines, silently changing the recorded amount. The
+   * caller's own value still wins when supplied.
+   */
+  keepFromCurrent?: string[];
 }
 
 /**
@@ -42,7 +51,10 @@ export async function mergeForFullUpdate(
   if (!id) throw new Error("read-merge-write update requires Id");
   const current = await getFn(String(id));
   const base: Record<string, any> = { ...(current ?? {}) };
-  for (const field of STRIP_FROM_CURRENT) delete base[field];
+  const keep = new Set(options.keepFromCurrent ?? []);
+  for (const field of STRIP_FROM_CURRENT) {
+    if (!keep.has(field)) delete base[field];
+  }
   for (const field of options.extraStrip ?? []) delete base[field];
   return { ...base, ...changes, Id: String(id), sparse: false };
 }

--- a/src/tools/create-bill.tool.ts
+++ b/src/tools/create-bill.tool.ts
@@ -1,6 +1,7 @@
 import { createQuickbooksBill } from "../handlers/create-quickbooks-bill.handler.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { globalTaxCalculationInputSchema } from "../helpers/global-tax.js";
 
 const toolName = "create-bill";
 const toolDescription = "Create a bill in QuickBooks Online.";
@@ -9,6 +10,36 @@ const refSchema = z.object({
   value: z.string(),
   name: z.string().optional(),
 });
+
+// Explicit TxnTaxDetail so per-invoice exact-tax overrides (PercentBased:false
+// TaxLine entries, e.g. tax 7.42 where 13% computes 7.43) are declared and
+// therefore never stripped by schema validation. QBO honors explicit TaxLine
+// overrides on current minorversions when the txn carries line TaxCodeRefs.
+const txnTaxDetailSchema = z
+  .object({
+    TotalTax: z.number().optional(),
+    TxnTaxCodeRef: refSchema.optional(),
+    TaxLine: z
+      .array(
+        z
+          .object({
+            Amount: z.number().optional(),
+            DetailType: z.string().optional(),
+            TaxLineDetail: z
+              .object({
+                TaxRateRef: refSchema.optional(),
+                PercentBased: z.boolean().optional(),
+                TaxPercent: z.number().optional(),
+                NetAmountTaxable: z.number().optional(),
+              })
+              .passthrough()
+              .optional(),
+          })
+          .passthrough()
+      )
+      .optional(),
+  })
+  .passthrough();
 
 const lineSchema = z.object({
   Amount: z.number(),
@@ -24,12 +55,16 @@ const lineSchema = z.object({
     ClassRef: refSchema.optional(),
     TaxCodeRef: refSchema.optional(),
   }).optional(),
+  // TaxCodeRef/ClassRef on item lines: without them, taxed inventory
+  // purchases force TaxCodeRef=NON and lose class tracking (defect #5).
   ItemBasedExpenseLineDetail: z.object({
     ItemRef: refSchema,
     Qty: z.number().optional(),
     UnitPrice: z.number().optional(),
     BillableStatus: z.string().optional(),
     CustomerRef: refSchema.optional(),
+    ClassRef: refSchema.optional(),
+    TaxCodeRef: refSchema.optional(),
   }).optional(),
 }).passthrough();
 
@@ -42,6 +77,14 @@ const toolSchema = z.object({
     DocNumber: z.string().optional(),
     PrivateNote: z.string().optional(),
     APAccountRef: refSchema.optional(),
+    CurrencyRef: refSchema.optional(),
+    ExchangeRate: z.number().optional(),
+    DepartmentRef: refSchema.optional(),
+    // Declared explicitly (not left to passthrough) so schema validation can
+    // never strip them — undeclared fields silently vanishing is exactly how
+    // GlobalTaxCalculation was lost on create (defect #1).
+    GlobalTaxCalculation: globalTaxCalculationInputSchema.optional(),
+    TxnTaxDetail: txnTaxDetailSchema.optional(),
     Balance: z.number().optional(),
     TotalAmt: z.number().optional(),
   }).passthrough(),

--- a/src/tools/create-purchase.tool.ts
+++ b/src/tools/create-purchase.tool.ts
@@ -1,14 +1,73 @@
 import { createQuickbooksPurchase } from "../handlers/create-quickbooks-purchase.handler.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { globalTaxCalculationInputSchema } from "../helpers/global-tax.js";
 
 // Define the tool metadata
 const toolName = "create_purchase";
-const toolDescription = "Create a purchase in QuickBooks Online.";
+const toolDescription =
+  "Create a purchase (expense/cheque/credit-card charge) in QuickBooks Online. For companies on the global tax model (CA/UK/AU), set line-level TaxCodeRef and a top-level GlobalTaxCalculation (TaxExcluded adds tax on top of line amounts; TaxInclusive extracts it from them). An explicit TxnTaxDetail with PercentBased:false TaxLine entries overrides QBO's computed tax for exact per-document amounts.";
 
-// Define the expected input schema for creating a purchase
+const refSchema = z.object({ value: z.string(), name: z.string().optional() });
+
+// The previous schema was `purchase: z.any()` — with no declared properties,
+// fields like GlobalTaxCalculation were silently stripped before the handler
+// ran (defect #1: TaxInclusive purchases posted as NotApplicable). Every
+// forwardable field is now declared explicitly; passthrough keeps the schema
+// open for the long tail of QBO Purchase fields.
+const purchaseLineSchema = z
+  .object({
+    Amount: z.number(),
+    DetailType: z.string(),
+    Description: z.string().optional(),
+    AccountBasedExpenseLineDetail: z
+      .object({
+        AccountRef: refSchema,
+        BillableStatus: z.string().optional(),
+        CustomerRef: refSchema.optional(),
+        ClassRef: refSchema.optional(),
+        TaxCodeRef: refSchema.optional(),
+      })
+      .passthrough()
+      .optional(),
+    ItemBasedExpenseLineDetail: z
+      .object({
+        ItemRef: refSchema,
+        Qty: z.number().optional(),
+        UnitPrice: z.number().optional(),
+        BillableStatus: z.string().optional(),
+        CustomerRef: refSchema.optional(),
+        ClassRef: refSchema.optional(),
+        TaxCodeRef: refSchema.optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
 const toolSchema = z.object({
-  purchase: z.any(),
+  purchase: z
+    .object({
+      PaymentType: z.enum(["Cash", "Check", "CreditCard"]).optional(),
+      AccountRef: refSchema.optional().describe("Bank/credit account the purchase is paid from"),
+      EntityRef: refSchema.optional().describe("Payee (vendor/customer/employee)"),
+      Line: z.array(purchaseLineSchema),
+      TxnDate: z.string().optional(),
+      DocNumber: z.string().optional(),
+      PrivateNote: z.string().optional(),
+      CurrencyRef: refSchema.optional(),
+      ExchangeRate: z.number().optional(),
+      DepartmentRef: refSchema.optional(),
+      GlobalTaxCalculation: globalTaxCalculationInputSchema.optional(),
+      TxnTaxDetail: z
+        .object({
+          TotalTax: z.number().optional(),
+          TaxLine: z.array(z.object({}).passthrough()).optional(),
+        })
+        .passthrough()
+        .optional(),
+    })
+    .passthrough(),
 });
 
 type ToolParams = z.infer<typeof toolSchema>;
@@ -38,4 +97,4 @@ export const CreatePurchaseTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: toolHandler,
-}; 
+};

--- a/src/tools/update-payment.tool.ts
+++ b/src/tools/update-payment.tool.ts
@@ -12,6 +12,10 @@ const toolSchema = z.object({
   total_amt: z.number().optional().describe("Total payment amount"),
   payment_method_ref: z.string().optional().describe("Payment method ID"),
   private_note: z.string().optional().describe("Private note"),
+  deposit_to_account_ref: z
+    .string()
+    .optional()
+    .describe("Account ID the payment is deposited to (Payment.DepositToAccountRef)"),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/src/tools/update-payment.tool.ts
+++ b/src/tools/update-payment.tool.ts
@@ -3,7 +3,18 @@ import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
 const toolName = "update_payment";
-const toolDescription = "Update an existing payment in QuickBooks Online.";
+const toolDescription =
+  "Update an existing payment in QuickBooks Online. Supports applying the payment to transactions via `line` (e.g. settling an unapplied payment against an invoice), mirroring create_payment. NOTE: `line` REPLACES the payment's existing applications rather than adding to them — QBO treats Payment.Line as the authoritative set. To keep current applications, read them with get_payment first and send them back alongside the new one; omit `line` entirely to leave applications untouched.";
+
+const linkedTxnSchema = z.object({
+  txn_id: z.string().describe("Transaction ID to apply the payment to"),
+  txn_type: z.string().describe("Transaction type (e.g., Invoice)"),
+});
+
+const lineSchema = z.object({
+  amount: z.number().describe("Amount to apply to this transaction"),
+  linked_txn: z.array(linkedTxnSchema).describe("Linked transactions"),
+});
 
 const toolSchema = z.object({
   id: z.string().min(1).describe("Payment ID"),
@@ -16,6 +27,12 @@ const toolSchema = z.object({
     .string()
     .optional()
     .describe("Account ID the payment is deposited to (Payment.DepositToAccountRef)"),
+  line: z
+    .array(lineSchema)
+    .optional()
+    .describe(
+      "Line items applying this payment to transactions (Payment.Line[].LinkedTxn). REPLACES all existing applications — include any you want to keep. Omit to leave the payment's current applications unchanged."
+    ),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/tests/mocks/quickbooks.mock.ts
+++ b/tests/mocks/quickbooks.mock.ts
@@ -267,6 +267,20 @@ export function resetAllMocks() {
       (mock as jest.Mock).mockReset();
     }
   });
+  // Update handlers perform read-merge-write: they fetch the current entity
+  // via getX before updating. Install a minimal default implementation on
+  // every get* method so update tests that only mock updateX keep working;
+  // tests needing a specific fetched entity override with mockImplementation.
+  Object.entries(mockQuickBooksInstance).forEach(([name, mock]) => {
+    if (name.startsWith('get') && typeof mock === 'function' && 'mockImplementation' in mock) {
+      (mock as jest.Mock).mockImplementation((...args: unknown[]) => {
+        const callback = args[args.length - 1] as (err: null, result: unknown) => void;
+        if (typeof callback === 'function') {
+          callback(null, { Id: String(args[0] ?? 'mock-id'), SyncToken: '0' });
+        }
+      });
+    }
+  });
   mockQuickbooksClient.authenticate.mockReset();
   mockQuickbooksClient.getQuickbooks.mockReset();
   (mockQuickbooksClient.getQuickbooks as any).mockReturnValue(mockQuickBooksInstance);

--- a/tests/unit/handlers/tax-and-update-integrity.test.ts
+++ b/tests/unit/handlers/tax-and-update-integrity.test.ts
@@ -21,6 +21,7 @@ const { updateQuickbooksPurchase } = await import('../../../src/handlers/update-
 const { normalizeGlobalTaxCalculation } = await import('../../../src/helpers/global-tax');
 const { mergeForFullUpdate } = await import('../../../src/helpers/read-merge-write');
 const { CreateBillTool } = await import('../../../src/tools/create-bill.tool');
+const { UpdatePaymentTool } = await import('../../../src/tools/update-payment.tool');
 
 const capture = (mock: any) => (mock.mock.calls[0] as any)[0];
 
@@ -95,6 +96,98 @@ describe('Tax forwarding and update integrity', () => {
       const override = { TotalTax: 7.42, TaxLine: [{ Amount: 7.42, DetailType: 'TaxLineDetail', TaxLineDetail: { TaxRateRef: { value: '14' }, PercentBased: false } }] };
       await createQuickbooksBill({ VendorRef: { value: '41' }, Line: [], TxnTaxDetail: override });
       expect(capture(mockQuickBooksInstance.createBill).TxnTaxDetail).toEqual(override);
+    });
+  });
+
+  describe('update_payment can apply a payment to a transaction (Payment.Line)', () => {
+    it('maps line/linked_txn to Payment.Line[].LinkedTxn like create_payment does', async () => {
+      mockQuickBooksInstance.getPayment.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '9', SyncToken: '0', CustomerRef: { value: '3' }, TotalAmt: 500, UnappliedAmt: 500 })
+      );
+      mockQuickBooksInstance.updatePayment.mockImplementation((p: any, cb: any) => cb(null, {}));
+
+      await updateQuickbooksPayment({
+        id: '9',
+        sync_token: '0',
+        line: [{ amount: 500, linked_txn: [{ txn_id: '77', txn_type: 'Invoice' }] }],
+      });
+
+      const sent = capture(mockQuickBooksInstance.updatePayment);
+      expect(sent.Line).toEqual([
+        { Amount: 500, LinkedTxn: [{ TxnId: '77', TxnType: 'Invoice' }] },
+      ]);
+      expect(sent.sparse).toBe(false);
+    });
+
+    it('REPLACES existing applications when line is supplied (documented QBO semantics)', async () => {
+      mockQuickBooksInstance.getPayment.mockImplementation((_id: any, cb: any) =>
+        cb(null, {
+          Id: '9',
+          SyncToken: '0',
+          TotalAmt: 500,
+          Line: [{ Amount: 200, LinkedTxn: [{ TxnId: '11', TxnType: 'Invoice' }] }],
+        })
+      );
+      mockQuickBooksInstance.updatePayment.mockImplementation((p: any, cb: any) => cb(null, {}));
+
+      await updateQuickbooksPayment({
+        id: '9',
+        sync_token: '0',
+        line: [{ amount: 500, linked_txn: [{ txn_id: '77', txn_type: 'Invoice' }] }],
+      });
+
+      const sent = capture(mockQuickBooksInstance.updatePayment);
+      expect(sent.Line).toHaveLength(1);
+      expect(sent.Line[0].LinkedTxn[0].TxnId).toBe('77'); // caller's set wins wholesale
+    });
+
+    it('leaves existing applications untouched when line is omitted', async () => {
+      const existing = [{ Amount: 200, LinkedTxn: [{ TxnId: '11', TxnType: 'Invoice' }] }];
+      mockQuickBooksInstance.getPayment.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '9', SyncToken: '0', TotalAmt: 500, Line: existing })
+      );
+      mockQuickBooksInstance.updatePayment.mockImplementation((p: any, cb: any) => cb(null, {}));
+
+      await updateQuickbooksPayment({ id: '9', sync_token: '0', private_note: 'note only' });
+
+      expect(capture(mockQuickBooksInstance.updatePayment).Line).toEqual(existing);
+    });
+
+    it('preserves TotalAmt so applying lines cannot silently rewrite the payment amount', async () => {
+      mockQuickBooksInstance.getPayment.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '9', SyncToken: '0', TotalAmt: 500, UnappliedAmt: 500 })
+      );
+      mockQuickBooksInstance.updatePayment.mockImplementation((p: any, cb: any) => cb(null, {}));
+
+      await updateQuickbooksPayment({
+        id: '9',
+        sync_token: '0',
+        line: [{ amount: 300, linked_txn: [{ txn_id: '77', txn_type: 'Invoice' }] }],
+      });
+
+      // Without this, TotalAmt is stripped as a "derived" field and QBO would
+      // re-derive 300 from the line — turning a $500 payment into a $300 one.
+      expect(capture(mockQuickBooksInstance.updatePayment).TotalAmt).toBe(500);
+    });
+
+    it('still lets an explicit total_amt override the stored value', async () => {
+      mockQuickBooksInstance.getPayment.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '9', SyncToken: '0', TotalAmt: 500 })
+      );
+      mockQuickBooksInstance.updatePayment.mockImplementation((p: any, cb: any) => cb(null, {}));
+
+      await updateQuickbooksPayment({ id: '9', sync_token: '0', total_amt: 750 });
+
+      expect(capture(mockQuickBooksInstance.updatePayment).TotalAmt).toBe(750);
+    });
+
+    it('(schema) update_payment declares line so validation cannot strip it', () => {
+      const parsed = (UpdatePaymentTool.schema as any).parse({
+        id: '9',
+        sync_token: '0',
+        line: [{ amount: 500, linked_txn: [{ txn_id: '77', txn_type: 'Invoice' }] }],
+      });
+      expect(parsed.line[0].linked_txn[0].txn_id).toBe('77');
     });
   });
 

--- a/tests/unit/handlers/tax-and-update-integrity.test.ts
+++ b/tests/unit/handlers/tax-and-update-integrity.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests: tax-field forwarding on create tools and read-merge-write
+ * update semantics. Grounded in production defects observed on a live
+ * global-tax-model (CA) company: GlobalTaxCalculation silently dropped
+ * (TaxInclusive posted as NotApplicable, computing tax on top instead of
+ * extracting it), the "TaxExclusive" misspelling failing whole requests with
+ * QBO's opaque parse fault, and sparse updates nulling omitted fields.
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+const { createQuickbooksPurchase } = await import('../../../src/handlers/create-quickbooks-purchase.handler');
+const { createQuickbooksBill } = await import('../../../src/handlers/create-quickbooks-bill.handler');
+const { updateQuickbooksPayment } = await import('../../../src/handlers/update-quickbooks-payment.handler');
+const { updateQuickbooksPurchase } = await import('../../../src/handlers/update-quickbooks-purchase.handler');
+const { normalizeGlobalTaxCalculation } = await import('../../../src/helpers/global-tax');
+const { mergeForFullUpdate } = await import('../../../src/helpers/read-merge-write');
+const { CreateBillTool } = await import('../../../src/tools/create-bill.tool');
+
+const capture = (mock: any) => (mock.mock.calls[0] as any)[0];
+
+describe('Tax forwarding and update integrity', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  describe('GlobalTaxCalculation forwarding (create_purchase / create-bill)', () => {
+    it('forwards GlobalTaxCalculation verbatim on create_purchase', async () => {
+      mockQuickBooksInstance.createPurchase.mockImplementation((p: any, cb: any) => cb(null, { Id: '1' }));
+      await createQuickbooksPurchase({
+        PaymentType: 'Cash',
+        Line: [{ Amount: 100, DetailType: 'AccountBasedExpenseLineDetail', AccountBasedExpenseLineDetail: { AccountRef: { value: '1' }, TaxCodeRef: { value: '7' } } }],
+        GlobalTaxCalculation: 'TaxInclusive',
+      });
+      expect(capture(mockQuickBooksInstance.createPurchase).GlobalTaxCalculation).toBe('TaxInclusive');
+    });
+
+    it('forwards GlobalTaxCalculation on create-bill', async () => {
+      mockQuickBooksInstance.createBill.mockImplementation((p: any, cb: any) => cb(null, { Id: '1' }));
+      await createQuickbooksBill({ VendorRef: { value: '41' }, Line: [], GlobalTaxCalculation: 'TaxInclusive' });
+      expect(capture(mockQuickBooksInstance.createBill).GlobalTaxCalculation).toBe('TaxInclusive');
+    });
+
+    it('(schema) create-bill declares GlobalTaxCalculation explicitly so schema validation cannot strip it', () => {
+      const parsed = (CreateBillTool.schema as any).parse({
+        bill: { VendorRef: { value: '41' }, Line: [], GlobalTaxCalculation: 'TaxInclusive' },
+      });
+      expect(parsed.bill.GlobalTaxCalculation).toBe('TaxInclusive');
+    });
+  });
+
+  describe('"TaxExclusive" normalization (QBO parse-fault prevention)', () => {
+    it('maps the TaxExclusive misspelling to TaxExcluded before the request leaves the server', async () => {
+      mockQuickBooksInstance.createPurchase.mockImplementation((p: any, cb: any) => cb(null, { Id: '1' }));
+      await createQuickbooksPurchase({ Line: [], GlobalTaxCalculation: 'TaxExclusive' });
+      expect(capture(mockQuickBooksInstance.createPurchase).GlobalTaxCalculation).toBe('TaxExcluded');
+    });
+
+    it('rejects an unknown value with an actionable message instead of forwarding it to QBO', async () => {
+      const result = await createQuickbooksPurchase({ Line: [], GlobalTaxCalculation: 'Bogus' });
+      expect(result.isError).toBe(true);
+      expect(result.error).toMatch(/Valid values: TaxExcluded, TaxInclusive, NotApplicable/);
+      expect(mockQuickBooksInstance.createPurchase).not.toHaveBeenCalled();
+    });
+
+    it('accepts all three real enum values unchanged', () => {
+      expect(normalizeGlobalTaxCalculation('TaxExcluded')).toBe('TaxExcluded');
+      expect(normalizeGlobalTaxCalculation('TaxInclusive')).toBe('TaxInclusive');
+      expect(normalizeGlobalTaxCalculation('NotApplicable')).toBe('NotApplicable');
+    });
+  });
+
+  describe('item-based create-bill lines carry tax and class', () => {
+    it('(schema) ItemBasedExpenseLineDetail keeps TaxCodeRef and ClassRef', () => {
+      const parsed = (CreateBillTool.schema as any).parse({
+        bill: {
+          VendorRef: { value: '41' },
+          Line: [{ Amount: 50, DetailType: 'ItemBasedExpenseLineDetail', ItemBasedExpenseLineDetail: { ItemRef: { value: 'i1' }, Qty: 2, TaxCodeRef: { value: '7' }, ClassRef: { value: 'c9' } } }],
+        },
+      });
+      const detail = parsed.bill.Line[0].ItemBasedExpenseLineDetail;
+      expect(detail.TaxCodeRef).toEqual({ value: '7' });
+      expect(detail.ClassRef).toEqual({ value: 'c9' });
+    });
+  });
+
+  describe('explicit TxnTaxDetail overrides on create-bill', () => {
+    it('forwards a PercentBased:false TaxLine override for exact per-document tax', async () => {
+      mockQuickBooksInstance.createBill.mockImplementation((p: any, cb: any) => cb(null, { Id: '1' }));
+      const override = { TotalTax: 7.42, TaxLine: [{ Amount: 7.42, DetailType: 'TaxLineDetail', TaxLineDetail: { TaxRateRef: { value: '14' }, PercentBased: false } }] };
+      await createQuickbooksBill({ VendorRef: { value: '41' }, Line: [], TxnTaxDetail: override });
+      expect(capture(mockQuickBooksInstance.createBill).TxnTaxDetail).toEqual(override);
+    });
+  });
+
+  describe('update_payment forwards DepositToAccountRef', () => {
+    it('sends Payment.DepositToAccountRef (previously accepted but silently dropped)', async () => {
+      mockQuickBooksInstance.updatePayment.mockImplementation((p: any, cb: any) => cb(null, {}));
+      await updateQuickbooksPayment({ id: '5', sync_token: '0', deposit_to_account_ref: '89' });
+      expect(capture(mockQuickBooksInstance.updatePayment).DepositToAccountRef).toEqual({ value: '89' });
+    });
+  });
+
+  describe('read-merge-write update semantics', () => {
+    it('update_purchase preserves omitted fields from the fetched entity instead of nulling them', async () => {
+      mockQuickBooksInstance.getPurchase.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '77', SyncToken: '4', PaymentType: 'Cash', AccountRef: { value: '35' }, TxnDate: '2026-07-01', TotalAmt: 113, TxnTaxDetail: { TotalTax: 13 }, MetaData: {} })
+      );
+      mockQuickBooksInstance.updatePurchase.mockImplementation((p: any, cb: any) => cb(null, {}));
+
+      await updateQuickbooksPurchase({ Id: '77', SyncToken: '4', PrivateNote: 'note only' });
+
+      const sent = capture(mockQuickBooksInstance.updatePurchase);
+      expect(sent.PaymentType).toBe('Cash');
+      expect(sent.AccountRef).toEqual({ value: '35' });
+      expect(sent.TxnDate).toBe('2026-07-01');
+      expect(sent.PrivateNote).toBe('note only');
+      expect(sent.sparse).toBe(false);
+      expect(sent.TotalAmt).toBeUndefined(); // derived — stripped so QBO recomputes
+      expect(sent.MetaData).toBeUndefined(); // read-only — stripped
+      expect(sent.TxnTaxDetail).toBeUndefined(); // recomputed from line tax codes
+    });
+
+    it('update_purchase normalizes GlobalTaxCalculation like create does', async () => {
+      mockQuickBooksInstance.getPurchase.mockImplementation((_id: any, cb: any) => cb(null, { Id: '77', SyncToken: '4' }));
+      mockQuickBooksInstance.updatePurchase.mockImplementation((p: any, cb: any) => cb(null, {}));
+      await updateQuickbooksPurchase({ Id: '77', SyncToken: '4', GlobalTaxCalculation: 'TaxExclusive' });
+      expect(capture(mockQuickBooksInstance.updatePurchase).GlobalTaxCalculation).toBe('TaxExcluded');
+    });
+
+    it('mergeForFullUpdate keeps the caller SyncToken over the fetched copy', async () => {
+      const getFn = async () => ({ Id: '1', SyncToken: '9', Keep: 'yes' });
+      const merged = await mergeForFullUpdate(getFn, { Id: '1', SyncToken: '3' });
+      expect(merged.SyncToken).toBe('3');
+      expect(merged.Keep).toBe('yes');
+    });
+  });
+});


### PR DESCRIPTION
…ntics

Grounded in production use on a live global-tax-model (CA) company (hundreds of create/update calls):

Tax forwarding (wrong-books class of bugs):
- create_purchase's schema was `z.any()` with no declared properties, so GlobalTaxCalculation was silently dropped: a TaxInclusive purchase posted as NotApplicable and QBO computed tax ON TOP of line amounts instead of extracting it (Amount 100.00 @ 13% returned TotalAmt 113.00, expected 100.00). The schema now declares every forwardable Purchase field (typed lines with TaxCodeRef/ClassRef, TxnTaxDetail, GlobalTaxCalculation, CurrencyRef/ExchangeRate, ...) with passthrough for the long tail.
- create-bill: GlobalTaxCalculation and TxnTaxDetail declared explicitly (PercentBased:false TaxLine overrides now reach QBO for exact per-document tax, e.g. 7.42 where 13% computes 7.43); item-based lines gained TaxCodeRef/ClassRef so taxed inventory purchases don't force NON.
- New helpers/global-tax.ts normalizes the common "TaxExclusive" misspelling to QBO's real "TaxExcluded" and rejects unknown values with an actionable message listing the valid enum — previously an invalid value reached QBO and failed the entire request with an opaque "Failed to parse json object" 400.

Update semantics:
- New helpers/read-merge-write.ts: fetch the current entity, merge the caller's changes over it, send a full non-sparse payload. Applied to 21 update handlers (purchase, payment, invoice, journal-entry, deposit, transfer, estimate, customer, vendor, item, term, class, department, employee, time-activity, credit-memo, sales-receipt, refund-receipt, purchase-order, bill-payment, payment-method) — sparse updates proved unreliable in production (omitted fields silently nulled). Derived fields (TxnTaxDetail/TotalAmt/Balance/MetaData) are stripped from the fetched copy so QBO recomputes them; the caller's SyncToken wins so a stale copy still 5010-conflicts. update-bill already has its own line-level read-merge-write (#86) and is untouched; account and attachable updates were recently reworked upstream and are deliberately left as-is.
- update_payment now forwards DepositToAccountRef (was accepted by the schema but silently dropped).
- update_purchase normalizes GlobalTaxCalculation like create does.

Tests: tax-and-update-integrity suite (12 cases: forwarding, normalization, rejection-before-QBO, RMW field preservation, SyncToken precedence); test mocks install default get* implementations so update tests that only mock updateX keep working under read-merge-write.

Note: update-bill is deliberately untouched — #86's line-level read-merge-write already covers it; this PR extends the same safety to the other 21 update handlers via a shared helper. account and attachable updates were recently reworked upstream and are also left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)