### PR TITLE
fix(auth): persist rotated refresh tokens for env-var deployments

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -6,6 +6,12 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import open from 'open';
+import {
+  readTokenStore,
+  resolveTokenStorePath,
+  selectRefreshToken,
+  writeTokenStore,
+} from '../helpers/token-store.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -59,6 +65,11 @@ export class QuickbooksClient {
   private isAuthenticating: boolean = false;
   private redirectUri: string;
 
+  // Sidecar store for rotated tokens, plus the environment-supplied token the
+  // current rotation chain began from. See persistRotatedToken().
+  private readonly tokenStorePath: string;
+  private readonly seedRefreshToken?: string;
+
   // Refresh 5 minutes before actual expiry to avoid edge cases
   private static readonly TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
@@ -82,10 +93,17 @@ export class QuickbooksClient {
   }) {
     this.clientId = config.clientId;
     this.clientSecret = config.clientSecret;
-    this.refreshToken = config.refreshToken;
-    this.realmId = config.realmId;
     this.environment = config.environment;
     this.redirectUri = config.redirectUri;
+
+    // A token rotated during an earlier run supersedes the configured one,
+    // but only while it descends from that same configured token — so
+    // re-authenticating by hand still takes precedence over a stale store.
+    this.tokenStorePath = resolveTokenStorePath();
+    this.seedRefreshToken = config.refreshToken;
+    const stored = readTokenStore(this.tokenStorePath);
+    this.refreshToken = selectRefreshToken(config.refreshToken, stored);
+    this.realmId = config.realmId || stored?.realm_id;
     this.oauthClient = new OAuthClient({
       clientId: this.clientId,
       clientSecret: this.clientSecret,
@@ -159,6 +177,7 @@ export class QuickbooksClient {
             // Save tokens
             this.refreshToken = tokens.refresh_token;
             this.realmId = tokens.realmId;
+            this.persistRotatedToken(tokens.refresh_token);
             this.saveTokensToEnv();
 
             // Send success response
@@ -244,6 +263,29 @@ export class QuickbooksClient {
         this.isAuthenticating = false;
         reject(error);
       });
+    });
+  }
+
+  /**
+   * Records a rotated refresh token in the sidecar store.
+   *
+   * Writing .env is not sufficient on its own. Credentials are commonly
+   * injected as environment variables by an MCP host's config file, which this
+   * process cannot write back to, and dotenv does not override a variable that
+   * is already set — so on the next start the stale configured token would win
+   * over the rotated one written to .env.
+   *
+   * Never throws: failing to record a rotation must not fail the API call that
+   * triggered it.
+   */
+  private persistRotatedToken(rotatedToken?: string): void {
+    if (!rotatedToken) return;
+
+    writeTokenStore(this.tokenStorePath, {
+      refresh_token: rotatedToken,
+      realm_id: this.realmId,
+      seed_refresh_token: this.seedRefreshToken,
+      updated_at: new Date().toISOString(),
     });
   }
 
@@ -358,6 +400,7 @@ export class QuickbooksClient {
         const newRefreshToken = token.refresh_token;
         if (newRefreshToken && newRefreshToken !== this.refreshToken) {
           this.refreshToken = newRefreshToken;
+          this.persistRotatedToken(newRefreshToken);
           try {
             this.saveTokensToEnv();
             console.error('[qbo-client] Refresh token rotated and persisted to .env');

--- a/src/helpers/token-store.ts
+++ b/src/helpers/token-store.ts
@@ -1,0 +1,108 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Intuit rotates the refresh token on refresh and expires it after 100 days of
+ * disuse, so the newest token is the only durable one. The credentials this
+ * server starts with arrive as environment variables (typically an MCP client's
+ * config file), which the server cannot safely rewrite, so rotated tokens are
+ * persisted to a sidecar store instead.
+ */
+export interface StoredTokens {
+  refresh_token: string;
+  realm_id?: string;
+  /**
+   * The environment-supplied refresh token this rotation chain started from.
+   * Lets a re-seeded environment take precedence over a stale store.
+   */
+  seed_refresh_token?: string;
+  updated_at: string;
+}
+
+/**
+ * Resolves the sidecar token store location. Kept outside the package directory
+ * so it survives a reinstall or rebuild.
+ * @param env Environment to read the QUICKBOOKS_TOKEN_STORE override from
+ * @returns Absolute path to the token store file
+ */
+export function resolveTokenStorePath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.QUICKBOOKS_TOKEN_STORE || path.join(os.homedir(), '.config', 'qbo-mcp', 'tokens.json');
+}
+
+/**
+ * Decides which refresh token to start with.
+ *
+ * The store is only trusted when it descends from the refresh token currently
+ * configured in the environment. If the two disagree, the operator has supplied
+ * fresh credentials by hand and those win — otherwise a stale store would
+ * silently override a manual re-authentication.
+ *
+ * @param seed Refresh token supplied via the environment
+ * @param stored Previously persisted tokens, if any
+ * @returns The refresh token to use, or undefined when neither source has one
+ */
+export function selectRefreshToken(
+  seed: string | undefined,
+  stored: StoredTokens | undefined
+): string | undefined {
+  if (stored?.refresh_token && stored.seed_refresh_token === seed) {
+    return stored.refresh_token;
+  }
+  return seed;
+}
+
+/**
+ * Reads the token store, treating any missing or malformed file as absent.
+ * @param storePath Path to the token store file
+ * @returns The stored tokens, or undefined when unreadable
+ */
+export function readTokenStore(storePath: string): StoredTokens | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    return typeof parsed?.refresh_token === 'string' ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Reported failures are rate-limited to the first one, see writeTokenStore. */
+let reportedWriteFailure = false;
+
+/**
+ * Persists tokens atomically with owner-only permissions. Failures are reported
+ * on stderr rather than thrown: losing the store degrades to re-reading the
+ * environment on restart, but throwing here would fail an otherwise good API call.
+ *
+ * Only the first failure is reported. A store that cannot be written usually
+ * cannot be written on the next rotation either, and refresh runs for the life
+ * of the process.
+ *
+ * Writes must not go to stdout, which carries the MCP stdio protocol.
+ *
+ * @param storePath Path to the token store file
+ * @param tokens Tokens to persist
+ * @returns True when the store was written
+ */
+export function writeTokenStore(storePath: string, tokens: StoredTokens): boolean {
+  const tempPath = `${storePath}.${process.pid}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(tempPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+    fs.renameSync(tempPath, storePath);
+    return true;
+  } catch (error: any) {
+    if (!reportedWriteFailure) {
+      reportedWriteFailure = true;
+      console.error(
+        `[quickbooks] could not persist rotated refresh token to ${storePath}: ${error.message}`
+      );
+    }
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // nothing to clean up
+    }
+    return false;
+  }
+}

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -14,6 +14,8 @@
  *    redirect_uri differs from the one used in the authorize request.
  */
 import { jest } from '@jest/globals';
+import os from 'os';
+import path from 'path';
 
 // The module under test validates env at import time. Set deterministic
 // values before importing it. QUICKBOOKS_REDIRECT_URI deliberately points
@@ -24,6 +26,8 @@ process.env.QUICKBOOKS_REFRESH_TOKEN = 'stale-refresh-token';
 process.env.QUICKBOOKS_REALM_ID = '12345';
 process.env.QUICKBOOKS_ENVIRONMENT = 'sandbox';
 process.env.QUICKBOOKS_REDIRECT_URI = 'https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl';
+// Keep the rotated-token store out of the developer's real home directory.
+process.env.QUICKBOOKS_TOKEN_STORE = path.join(os.tmpdir(), 'qbo-auth-test-tokens.json');
 
 // Track every OAuthClient the module constructs so tests can tell the
 // module-level client (env redirect) apart from the flow client (localhost).

--- a/tests/unit/clients/save-tokens-to-env.test.ts
+++ b/tests/unit/clients/save-tokens-to-env.test.ts
@@ -12,6 +12,8 @@
  * 4. isSymbolicLink: fails closed (returns false) on any fs error.
  */
 import { jest } from '@jest/globals';
+import os from 'os';
+import nodePath from 'path';
 
 process.env.QUICKBOOKS_CLIENT_ID = 'test-client-id';
 process.env.QUICKBOOKS_CLIENT_SECRET = 'test-client-secret';
@@ -19,6 +21,8 @@ process.env.QUICKBOOKS_REFRESH_TOKEN = 'initial-token';
 process.env.QUICKBOOKS_REALM_ID = '99999';
 process.env.QUICKBOOKS_ENVIRONMENT = 'sandbox';
 process.env.QUICKBOOKS_REDIRECT_URI = 'http://localhost:8000/callback';
+// Keep the rotated-token store out of the developer's real home directory.
+process.env.QUICKBOOKS_TOKEN_STORE = nodePath.join(os.tmpdir(), 'qbo-symlink-test-tokens.json');
 
 // --- fs mock state (mutated by each test) ---
 let lstatBehavior: 'regular' | 'symlink' | 'throws' = 'regular';

--- a/tests/unit/helpers/token-store.test.ts
+++ b/tests/unit/helpers/token-store.test.ts
@@ -1,0 +1,139 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  readTokenStore,
+  resolveTokenStorePath,
+  selectRefreshToken,
+  writeTokenStore,
+  StoredTokens,
+} from '../../../src/helpers/token-store';
+
+const makeTokens = (overrides: Partial<StoredTokens> = {}): StoredTokens => ({
+  refresh_token: 'RT-rotated',
+  realm_id: '1234567890',
+  seed_refresh_token: 'RT-seed',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('resolveTokenStorePath', () => {
+  it('should honour the QUICKBOOKS_TOKEN_STORE override', () => {
+    expect(resolveTokenStorePath({ QUICKBOOKS_TOKEN_STORE: '/tmp/custom.json' })).toBe(
+      '/tmp/custom.json'
+    );
+  });
+
+  it('should default to a location outside the package directory', () => {
+    const resolved = resolveTokenStorePath({});
+    expect(resolved).toBe(path.join(os.homedir(), '.config', 'qbo-mcp', 'tokens.json'));
+  });
+
+  it('should read the ambient environment when none is supplied', () => {
+    const previous = process.env.QUICKBOOKS_TOKEN_STORE;
+    process.env.QUICKBOOKS_TOKEN_STORE = '/tmp/ambient.json';
+    try {
+      expect(resolveTokenStorePath()).toBe('/tmp/ambient.json');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.QUICKBOOKS_TOKEN_STORE;
+      } else {
+        process.env.QUICKBOOKS_TOKEN_STORE = previous;
+      }
+    }
+  });
+});
+
+describe('selectRefreshToken', () => {
+  it('should prefer a stored token that descends from the configured seed', () => {
+    const stored = makeTokens({ refresh_token: 'RT-rotated', seed_refresh_token: 'RT-seed' });
+    expect(selectRefreshToken('RT-seed', stored)).toBe('RT-rotated');
+  });
+
+  it('should prefer the environment when it has been re-seeded by hand', () => {
+    const stored = makeTokens({ refresh_token: 'RT-stale', seed_refresh_token: 'RT-old-seed' });
+    expect(selectRefreshToken('RT-freshly-pasted', stored)).toBe('RT-freshly-pasted');
+  });
+
+  it('should fall back to the seed when no store exists', () => {
+    expect(selectRefreshToken('RT-seed', undefined)).toBe('RT-seed');
+  });
+
+  it('should track rotations when the environment supplies no token', () => {
+    const stored = makeTokens({ seed_refresh_token: undefined });
+    expect(selectRefreshToken(undefined, stored)).toBe('RT-rotated');
+  });
+
+  it('should return undefined when neither source has a token', () => {
+    expect(selectRefreshToken(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('token store persistence', () => {
+  let storeDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qbo-token-store-'));
+    storePath = path.join(storeDir, 'nested', 'tokens.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('should round-trip tokens, creating parent directories', () => {
+    expect(writeTokenStore(storePath, makeTokens())).toBe(true);
+    expect(readTokenStore(storePath)).toEqual(makeTokens());
+  });
+
+  it('should write the store readable only by its owner', () => {
+    writeTokenStore(storePath, makeTokens());
+    expect(fs.statSync(storePath).mode & 0o777).toBe(0o600);
+  });
+
+  it('should leave no temporary files behind', () => {
+    writeTokenStore(storePath, makeTokens());
+    expect(fs.readdirSync(path.dirname(storePath))).toEqual(['tokens.json']);
+  });
+
+  it('should overwrite a previous rotation', () => {
+    writeTokenStore(storePath, makeTokens({ refresh_token: 'RT-first' }));
+    writeTokenStore(storePath, makeTokens({ refresh_token: 'RT-second' }));
+    expect(readTokenStore(storePath)?.refresh_token).toBe('RT-second');
+  });
+
+  it('should treat a missing store as absent', () => {
+    expect(readTokenStore(path.join(storeDir, 'nope.json'))).toBeUndefined();
+  });
+
+  it('should treat a malformed store as absent', () => {
+    fs.writeFileSync(path.join(storeDir, 'bad.json'), 'not json{');
+    expect(readTokenStore(path.join(storeDir, 'bad.json'))).toBeUndefined();
+  });
+
+  it('should treat a store without a refresh token as absent', () => {
+    fs.writeFileSync(path.join(storeDir, 'partial.json'), JSON.stringify({ realm_id: '1' }));
+    expect(readTokenStore(path.join(storeDir, 'partial.json'))).toBeUndefined();
+  });
+
+  it('should report failure on stderr rather than throwing, and only once', () => {
+    const stderr = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // A regular file where a directory is required, so the write genuinely fails.
+    const blocker = path.join(storeDir, 'blocker');
+    fs.writeFileSync(blocker, 'not a directory');
+    const unwritable = path.join(blocker, 'tokens.json');
+
+    expect(writeTokenStore(unwritable, makeTokens())).toBe(false);
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining('could not persist rotated refresh token')
+    );
+
+    // A store that cannot be written stays unwritable; do not repeat the noise
+    // on every subsequent rotation.
+    expect(writeTokenStore(unwritable, makeTokens())).toBe(false);
+    expect(stderr).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #117.

`19c90be` persists a rotated refresh token with `saveTokensToEnv()`. When credentials arrive as environment variables from an MCP host's config file — the normal setup — that write is never read back: the server cannot write to the host's config, and `dotenv.config()` does not override an already-set variable. The stale configured token wins on the next start and the rotation is lost.

### What this changes

Rotated tokens are **additionally** recorded in a sidecar store. Writing `.env` is untouched, so nothing changes for people who manage credentials that way.

- Default `~/.config/qbo-mcp/tokens.json`, override with `QUICKBOOKS_TOKEN_STORE`
- Written atomically (temp + rename) with mode `0600`
- Lives outside the package so it survives a reinstall or rebuild

Both persistence sites are covered: the rotation branch in `refreshAccessToken`, and the token save in the OAuth callback.

### Precedence

The interesting design point from the issue. The store records which configured token its rotation chain began from (`seed_refresh_token`) and is trusted only while that still matches what the environment supplies today.

- Normal rotation: seed unchanged → store wins → rotations survive restarts
- Operator pastes a freshly minted token into their host config: seed differs → the environment wins → a stale store cannot silently undo a manual re-auth

That second case is not hypothetical; it is what happens every time someone recovers a dead integration by hand.

### Failure behaviour

`writeTokenStore` never throws — failing to record a rotation must not fail the API call that triggered it. A failure is reported on stderr (never stdout, which carries the MCP stdio protocol) and only the first one, since a store that cannot be written usually stays that way and refresh runs for the life of the process.

### Tests

`npm test` → 620 passing, 33 suites, coverage gates green.

- `tests/unit/helpers/token-store.test.ts` — round-trip, parent-directory creation, `0600` mode, no leftover temp files, malformed/missing/partial stores treated as absent, the precedence rule in both directions, and the report-once failure path
- Both existing client suites now point `QUICKBOOKS_TOKEN_STORE` at a temp path. Worth calling out on its own: without it a test run writes to the developer's real `~/.config`. It does not today only because the `fs` mocks happen to omit `mkdirSync`, which is incidental rather than intentional.

I deliberately did not add `mkdirSync` to those `fs` mocks. Doing so would let the store write reach the shared `renameSync` spy that `save-tokens-to-env.test.ts` asserts against by call index, which would make those assertions about `.env` quietly wrong.

### Verified against production

Refresh plus a `companyinfo` round-trip against a live production realm on this branch, in a deployment configured entirely through an MCP `env` block. Rotation itself is covered by tests rather than observed live, since Intuit only issues a new refresh token roughly every 24h.
