### PR TITLE
feat: query-type coercion, attachables search ergonomics, response sh…

### DIFF
--- a/src/handlers/get-quickbooks-general-ledger.handler.ts
+++ b/src/handlers/get-quickbooks-general-ledger.handler.ts
@@ -9,6 +9,39 @@ export interface GeneralLedgerOptions {
   account?: string;
   source_account?: string;
   sort_by?: string;
+  /** Return compact flattened rows instead of QBO's raw nested report (defect #12). */
+  summary?: boolean;
+  /** With summary, keep only these columns (by column title). */
+  fields?: string[];
+}
+
+/**
+ * Flatten QBO's nested report structure (Rows.Row[] with ColData, sections,
+ * and sub-rows) into an array of {columnTitle: value} objects — a fraction of
+ * the raw report's size and directly usable by the caller.
+ */
+export function flattenReportRows(report: any, fields?: string[]): { columns: string[]; rows: any[] } {
+  const columns: string[] = (report?.Columns?.Column ?? []).map(
+    (c: any, i: number) => c?.ColTitle || c?.ColType || `col${i}`
+  );
+  const rows: any[] = [];
+  const walk = (rowContainer: any, section: string | undefined) => {
+    for (const row of rowContainer?.Row ?? []) {
+      const header = row?.Header?.ColData?.[0]?.value;
+      if (Array.isArray(row?.ColData)) {
+        const obj: Record<string, any> = {};
+        row.ColData.forEach((cd: any, i: number) => {
+          const key = columns[i] ?? `col${i}`;
+          if (!fields || fields.length === 0 || fields.includes(key)) obj[key] = cd?.value ?? "";
+        });
+        if (section) obj._section = section;
+        rows.push(obj);
+      }
+      if (row?.Rows) walk(row.Rows, header ?? section);
+    }
+  };
+  walk(report?.Rows, undefined);
+  return { columns, rows };
 }
 
 export async function getQuickbooksGeneralLedger(options: GeneralLedgerOptions): Promise<ToolResponse<any>> {
@@ -25,7 +58,9 @@ export async function getQuickbooksGeneralLedger(options: GeneralLedgerOptions):
     return new Promise((resolve) => {
       (quickbooks as any).reportGeneralLedgerDetail(params, (err: any, report: any) => {
         if (err) resolve({ result: null, isError: true, error: formatError(err) });
-        else resolve({ result: report, isError: false, error: null });
+        else if (options.summary || (options.fields && options.fields.length > 0)) {
+          resolve({ result: flattenReportRows(report, options.fields), isError: false, error: null });
+        } else resolve({ result: report, isError: false, error: null });
       });
     });
   } catch (error) {

--- a/src/handlers/search-quickbooks-attachables.handler.ts
+++ b/src/handlers/search-quickbooks-attachables.handler.ts
@@ -4,17 +4,40 @@ import { formatError } from "../helpers/format-error.js";
 
 export interface SearchAttachablesInput {
   file_name?: string;
+  file_name_like?: string;
   content_type?: string;
+  created_after?: string;
+  created_before?: string;
   limit?: number;
+  offset?: number;
+  orderby?: string;
 }
 
+/**
+ * Search attachables with pagination, ordering (default: newest first — the
+ * QBO default of oldest-first made "does txn X have a recent attachment"
+ * impossible on large files), and created-date range filters.
+ */
 export async function searchQuickbooksAttachables(data: SearchAttachablesInput): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
-    const criteria: Record<string, any> = {};
-    if (data.file_name) criteria.FileName = data.file_name;
-    if (data.content_type) criteria.ContentType = data.content_type;
-    if (data.limit) criteria.limit = data.limit;
+    const criteria: Array<Record<string, any>> = [];
+    if (data.file_name) criteria.push({ field: "FileName", value: data.file_name, operator: "=" });
+    if (data.file_name_like)
+      criteria.push({ field: "FileName", value: `%${data.file_name_like}%`, operator: "LIKE" });
+    if (data.content_type) criteria.push({ field: "ContentType", value: data.content_type, operator: "=" });
+    if (data.created_after)
+      criteria.push({ field: "MetaData.CreateTime", value: data.created_after, operator: ">=" });
+    if (data.created_before)
+      criteria.push({ field: "MetaData.CreateTime", value: data.created_before, operator: "<=" });
+    if (data.limit) criteria.push({ field: "limit", value: data.limit });
+    if (data.offset) criteria.push({ field: "offset", value: data.offset });
+
+    // Ordering: default newest-first. node-quickbooks expects {field:'asc'|'desc', value:<field>}.
+    const orderby = (data.orderby ?? "MetaData.CreateTime DESC").trim();
+    const descending = / desc$/i.test(orderby);
+    const orderField = orderby.replace(/ (asc|desc)$/i, "");
+    criteria.push({ field: descending ? "desc" : "asc", value: orderField });
 
     return new Promise((resolve) => {
       (quickbooks as any).findAttachables(criteria, (err: any, result: any) => {
@@ -27,3 +50,53 @@ export async function searchQuickbooksAttachables(data: SearchAttachablesInput):
   }
 }
 
+/**
+ * Convenience: all attachables referencing a given entity (bill, purchase,
+ * invoice, ...). AttachableRef is not queryable in QBO SQL, so this pages
+ * through attachables newest-first and filters by AttachableRef server-side
+ * before returning — the caller never sees the unfiltered dump.
+ */
+export async function getQuickbooksEntityAttachments(data: {
+  entity_type: string;
+  entity_id: string;
+  max_scan?: number;
+}): Promise<ToolResponse<any>> {
+  try {
+    const quickbooks = await QuickbooksClient.getInstance();
+    const targetType = data.entity_type.trim().toLowerCase().replace(/[\s_-]/g, "");
+    const targetId = String(data.entity_id);
+    const pageSize = 1000;
+    const maxScan = data.max_scan ?? 5000;
+    const matches: any[] = [];
+    let scanned = 0;
+
+    for (let offset = 1; scanned < maxScan; offset += pageSize) {
+      const page: any[] = await new Promise((resolve, reject) => {
+        (quickbooks as any).findAttachables(
+          [
+            { field: "desc", value: "MetaData.CreateTime" },
+            { field: "limit", value: pageSize },
+            { field: "offset", value: offset },
+          ],
+          (err: any, result: any) =>
+            err ? reject(err) : resolve(result?.QueryResponse?.Attachable || [])
+        );
+      });
+      scanned += page.length;
+      for (const att of page) {
+        const refs: any[] = att?.AttachableRef ?? [];
+        const hit = refs.some(
+          (r) =>
+            String(r?.EntityRef?.value ?? "") === targetId &&
+            String(r?.EntityRef?.type ?? "").toLowerCase().replace(/[\s_-]/g, "") === targetType
+        );
+        if (hit) matches.push(att);
+      }
+      if (page.length < pageSize) break; // last page
+    }
+
+    return { result: { matches, scanned, complete: scanned < maxScan }, isError: false, error: null };
+  } catch (error) {
+    return { result: null, isError: true, error: formatError(error) };
+  }
+}

--- a/src/helpers/build-quickbooks-search-criteria.ts
+++ b/src/helpers/build-quickbooks-search-criteria.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export interface QuickbooksFilter {
   /** Field/column name to filter on */
   field: string;
@@ -5,6 +7,115 @@ export interface QuickbooksFilter {
   value: any;
   /** Comparison operator to use (default '=') */
   operator?: string;
+}
+
+// ── Shared criterion schema + type coercion ─────────────────────────────────
+// One schema for every search tool's criteria array. Values are accepted
+// NATIVELY as string, number, boolean, or an array (for IN) — node-quickbooks
+// quotes strings, leaves numbers/booleans bare, and expands arrays to a SQL
+// tuple, so the type we forward is the type QBO's SQL sees. Rejecting numbers
+// (old schemas: z.string()|z.boolean()) or forwarding boolean-as-string
+// ("true" → QBO "String cannot be cast to Boolean") were both production bugs.
+export const searchCriterionValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.union([z.string(), z.number()])).min(1),
+]);
+
+export const searchCriterionSchema = z.object({
+  field: z.string().min(1).describe("QBO field/column name to filter on"),
+  value: searchCriterionValueSchema.describe(
+    "Match value. Use the native JSON type (number for amounts, boolean for flags like Active, string otherwise). For the IN operator pass a JSON array of values."
+  ),
+  operator: z
+    .enum(["=", "<", ">", "<=", ">=", "LIKE", "IN"])
+    .optional()
+    .describe("Comparison operator. Defaults to '='. IN expects value to be a JSON array."),
+});
+
+// QBO fields that are boolean-typed in the query grammar. A string "true"
+// forwarded to one of these produces QueryProcessingError: String cannot be
+// cast to Boolean — coerce it. Everything else keeps its native type.
+const BOOLEAN_QUERY_FIELDS = new Set([
+  "active",
+  "taxable",
+  "hidden",
+  "taxgroup",
+  "vendor1099",
+  "isadjustment",
+  "applytaxafterdiscount",
+  "isproject",
+  "job",
+]);
+
+/**
+ * Coerce criterion values to the types QBO's query grammar expects:
+ * - "true"/"false" strings on known boolean fields → real booleans
+ * - IN operator with an array → left native (node-quickbooks builds the tuple)
+ * - IN operator with a pre-built SQL-tuple string "('a','b')" → parsed into an
+ *   array (forwarding the raw tuple string is double-quoted by the SQL builder
+ *   and yields QueryParserError)
+ */
+export function coerceCriterionTypes(criteria: QuickbooksFilter[]): QuickbooksFilter[] {
+  return criteria.map((c) => {
+    let value = c.value;
+    const operator = c.operator;
+    if (typeof value === "string") {
+      const lower = value.toLowerCase();
+      if (BOOLEAN_QUERY_FIELDS.has(c.field.toLowerCase()) && (lower === "true" || lower === "false")) {
+        value = lower === "true";
+      } else if (operator === "IN" && /^\(.*\)$/.test(value.trim())) {
+        value = value
+          .trim()
+          .slice(1, -1)
+          .split(",")
+          .map((part) => part.trim().replace(/^'(.*)'$/, "$1"))
+          .filter((part) => part.length > 0);
+      }
+    }
+    return { field: c.field, value, operator };
+  });
+}
+
+// ── Search-result shaping (fields projection / summary mode) ────────────────
+
+/** Project each entity to the requested dot-path fields (e.g. "VendorRef.name"). */
+export function projectEntityFields(entities: any[], fields: string[]): any[] {
+  const pick = (obj: any, path: string) =>
+    path.split(".").reduce((acc, key) => (acc == null ? undefined : acc[key]), obj);
+  return entities.map((entity) => {
+    const out: Record<string, any> = {};
+    for (const field of fields) {
+      const value = pick(entity, field);
+      if (value !== undefined) out[field] = value;
+    }
+    return out;
+  });
+}
+
+/** One compact line per entity: the fields that identify a transaction at a glance. */
+export function summarizeEntities(entities: any[]): any[] {
+  return entities.map((e) => ({
+    Id: e?.Id,
+    DocNumber: e?.DocNumber,
+    Name: e?.DisplayName ?? e?.Name,
+    VendorRef: e?.VendorRef?.name,
+    CustomerRef: e?.CustomerRef?.name,
+    TxnDate: e?.TxnDate,
+    TotalAmt: e?.TotalAmt,
+    Balance: e?.Balance,
+  }));
+}
+
+/** Apply summary/fields shaping to a search result array, if requested. */
+export function shapeSearchResults(
+  entities: any[],
+  options: { fields?: string[]; summary?: boolean }
+): any[] {
+  if (options.summary) return summarizeEntities(entities);
+  if (options.fields && options.fields.length > 0) return projectEntityFields(entities, options.fields);
+  return entities;
 }
 
 export interface AdvancedQuickbooksSearchOptions {
@@ -47,9 +158,15 @@ export type QuickbooksSearchCriteriaInput =
 export function buildQuickbooksSearchCriteria(
   input: QuickbooksSearchCriteriaInput
 ): Record<string, any> | Array<Record<string, any>> {
-  // If the user supplied an array we assume they know what they're doing.
+  // If the user supplied an array we assume they know what they're doing —
+  // but still coerce value types on {field,value} entries so boolean-string
+  // and SQL-tuple-string inputs can't reach QBO's query grammar raw.
   if (Array.isArray(input)) {
-    return input as Array<Record<string, any>>;
+    return (input as Array<Record<string, any>>).map((entry) =>
+      entry && typeof entry === "object" && "field" in entry && "value" in entry
+        ? coerceCriterionTypes([entry as QuickbooksFilter])[0]
+        : entry
+    );
   }
 
   // If the input is a plain object that does NOT look like advanced options, forward as-is
@@ -78,11 +195,14 @@ export function buildQuickbooksSearchCriteria(
   const options = input as AdvancedQuickbooksSearchOptions;
   const criteriaArr: Array<Record<string, any>> = [];
 
-  // Convert filters (accept both "filters" and "criteria" as the key)
+  // Convert filters (accept both "filters" and "criteria" as the key),
+  // coercing value types to what QBO's query grammar expects.
   const filterList = options.filters ?? options.criteria;
-  filterList?.forEach((f) => {
-    criteriaArr.push({ field: f.field, value: f.value, operator: f.operator });
-  });
+  if (filterList) {
+    for (const f of coerceCriterionTypes(filterList)) {
+      criteriaArr.push({ field: f.field, value: f.value, operator: f.operator });
+    }
+  }
 
   // Sorting
   if (options.asc) {

--- a/src/helpers/qbo-entity-link.ts
+++ b/src/helpers/qbo-entity-link.ts
@@ -1,0 +1,130 @@
+import { QuickbooksClient } from "../clients/quickbooks-client.js";
+
+// QBO web-app deep-link slugs per entity. txnId resolves against whichever
+// company is ACTIVE IN THE USER'S BROWSER SESSION, not the realm this MCP
+// instance is bound to — which is why every link is prefixed with the company
+// name, so the user can confirm the QBO header matches before acting.
+const ENTITY_SLUGS: Record<string, string> = {
+  bill: "bill",
+  purchase: "expense",
+  expense: "expense",
+  cheque: "check",
+  check: "check",
+  transfer: "transfer",
+  journal_entry: "journal",
+  journalentry: "journal",
+  journal: "journal",
+  bill_payment: "billpayment",
+  billpayment: "billpayment",
+  deposit: "deposit",
+  payment: "recvpayment",
+  customer_payment: "recvpayment",
+  invoice: "invoice",
+  credit_memo: "creditmemo",
+  creditmemo: "creditmemo",
+  vendor_credit: "vendorcredit",
+  vendorcredit: "vendorcredit",
+};
+
+export function supportedLinkEntityTypes(): string[] {
+  return Object.keys(ENTITY_SLUGS).sort();
+}
+
+// Company name cache — resolved once per process, lazily (never at module
+// load: a network call in a constructor would delay server startup).
+let companyNamePromise: Promise<string> | null = null;
+
+async function fetchCompanyName(): Promise<string> {
+  const quickbooks: any = await QuickbooksClient.getInstance();
+  const { realmId } = await QuickbooksClient.getAuthCredentials();
+  return new Promise((resolve) => {
+    quickbooks.getCompanyInfo(realmId, (err: any, info: any) => {
+      if (err || !info) resolve("Unknown company");
+      else resolve(info.CompanyName ?? "Unknown company");
+    });
+  });
+}
+
+export function getCachedCompanyName(): Promise<string> {
+  if (!companyNamePromise) {
+    companyNamePromise = fetchCompanyName().catch(() => {
+      companyNamePromise = null; // allow a retry on the next call
+      return "Unknown company";
+    });
+  }
+  return companyNamePromise;
+}
+
+/** Test seam: reset the company-name cache. */
+export function resetCompanyNameCache(): void {
+  companyNamePromise = null;
+}
+
+/**
+ * Build the QBO web deep link for an entity, prefixed with the company name:
+ *   "[Example Company Inc.] https://qbo.intuit.com/app/bill?txnId=123"
+ * Returns undefined for entity types without a known web slug.
+ */
+export async function buildQboLink(entityType: string, id: string): Promise<string | undefined> {
+  const slug = ENTITY_SLUGS[entityType.toLowerCase().replace(/[\s-]/g, "_")];
+  if (!slug || !id) return undefined;
+  const company = await getCachedCompanyName();
+  return `[${company}] https://qbo.intuit.com/app/${slug}?txnId=${encodeURIComponent(id)}`;
+}
+
+// Map a create_/update_ tool name to the entity type used for deep links.
+// Only transaction entities QBO exposes web deep links for are mapped —
+// list entities (vendor, customer, item, account, ...) have no txnId page.
+const TOOL_ENTITY_MAP: Array<[RegExp, string]> = [
+  [/^(create|update)[-_]bill[-_]payment$/, "billpayment"],
+  [/^(create|update)[-_]bill$/, "bill"],
+  [/^(create|update)[-_]purchase$/, "expense"],
+  [/^(create|update)[-_]transfer$/, "transfer"],
+  [/^(create|update)[-_]journal[-_]entry$/, "journal"],
+  [/^(create|update)[-_]deposit$/, "deposit"],
+  [/^(create|update)[-_]payment$/, "recvpayment"],
+  [/^(create|update)[-_]invoice$/, "invoice"],
+  [/^(create|update)[-_]credit[-_]memo$/, "creditmemo"],
+  [/^(create|update)[-_]vendor[-_]credit$/, "vendorcredit"],
+];
+
+export function entityTypeForTool(toolName: string): string | undefined {
+  for (const [pattern, entity] of TOOL_ENTITY_MAP) {
+    if (pattern.test(toolName)) return entity;
+  }
+  return undefined;
+}
+
+/**
+ * Inject a qbo_link field into a create_/update_ tool's JSON response text.
+ * Finds the first JSON-object content item, extracts the entity Id (handling
+ * both bare entities and {Entity: {...}} wrappers), and adds qbo_link.
+ * Non-JSON or Id-less responses are returned untouched — never throws.
+ */
+export async function injectQboLinkIntoContent(
+  toolName: string,
+  content: Array<{ type: string; text?: string }>
+): Promise<void> {
+  const entityType = entityTypeForTool(toolName);
+  if (!entityType) return;
+  for (const item of content) {
+    if (item.type !== "text" || !item.text || !item.text.trim().startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(item.text);
+      const entity =
+        parsed && typeof parsed === "object" && !parsed.Id
+          ? Object.values(parsed).find((v: any) => v && typeof v === "object" && v.Id)
+          : parsed;
+      const id = (entity as any)?.Id;
+      if (!id) return;
+      const link = await buildQboLink(entityType, String(id));
+      if (!link) return;
+      parsed.qbo_link = link;
+      const pretty = item.text.includes("\n");
+      item.text = pretty ? JSON.stringify(parsed, null, 2) : JSON.stringify(parsed);
+      return; // only the first JSON payload gets the link
+    } catch {
+      return; // malformed JSON — leave the response untouched
+    }
+  }
+}

--- a/src/helpers/register-tool.ts
+++ b/src/helpers/register-tool.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { injectQboLinkIntoContent } from "./qbo-entity-link.js";
 
 /**
  * Defines CRUD categories for tools
@@ -69,10 +70,41 @@ export function RegisterTool<T extends z.ZodType<any, any>>(
   toolDefinition: ToolDefinition<T>
 ) {
   if (isToolDisabled(toolDefinition.name)) return;
-  server.tool(
-    toolDefinition.name,
-    toolDefinition.description,
-    { params: toolDefinition.schema },
-    toolDefinition.handler
-  );
+
+  // For create_/update_ tools, append a qbo_link deep link (prefixed with the
+  // company name — txnId resolves against the browser's ACTIVE company, so the
+  // user must be able to confirm the header) to the JSON response. Centralized
+  // here so every transaction tool gets it uniformly. Failures never break the
+  // underlying response.
+  const category = getCrudCategory(toolDefinition.name);
+  const baseHandler = toolDefinition.handler as unknown as (...a: any[]) => Promise<any>;
+  const wrapped = async (...a: any[]) => {
+    const result = await baseHandler(...a);
+    try {
+      if (result && Array.isArray(result.content)) {
+        await injectQboLinkIntoContent(toolDefinition.name, result.content);
+      }
+    } catch {
+      /* link injection is best-effort — never fail the tool call */
+    }
+    return result;
+  };
+  const handler = (
+    category === CRUD_CATEGORY.WRITE || category === CRUD_CATEGORY.UPDATE ? wrapped : baseHandler
+  ) as typeof toolDefinition.handler;
+
+  server.tool(toolDefinition.name, toolDefinition.description, { params: toolDefinition.schema }, handler);
+
+  // Legacy hyphenated names (create-bill, update-vendor, ...) get an
+  // underscore alias (create_bill, ...) for naming consistency with the rest
+  // of the surface. The hyphen name stays registered for backward compat.
+  if (toolDefinition.name.includes("-")) {
+    const alias = toolDefinition.name.replace(/-/g, "_");
+    server.tool(
+      alias,
+      `${toolDefinition.description} (Alias of ${toolDefinition.name}.)`,
+      { params: toolDefinition.schema },
+      handler
+    );
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { QuickbooksMCPServer } from "./server/qbo-mcp-server.js";
 // import { CreateCustomerTool } from "./tools/create-customer.tool.js";
 import { CreateInvoiceTool } from "./tools/create-invoice.tool.js";
 import { RegisterTool } from "./helpers/register-tool.js";
+import { GetTransactionLinkTool } from "./tools/get-transaction-link.tool.js";
+import { GetEntityAttachmentsTool } from "./tools/get-entity-attachments.tool.js";
 import { ReadInvoiceTool } from "./tools/read-invoice.tool.js";
 import { SearchInvoicesTool } from "./tools/search-invoices.tool.js";
 import { UpdateInvoiceTool } from "./tools/update-invoice.tool.js";
@@ -402,6 +404,8 @@ const main = async () => {
 
   // Add tools for company info
   RegisterTool(server, GetCompanyInfoTool);
+  RegisterTool(server, GetTransactionLinkTool);
+  RegisterTool(server, GetEntityAttachmentsTool);
   RegisterTool(server, UpdateCompanyInfoTool);
 
   // Add tools for attachables

--- a/src/tools/create-attachable.tool.ts
+++ b/src/tools/create-attachable.tool.ts
@@ -45,15 +45,37 @@ const toolSchema = z.object({
     })
     .optional()
     .describe("Optional reference to a QBO entity this file is attached to."),
+  return_download_uri: z
+    .boolean()
+    .optional()
+    .describe(
+      "If true, include TempDownloadUri (a multi-KB pre-signed URL) in the response. Omitted by default to keep responses small — use get_attachable when you need the download link."
+    ),
 });
+
+// TempDownloadUri is a multi-KB pre-signed URL with an embedded auth blob —
+// stripped from responses by default (defect #16).
+function stripDownloadUris(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripDownloadUris);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (k === "TempDownloadUri") continue;
+      out[k] = stripDownloadUris(v);
+    }
+    return out;
+  }
+  return value;
+}
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksAttachable(params);
   if (response.isError) return { content: [{ type: "text" as const, text: `Error: ${response.error}` }] };
+  const result = params?.return_download_uri ? response.result : stripDownloadUris(response.result);
   return {
     content: [
       { type: "text" as const, text: `Attachable created:` },
-      { type: "text" as const, text: JSON.stringify(response.result, null, 2) },
+      { type: "text" as const, text: JSON.stringify(result, null, 2) },
     ],
   };
 };

--- a/src/tools/create-vendor.tool.ts
+++ b/src/tools/create-vendor.tool.ts
@@ -23,7 +23,15 @@ const toolSchema = z.object({
       CountrySubDivisionCode: z.string().optional(),
       PostalCode: z.string().optional(),
     }).optional(),
-  }),
+    // Vendor currency drives transaction currency and CANNOT be changed after
+    // the vendor's first use — it must be settable at create (defect #15).
+    CurrencyRef: z.object({ value: z.string(), name: z.string().optional() }).optional()
+      .describe("Vendor currency (e.g. {value:'USD'}). Immutable after first transaction — set it now."),
+    TermRef: z.object({ value: z.string(), name: z.string().optional() }).optional()
+      .describe("Default payment terms"),
+    TaxIdentifier: z.string().optional().describe("Vendor tax ID (BN/EIN/VAT number)"),
+    Vendor1099: z.boolean().optional().describe("Whether the vendor is 1099-eligible (US)"),
+  }).passthrough(),
 });
 
 const toolHandler = async (args: { [x: string]: any }) => {

--- a/src/tools/get-entity-attachments.tool.ts
+++ b/src/tools/get-entity-attachments.tool.ts
@@ -1,0 +1,41 @@
+import { getQuickbooksEntityAttachments } from "../handlers/search-quickbooks-attachables.handler.js";
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+
+const toolName = "get_entity_attachments";
+const toolDescription =
+  "List the attachments of a specific QuickBooks transaction/entity (bill, purchase, invoice, ...). Scans attachables newest-first and filters by AttachableRef server-side. Response includes 'complete': false when the scan cap was reached before exhausting the file — raise max_scan to search deeper.";
+
+const toolSchema = z.object({
+  entity_type: z
+    .string()
+    .min(1)
+    .describe("QBO entity type the attachment is linked to, e.g. 'Bill', 'Purchase', 'Invoice', 'JournalEntry'"),
+  entity_id: z.string().min(1).describe("The entity's QBO Id"),
+  max_scan: z
+    .number()
+    .optional()
+    .describe("Maximum attachables to scan newest-first before giving up (default 5000)"),
+});
+
+const toolHandler = async ({ params }: any) => {
+  const response = await getQuickbooksEntityAttachments(params);
+  if (response.isError) return { content: [{ type: "text" as const, text: `Error: ${response.error}` }] };
+  const { matches, scanned, complete } = response.result;
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Found ${matches.length} attachment(s) for ${params.entity_type} ${params.entity_id} (scanned ${scanned} attachables${complete ? "" : " — scan cap reached, result may be incomplete; raise max_scan"}):`,
+      },
+      { type: "text" as const, text: JSON.stringify(matches, null, 2) },
+    ],
+  };
+};
+
+export const GetEntityAttachmentsTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/src/tools/get-general-ledger.tool.ts
+++ b/src/tools/get-general-ledger.tool.ts
@@ -8,9 +8,17 @@ const toolSchema = z.object({
   start_date: z.string().optional().describe("Start date (YYYY-MM-DD)"),
   end_date: z.string().optional().describe("End date (YYYY-MM-DD)"),
   accounting_method: z.enum(["Cash", "Accrual"]).optional().describe("Accounting method"),
-  account: z.string().optional().describe("Filter by account ID"),
+  account: z.string().optional().describe("Filter by account ID (comma-separate for multiple)"),
   source_account: z.string().optional().describe("Filter by source account"),
   sort_by: z.string().optional().describe("Field to sort by"),
+  summary: z
+    .boolean()
+    .optional()
+    .describe("Return compact flattened rows ({column: value} per transaction line) instead of QBO's raw nested report — a fraction of the size"),
+  fields: z
+    .array(z.string())
+    .optional()
+    .describe("With summary, keep only these columns (by column title, e.g. ['Date','Amount','Balance'])"),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/src/tools/get-journal-entry.tool.ts
+++ b/src/tools/get-journal-entry.tool.ts
@@ -6,16 +6,26 @@ import { z } from "zod";
 const toolName = "get_journal_entry";
 const toolDescription = "Get a journal entry by Id from QuickBooks Online.";
 
-// Define the expected input schema for getting a journal entry
-const toolSchema = z.object({
-  id: z.string(),
-});
+// Uniform envelope: {params:{id}} like every other get_* tool, with tolerant
+// aliases (journal_entry_id, entry_id) accepted for backward compatibility
+// with callers that used a different nesting (defect #13).
+const toolSchema = z
+  .object({
+    id: z.string().optional().describe("Journal entry ID"),
+    journal_entry_id: z.string().optional().describe("Alias of id"),
+    entry_id: z.string().optional().describe("Alias of id"),
+  })
+  .refine((v) => v.id || v.journal_entry_id || v.entry_id, {
+    message: "Provide the journal entry id (params.id)",
+  });
 
 type ToolParams = z.infer<typeof toolSchema>;
 
 // Define the tool handler
 const toolHandler = async (args: any) => {
-  const response = await getQuickbooksJournalEntry(args.params.id);
+  const p = args?.params ?? args ?? {};
+  const id = p.id ?? p.journal_entry_id ?? p.entry_id;
+  const response = await getQuickbooksJournalEntry(id);
 
   if (response.isError) {
     return {

--- a/src/tools/get-transaction-link.tool.ts
+++ b/src/tools/get-transaction-link.tool.ts
@@ -1,0 +1,46 @@
+import { ToolDefinition } from "../types/tool-definition.js";
+import { z } from "zod";
+import { buildQboLink, supportedLinkEntityTypes } from "../helpers/qbo-entity-link.js";
+
+const toolName = "get_transaction_link";
+const toolDescription =
+  "Get the QuickBooks Online web deep link for a transaction so it can be opened (and, if mis-created, deleted/voided manually) in the browser. IMPORTANT: the link's txnId resolves against whichever company is ACTIVE in the browser session, not necessarily this server's company — the link is prefixed with this server's company name; confirm the QBO page header matches it before acting. Deleting/voiding is deliberately NOT possible through this API.";
+
+const toolSchema = z.object({
+  entity_type: z
+    .string()
+    .min(1)
+    .describe(
+      `Transaction type. Supported: ${supportedLinkEntityTypes().join(", ")}`
+    ),
+  id: z.string().min(1).describe("The transaction's QBO Id"),
+});
+
+const toolHandler = async ({ params }: any) => {
+  const link = await buildQboLink(params.entity_type, params.id);
+  if (!link) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error: unsupported entity_type "${params.entity_type}". Supported: ${supportedLinkEntityTypes().join(", ")}`,
+        },
+      ],
+    };
+  }
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `${link}\n(Confirm the company shown in the QBO header matches the bracketed name before deleting/editing — txnId resolves against the browser's active company.)`,
+      },
+    ],
+  };
+};
+
+export const GetTransactionLinkTool: ToolDefinition<typeof toolSchema> = {
+  name: toolName,
+  description: toolDescription,
+  schema: toolSchema,
+  handler: toolHandler,
+};

--- a/src/tools/search-accounts.tool.ts
+++ b/src/tools/search-accounts.tool.ts
@@ -100,6 +100,8 @@ const advancedCriteriaSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
   fetchAll: z.boolean().optional(),
 });
 

--- a/src/tools/search-attachables.tool.ts
+++ b/src/tools/search-attachables.tool.ts
@@ -3,11 +3,20 @@ import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
 
 const toolName = "search_attachables";
-const toolDescription = "Search for attachables in QuickBooks Online with optional filters.";
+const toolDescription =
+  "Search for attachables in QuickBooks Online. Returns newest-first by default (orderby MetaData.CreateTime DESC). Supports pagination (limit/offset) and created-date range filters. To find the attachments of a specific transaction, prefer get_entity_attachments.";
 const toolSchema = z.object({
-  file_name: z.string().optional().describe("Filter by file name"),
+  file_name: z.string().optional().describe("Filter by file name (exact match; use file_name_like for contains)"),
+  file_name_like: z.string().optional().describe("Filter by file name substring (LIKE '%value%')"),
   content_type: z.string().optional().describe("Filter by content type"),
-  limit: z.number().optional().describe("Maximum results to return"),
+  created_after: z.string().optional().describe("Only attachables created on/after this ISO date (MetaData.CreateTime >=)"),
+  created_before: z.string().optional().describe("Only attachables created on/before this ISO date (MetaData.CreateTime <=)"),
+  limit: z.number().optional().describe("Maximum results to return (default 1000)"),
+  offset: z.number().optional().describe("1-based start position for pagination (QBO STARTPOSITION)"),
+  orderby: z
+    .string()
+    .optional()
+    .describe("Field to order by, optionally with direction, e.g. 'MetaData.CreateTime DESC' (the default) or 'FileName ASC'"),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/src/tools/search-bill-payments.tool.ts
+++ b/src/tools/search-bill-payments.tool.ts
@@ -14,6 +14,8 @@ const toolSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
   fetchAll: z.boolean().optional(),
 });
 

--- a/src/tools/search-bills.tool.ts
+++ b/src/tools/search-bills.tool.ts
@@ -1,6 +1,7 @@
 import { searchQuickbooksBills } from "../handlers/search-quickbooks-bills.handler.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { shapeSearchResults } from "../helpers/build-quickbooks-search-criteria.js";
 
 const toolName = "search_bills";
 const toolDescription = "Search bills in QuickBooks Online that match given criteria.";
@@ -31,13 +32,13 @@ const billFieldEnum = z.enum([
 
 const criterionSchema = z.object({
   key: z.string().describe("Simple key (legacy) – any Bill property name."),
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
 });
 
 // Advanced criterion schema with operator support.
 const advancedCriterionSchema = z.object({
   field: billFieldEnum,
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
   operator: z
     .enum(["=", "<", ">", "<=", ">=", "LIKE", "IN"])
     .optional()
@@ -59,6 +60,8 @@ const toolSchema = z.object({
   desc: z.string().optional(),
   fetchAll: z.boolean().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
 });
 
 export const SearchBillsTool: ToolDefinition<typeof toolSchema> = {
@@ -66,7 +69,7 @@ export const SearchBillsTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: async (args) => {
-    const { criteria = [], ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
+    const { criteria = [], fields, summary, ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
 
     // build criteria to pass to SDK, supporting advanced operator syntax
     let criteriaToSend: any;
@@ -90,11 +93,12 @@ export const SearchBillsTool: ToolDefinition<typeof toolSchema> = {
         content: [{ type: "text" as const, text: `Error searching bills: ${response.error}` }],
       };
     }
+    const shaped = Array.isArray(response.result) ? shapeSearchResults(response.result, { fields, summary }) : (response.result ?? []);
     return {
       content: [
-        { type: "text" as const, text: Array.isArray(response.result) ? `Found ${response.result.length} bills:` : `Count: ${response.result}` },
+        { type: "text" as const, text: Array.isArray(response.result) ? `Found ${shaped.length} bills:` : `Count: ${response.result}` },
         ...(Array.isArray(response.result)
-          ? response.result.map((b) => ({ type: "text" as const, text: JSON.stringify(b) }))
+          ? shaped.map((b: any) => ({ type: "text" as const, text: JSON.stringify(b) }))
           : []),
       ],
     };

--- a/src/tools/search-customers.tool.ts
+++ b/src/tools/search-customers.tool.ts
@@ -1,6 +1,7 @@
 import { searchQuickbooksCustomers } from "../handlers/search-quickbooks-customers.handler.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { shapeSearchResults } from "../helpers/build-quickbooks-search-criteria.js";
 
 const toolName = "search_customers";
 const toolDescription = "Search customers in QuickBooks Online that match given criteria.";
@@ -25,12 +26,12 @@ const customerFieldEnum = z.enum([
 
 const criterionSchema = z.object({
   key: z.string().describe("Simple key (legacy) – any Customer property name."),
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
 });
 
 const advancedCriterionSchema = z.object({
   field: customerFieldEnum,
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
   operator: z.enum(["=", "<", ">", "<=", ">=", "LIKE", "IN"]).optional(),
 });
 
@@ -51,10 +52,12 @@ const toolSchema = z.object({
   desc: z.string().optional(),
   fetchAll: z.boolean().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
 });
 
 const toolHandler = async (args: any) => {
-  const { criteria = [], ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
+  const { criteria = [], fields, summary, ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
 
   // Build criteria to send to SDK. If user provided the advanced array with field/operator/value
   // we pass it straight through. Otherwise we transform legacy {key,value} pairs to object.
@@ -80,11 +83,12 @@ const toolHandler = async (args: any) => {
       content: [{ type: "text" as const, text: `Error searching customers: ${response.error}` }],
     };
   }
+  const shaped = Array.isArray(response.result) ? shapeSearchResults(response.result, { fields, summary }) : (response.result ?? []);
   return {
     content: [
-      { type: "text" as const, text: Array.isArray(response.result) ? `Found ${response.result.length} customers:` : `Count: ${response.result}` },
+      { type: "text" as const, text: Array.isArray(response.result) ? `Found ${shaped.length} customers:` : `Count: ${response.result}` },
       ...(Array.isArray(response.result)
-        ? response.result.map((c) => ({ type: "text" as const, text: JSON.stringify(c) }))
+        ? shaped.map((c: any) => ({ type: "text" as const, text: JSON.stringify(c) }))
         : []),
     ],
   };

--- a/src/tools/search-employees.tool.ts
+++ b/src/tools/search-employees.tool.ts
@@ -14,6 +14,8 @@ const toolSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
   fetchAll: z.boolean().optional(),
 });
 

--- a/src/tools/search-estimates.tool.ts
+++ b/src/tools/search-estimates.tool.ts
@@ -1,6 +1,7 @@
 import { searchQuickbooksEstimates } from "../handlers/search-quickbooks-estimates.handler.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { shapeSearchResults } from "../helpers/build-quickbooks-search-criteria.js";
 
 const toolName = "search_estimates";
 const toolDescription = "Search estimates in QuickBooks Online that match given criteria.";
@@ -24,13 +25,13 @@ const estimateFieldEnum = z.enum([
 
 const criterionSchema = z.object({
   key: z.string().describe("Simple key (legacy) – any Estimate property name."),
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
 });
 
 // Advanced criterion schema with operator support.
 const advancedCriterionSchema = z.object({
   field: estimateFieldEnum,
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
   operator: z
     .enum(["=", "<", ">", "<=", ">=", "LIKE", "IN"])
     .optional()
@@ -52,6 +53,8 @@ const toolSchema = z.object({
   desc: z.string().optional(),
   fetchAll: z.boolean().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
 });
 
 export const SearchEstimatesTool: ToolDefinition<typeof toolSchema> = {
@@ -59,7 +62,7 @@ export const SearchEstimatesTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: async (args) => {
-    const { criteria = [], ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
+    const { criteria = [], fields, summary, ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
 
     // build criteria to pass to SDK, supporting advanced operator syntax
     let criteriaToSend: any;
@@ -83,11 +86,12 @@ export const SearchEstimatesTool: ToolDefinition<typeof toolSchema> = {
         content: [{ type: "text" as const, text: `Error searching estimates: ${response.error}` }],
       };
     }
+    const shaped = Array.isArray(response.result) ? shapeSearchResults(response.result, { fields, summary }) : (response.result ?? []);
     return {
       content: [
-        { type: "text" as const, text: Array.isArray(response.result) ? `Found ${response.result.length} estimates:` : `Count: ${response.result}` },
+        { type: "text" as const, text: Array.isArray(response.result) ? `Found ${shaped.length} estimates:` : `Count: ${response.result}` },
         ...(Array.isArray(response.result)
-          ? response.result.map((e) => ({ type: "text" as const, text: JSON.stringify(e) }))
+          ? shaped.map((e: any) => ({ type: "text" as const, text: JSON.stringify(e) }))
           : []),
       ],
     };

--- a/src/tools/search-invoices.tool.ts
+++ b/src/tools/search-invoices.tool.ts
@@ -86,6 +86,8 @@ const advancedCriteriaSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
   fetchAll: z.boolean().optional(),
 });
 

--- a/src/tools/search-items.tool.ts
+++ b/src/tools/search-items.tool.ts
@@ -76,6 +76,8 @@ const advancedCriteriaSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
   fetchAll: z.boolean().optional(),
 });
 

--- a/src/tools/search-journal-entries.tool.ts
+++ b/src/tools/search-journal-entries.tool.ts
@@ -14,6 +14,8 @@ const toolSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
   fetchAll: z.boolean().optional(),
 });
 

--- a/src/tools/search-purchases.tool.ts
+++ b/src/tools/search-purchases.tool.ts
@@ -14,6 +14,8 @@ const toolSchema = z.object({
   limit: z.number().optional(),
   offset: z.number().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
   fetchAll: z.boolean().optional(),
 });
 

--- a/src/tools/search-vendors.tool.ts
+++ b/src/tools/search-vendors.tool.ts
@@ -1,6 +1,7 @@
 import { searchQuickbooksVendors } from "../handlers/search-quickbooks-vendors.handler.js";
 import { ToolDefinition } from "../types/tool-definition.js";
 import { z } from "zod";
+import { shapeSearchResults } from "../helpers/build-quickbooks-search-criteria.js";
 
 const toolName = "search_vendors";
 const toolDescription = "Search vendors in QuickBooks Online that match given criteria.";
@@ -38,13 +39,13 @@ const vendorFieldEnum = z.enum([
 
 const criterionSchema = z.object({
   key: z.string().describe("Simple key (legacy) – any Vendor property name."),
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
 });
 
 // Advanced criterion schema with operator support.
 const advancedCriterionSchema = z.object({
   field: vendorFieldEnum,
-  value: z.union([z.string(), z.boolean()]),
+  value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
   operator: z
     .enum(["=", "<", ">", "<=", ">=", "LIKE", "IN"])
     .optional()
@@ -66,6 +67,8 @@ const toolSchema = z.object({
   desc: z.string().optional(),
   fetchAll: z.boolean().optional(),
   count: z.boolean().optional(),
+  fields: z.array(z.string()).optional().describe("Project results to these dot-path fields (e.g. ['Id','TotalAmt','VendorRef.name'])"),
+  summary: z.boolean().optional().describe("Return one compact line per entity (Id, DocNumber, refs, TxnDate, TotalAmt, Balance)"),
 });
 
 export const SearchVendorsTool: ToolDefinition<typeof toolSchema> = {
@@ -73,7 +76,7 @@ export const SearchVendorsTool: ToolDefinition<typeof toolSchema> = {
   description: toolDescription,
   schema: toolSchema,
   handler: async (args) => {
-    const { criteria = [], ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
+    const { criteria = [], fields, summary, ...options } = (args.params ?? {}) as z.infer<typeof toolSchema>;
 
     // build criteria to pass to SDK, supporting advanced operator syntax
     let criteriaToSend: any;
@@ -97,11 +100,12 @@ export const SearchVendorsTool: ToolDefinition<typeof toolSchema> = {
         content: [{ type: "text" as const, text: `Error searching vendors: ${response.error}` }],
       };
     }
+    const shaped = Array.isArray(response.result) ? shapeSearchResults(response.result, { fields, summary }) : (response.result ?? []);
     return {
       content: [
-        { type: "text" as const, text: Array.isArray(response.result) ? `Found ${response.result.length} vendors:` : `Count: ${response.result}` },
+        { type: "text" as const, text: Array.isArray(response.result) ? `Found ${shaped.length} vendors:` : `Count: ${response.result}` },
         ...(Array.isArray(response.result)
-          ? response.result.map((v) => ({ type: "text" as const, text: JSON.stringify(v) }))
+          ? shaped.map((v: any) => ({ type: "text" as const, text: JSON.stringify(v) }))
           : []),
       ],
     };

--- a/tests/unit/handlers/query-layer-ergonomics.test.ts
+++ b/tests/unit/handlers/query-layer-ergonomics.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression tests: query-layer type handling, attachables search ergonomics,
+ * response shaping, deep links, tool-name aliases, and schema completeness.
+ * Grounded in production defects observed during heavy live use.
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { mockQuickbooksClient, mockQuickbooksClientClass, mockQuickBooksInstance, resetAllMocks } from '../../mocks/quickbooks.mock';
+
+jest.unstable_mockModule('../../../src/clients/quickbooks-client', () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+const { searchQuickbooksAttachables, getQuickbooksEntityAttachments } = await import('../../../src/handlers/search-quickbooks-attachables.handler');
+const { getQuickbooksGeneralLedger, flattenReportRows } = await import('../../../src/handlers/get-quickbooks-general-ledger.handler');
+const { coerceCriterionTypes, searchCriterionValueSchema, shapeSearchResults } = await import('../../../src/helpers/build-quickbooks-search-criteria');
+const { buildQboLink, injectQboLinkIntoContent, resetCompanyNameCache } = await import('../../../src/helpers/qbo-entity-link');
+const { RegisterTool } = await import('../../../src/helpers/register-tool');
+const { GetJournalEntryTool } = await import('../../../src/tools/get-journal-entry.tool');
+const { CreateVendorTool } = await import('../../../src/tools/create-vendor.tool');
+const { CreateAttachableTool } = await import('../../../src/tools/create-attachable.tool');
+const { GetTransactionLinkTool } = await import('../../../src/tools/get-transaction-link.tool');
+const { UpdateBillTool } = await import('../../../src/tools/update-bill.tool');
+
+const capture = (mock: any) => (mock.mock.calls[0] as any)[0];
+
+describe('Query layer and ergonomics', () => {
+  beforeEach(() => {
+    resetAllMocks();
+    resetCompanyNameCache();
+  });
+
+  describe('criteria type handling', () => {
+    it('schema accepts string, number, boolean, and array values natively', () => {
+      for (const v of ['x', 42, true, ['a', 'b']]) {
+        expect(() => searchCriterionValueSchema.parse(v)).not.toThrow();
+      }
+    });
+
+    it('coerces boolean-strings on known boolean fields (Active) to real booleans', () => {
+      const [c] = coerceCriterionTypes([{ field: 'Active', value: 'true' }]);
+      expect(c.value).toBe(true); // "true" raw → QBO "String cannot be cast to Boolean"
+    });
+
+    it('leaves boolean-looking strings alone on non-boolean fields', () => {
+      const [c] = coerceCriterionTypes([{ field: 'DisplayName', value: 'true' }]);
+      expect(c.value).toBe('true');
+    });
+
+    it('parses a pre-built SQL tuple string for IN into an array', () => {
+      const [c] = coerceCriterionTypes([{ field: 'Id', value: "('a','b')", operator: 'IN' }]);
+      expect(c.value).toEqual(['a', 'b']); // raw tuple string → QueryParserError before
+    });
+
+    it('passes a native array for IN through untouched (node-quickbooks builds the tuple)', () => {
+      const [c] = coerceCriterionTypes([{ field: 'Id', value: ['1', '2'], operator: 'IN' }]);
+      expect(c.value).toEqual(['1', '2']);
+    });
+  });
+
+  describe('attachables search + entity attachments', () => {
+    it('defaults to newest-first ordering and forwards limit/offset/date filters', async () => {
+      mockQuickBooksInstance.findAttachables.mockImplementation((criteria: any, cb: any) => cb(null, { QueryResponse: { Attachable: [] } }));
+      await searchQuickbooksAttachables({ limit: 50, offset: 101, created_after: '2026-01-01' });
+      const criteria = capture(mockQuickBooksInstance.findAttachables);
+      expect(criteria).toContainEqual({ field: 'desc', value: 'MetaData.CreateTime' });
+      expect(criteria).toContainEqual({ field: 'limit', value: 50 });
+      expect(criteria).toContainEqual({ field: 'offset', value: 101 });
+      expect(criteria).toContainEqual({ field: 'MetaData.CreateTime', value: '2026-01-01', operator: '>=' });
+    });
+
+    it('get_entity_attachments filters by AttachableRef server-side before returning', async () => {
+      const atts = [
+        { Id: 'a1', AttachableRef: [{ EntityRef: { type: 'Bill', value: '100' } }] },
+        { Id: 'a2', AttachableRef: [{ EntityRef: { type: 'Bill', value: '999' } }] },
+        { Id: 'a3', AttachableRef: [{ EntityRef: { type: 'Purchase', value: '100' } }] },
+      ];
+      mockQuickBooksInstance.findAttachables.mockImplementation((_c: any, cb: any) => cb(null, { QueryResponse: { Attachable: atts } }));
+      const result = await getQuickbooksEntityAttachments({ entity_type: 'Bill', entity_id: '100' });
+      expect(result.isError).toBe(false);
+      expect(result.result.matches.map((m: any) => m.Id)).toEqual(['a1']);
+    });
+  });
+
+  describe('response shaping', () => {
+    it('summary mode compacts entities to identifying fields', () => {
+      const shaped = shapeSearchResults(
+        [{ Id: '1', DocNumber: 'B-1', VendorRef: { name: 'Acme Supply' }, TxnDate: '2026-01-31', TotalAmt: 113, Balance: 113, Line: [{ big: 'payload' }] }],
+        { summary: true }
+      );
+      expect(shaped[0]).toEqual({ Id: '1', DocNumber: 'B-1', Name: undefined, VendorRef: 'Acme Supply', CustomerRef: undefined, TxnDate: '2026-01-31', TotalAmt: 113, Balance: 113 });
+    });
+
+    it('fields projection picks dot-paths', () => {
+      const shaped = shapeSearchResults([{ Id: '1', VendorRef: { name: 'Acme', value: '41' } }], { fields: ['Id', 'VendorRef.name'] });
+      expect(shaped[0]).toEqual({ Id: '1', 'VendorRef.name': 'Acme' });
+    });
+
+    it('get_general_ledger forwards account and source_account to the Reports API', async () => {
+      mockQuickBooksInstance.reportGeneralLedgerDetail.mockImplementation((criteria: any, cb: any) => cb(null, { Rows: {} }));
+      await getQuickbooksGeneralLedger({ account: '18', source_account: '35' });
+      const criteria = capture(mockQuickBooksInstance.reportGeneralLedgerDetail);
+      expect(criteria.account).toBe('18');
+      expect(criteria.source_account).toBe('35');
+    });
+
+    it('flattens nested report rows into compact objects', () => {
+      const report = {
+        Columns: { Column: [{ ColTitle: 'Date' }, { ColTitle: 'Amount' }] },
+        Rows: { Row: [{ Header: { ColData: [{ value: 'Accrued Liabilities' }] }, Rows: { Row: [{ ColData: [{ value: '2026-06-30' }, { value: '100.00' }] }] } }] },
+      };
+      const { rows } = flattenReportRows(report);
+      expect(rows).toEqual([{ Date: '2026-06-30', Amount: '100.00', _section: 'Accrued Liabilities' }]);
+    });
+  });
+
+  describe('transaction deep links', () => {
+    it('get_transaction_link returns a company-prefixed deep link', async () => {
+      mockQuickBooksInstance.getCompanyInfo.mockImplementation((_id: any, cb: any) => cb(null, { CompanyName: 'Testco Inc' }));
+      const result = await (GetTransactionLinkTool.handler as any)({ params: { entity_type: 'bill', id: '100' } });
+      expect(result.content[0].text).toContain('[Testco Inc] https://qbo.intuit.com/app/bill?txnId=100');
+    });
+
+    it('rejects unsupported entity types with the supported list', async () => {
+      const result = await (GetTransactionLinkTool.handler as any)({ params: { entity_type: 'timesheet', id: '1' } });
+      expect(result.content[0].text).toMatch(/unsupported entity_type/);
+    });
+
+    it('injects qbo_link into a create/update transaction JSON response', async () => {
+      mockQuickBooksInstance.getCompanyInfo.mockImplementation((_id: any, cb: any) => cb(null, { CompanyName: 'Testco Inc' }));
+      const content = [
+        { type: 'text', text: 'created:' },
+        { type: 'text', text: JSON.stringify({ Id: '99', DocNumber: 'B-1' }) },
+      ];
+      await injectQboLinkIntoContent('create-bill', content as any);
+      expect(JSON.parse(content[1].text!).qbo_link).toBe('[Testco Inc] https://qbo.intuit.com/app/bill?txnId=99');
+    });
+
+    it('leaves non-transaction tools without a link', async () => {
+      const content = [{ type: 'text', text: JSON.stringify({ Id: '7' }) }];
+      await injectQboLinkIntoContent('create-vendor', content as any);
+      expect(JSON.parse(content[0].text!).qbo_link).toBeUndefined();
+    });
+  });
+
+  describe('tool-name aliases', () => {
+    it('registers create_bill alongside create-bill (hyphen name kept for compat)', () => {
+      const registered: string[] = [];
+      const fakeServer = { tool: (name: string) => registered.push(name) } as any;
+      RegisterTool(fakeServer, UpdateBillTool as any);
+      expect(registered).toEqual(['update-bill', 'update_bill']);
+    });
+
+    it('does not alias underscore-named tools', () => {
+      const registered: string[] = [];
+      const fakeServer = { tool: (name: string) => registered.push(name) } as any;
+      RegisterTool(fakeServer, GetJournalEntryTool as any);
+      expect(registered).toEqual(['get_journal_entry']);
+    });
+  });
+
+  describe('envelope tolerance and schema completeness', () => {
+    it('get_journal_entry accepts params.id and the journal_entry_id alias', async () => {
+      mockQuickBooksInstance.getJournalEntry.mockImplementation((id: any, cb: any) => cb(null, { Id: id }));
+      await (GetJournalEntryTool.handler as any)({ params: { id: '7' } });
+      await (GetJournalEntryTool.handler as any)({ params: { journal_entry_id: '9' } });
+      expect(mockQuickBooksInstance.getJournalEntry.mock.calls.map((c: any) => c[0])).toEqual(['7', '9']);
+    });
+
+    it('create-vendor keeps CurrencyRef (immutable after first use), TermRef, TaxIdentifier, Vendor1099', () => {
+      const parsed = (CreateVendorTool.schema as any).parse({
+        vendor: { DisplayName: 'ACME', CurrencyRef: { value: 'USD' }, TermRef: { value: '3' }, TaxIdentifier: '123456789', Vendor1099: true },
+      });
+      expect(parsed.vendor.CurrencyRef).toEqual({ value: 'USD' });
+      expect(parsed.vendor.Vendor1099).toBe(true);
+    });
+
+    it('create_attachable strips TempDownloadUri by default and keeps it on request', async () => {
+      mockQuickBooksInstance.createAttachable.mockImplementation((p: any, cb: any) =>
+        cb(null, { Id: '1', FileName: 'x.pdf', TempDownloadUri: 'https://long-presigned-url/blob' })
+      );
+      const stripped = await (CreateAttachableTool.handler as any)({ params: { file_name: 'x.pdf' } });
+      expect(stripped.content[1].text).not.toContain('TempDownloadUri');
+      resetAllMocks();
+      mockQuickBooksInstance.createAttachable.mockImplementation((p: any, cb: any) =>
+        cb(null, { Id: '1', FileName: 'x.pdf', TempDownloadUri: 'https://long-presigned-url/blob' })
+      );
+      const kept = await (CreateAttachableTool.handler as any)({ params: { file_name: 'x.pdf', return_download_uri: true } });
+      expect(kept.content[1].text).toContain('TempDownloadUri');
+    });
+  });
+});


### PR DESCRIPTION
…aping, transaction deep links, tool aliases

Grounded in heavy production use (hundreds of search/create/update calls):

Query layer:
- Search criteria values are accepted natively as string/number/boolean/ array. Previously numeric values were rejected by the Zod schema ("Expected string, received number"), boolean-as-string "true" was forwarded raw into QBO SQL (QueryProcessingError: String cannot be cast to Boolean), and IN was unusable (JSON arrays rejected; a pre-built SQL-tuple string double-quoted into QueryParserError). Booleans-as- strings are coerced on known boolean fields; IN accepts a JSON array (node-quickbooks builds the tuple) and legacy tuple strings are parsed.
- search_attachables: pagination (limit/offset), orderby with a newest-first default (QBO's oldest-first default made "does txn X have a recent attachment" impossible on large files), and created-date range filters. New get_entity_attachments(entity_type, entity_id) pages newest-first and filters by AttachableRef server-side (AttachableRef is not queryable in QBO SQL), reporting scan completeness.
- Optional fields (dot-path projection) and summary (one compact line per entity) on criteria-based search tools; get_general_ledger gains a flatten mode (Columns/Rows -> [{column: value}]) — raw GL responses ran to megabytes. A test pins that account/source_account reach the Reports API.

Transaction deep links (safe remediation for mis-created transactions):
- New get_transaction_link tool: (entity_type, id) -> the QBO web deep link, e.g. https://qbo.intuit.com/app/bill?txnId=<id>, covering bill, expense/cheque, transfer, journal, billpayment, deposit, recvpayment, invoice, creditmemo, vendorcredit.
- Every create_/update_ transaction response now includes a qbo_link field. CAVEAT handled: txnId resolves against whichever company is active in the browser session, so every link is prefixed with the server's company name (cached from CompanyInfo) for the user to verify before acting.

Ergonomics:
- Underscore aliases for hyphenated tool names (create_bill, update_bill, get_bill, create_vendor, update_vendor, get_vendor); hyphen names kept.
- get_journal_entry accepts id aliases (journal_entry_id/entry_id).
- create-vendor: CurrencyRef (immutable after the vendor's first transaction — must be settable at create), TermRef, TaxIdentifier, Vendor1099; schema opened with passthrough.
- create_attachable: TempDownloadUri (multi-KB pre-signed URL) stripped from responses unless return_download_uri: true.

Tests: query-layer-ergonomics suite (17 cases).

Complementary to #107 (zero file overlap — the two merge independently in either order).