### PR TITLE
fix(auth): allow a public callback URL for the production OAuth flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ QUICKBOOKS_REALM_ID=your_company_id_here
 QUICKBOOKS_REDIRECT_URI=http://localhost:8000/callback
 QUICKBOOKS_ENVIRONMENT=sandbox
 
+# Production only: public tunnel URL (ngrok et al) that forwards to port 8000.
+# Intuit refuses to register a localhost redirect for production apps, so the
+# interactive `npm run auth` flow needs a public callback for the one-time
+# handshake. Must exactly match a Redirect URI on your Intuit app. Unused in
+# sandbox, and unused after the handshake — token refresh doesn't need it.
+# QUICKBOOKS_OAUTH_PUBLIC_CALLBACK=https://<id>.ngrok-free.app/callback
+
 # Restriction Mode — omit or set to false to register all tools (default: all tools registered)
 # QUICKBOOKS_DISABLE_WRITE=true    # suppress create_* and create-* tools
 # QUICKBOOKS_DISABLE_UPDATE=true   # suppress update_* and update-* tools

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -107,16 +107,25 @@ export class QuickbooksClient {
     this.isAuthenticating = true;
     const port = 8000;
 
-    // The local server below receives the callback, so the authorize/exchange
-    // pair must use the localhost redirect even when QUICKBOOKS_REDIRECT_URI
-    // points elsewhere (e.g. the OAuth playground used for manual token
-    // generation). Intuit rejects the exchange if the redirect_uri does not
-    // match the one used in the authorize request.
+    // The local server below receives the callback, so by default the
+    // authorize/exchange pair must use the localhost redirect even when
+    // QUICKBOOKS_REDIRECT_URI points elsewhere (e.g. the OAuth playground used
+    // for manual token generation). Intuit rejects the exchange if the
+    // redirect_uri does not match the one used in the authorize request.
+    //
+    // Production apps are the exception: Intuit refuses to register a localhost
+    // redirect for them, so the authorize step fails before a callback can ever
+    // arrive. For that case a public tunnel (ngrok et al) that forwards to this
+    // port can be declared via QUICKBOOKS_OAUTH_PUBLIC_CALLBACK. It is then used
+    // for BOTH authorize and exchange (they must match), while the callback
+    // still lands on the local server below by way of the tunnel.
+    const publicCallback = process.env.QUICKBOOKS_OAUTH_PUBLIC_CALLBACK;
+    const flowRedirectUri = publicCallback || `http://localhost:${port}/callback`;
     const flowClient = new OAuthClient({
       clientId: this.clientId,
       clientSecret: this.clientSecret,
       environment: this.environment,
-      redirectUri: `http://localhost:${port}/callback`,
+      redirectUri: flowRedirectUri,
     });
 
     return new Promise((resolve, reject) => {
@@ -226,7 +235,12 @@ export class QuickbooksClient {
         }).toString();
 
         console.log('\n=== QuickBooks Authorization ===');
-        console.log('Open this URL in a browser to authorize:\n');
+        console.log(`Environment: ${this.environment}`);
+        console.log(`Callback redirect_uri: ${flowRedirectUri}`);
+        if (publicCallback) {
+          console.log(`(public tunnel must forward to port ${port}, and this exact URL must be registered in your Intuit app)`);
+        }
+        console.log('\nOpen this URL in a browser to authorize:\n');
         console.log(authUri);
         console.log('\nWaiting for callback...\n');
 

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -164,4 +164,41 @@ describe('QuickbooksClient.authenticate', () => {
     expect(refreshDispatch).toHaveBeenLastCalledWith('flow-refresh-token');
     expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
   }, 15000);
+
+  it('authorizes and exchanges with QUICKBOOKS_OAUTH_PUBLIC_CALLBACK when set, for production tunnels', async () => {
+    // Production apps cannot register a localhost redirect, so the flow must be
+    // able to front the local callback server with a public tunnel URL. Both
+    // authorize and exchange have to use it or Intuit rejects the exchange.
+    const tunnel = 'https://example-tunnel.ngrok-free.dev/callback';
+    process.env.QUICKBOOKS_OAUTH_PUBLIC_CALLBACK = tunnel;
+    callbackHandler = undefined;
+
+    try {
+      (quickbooksClient as unknown as { accessTokenExpiry?: Date }).accessTokenExpiry = new Date(0);
+
+      refreshDispatch
+        .mockRejectedValueOnce(new Error('invalid_grant'))
+        .mockResolvedValueOnce({
+          token: { access_token: 'access-3', expires_in: 3600, refresh_token: 'rotated-3' },
+        });
+      createTokenDispatch.mockResolvedValueOnce({
+        token: { refresh_token: 'tunnel-refresh-token', realmId: '12345' },
+      });
+
+      const authPromise = quickbooksClient.authenticate();
+
+      await untilCallbackRegistered();
+      const res = { writeHead: jest.fn(), end: jest.fn() };
+      await callbackHandler!({ url: '/callback?code=xyz&state=testState', method: 'GET' }, res);
+
+      await authPromise;
+
+      const flowClient = oauthInstances[oauthInstances.length - 1];
+      expect(flowClient.cfg.redirectUri).toBe(tunnel);
+      expect(flowClient.createToken).toHaveBeenCalledWith('/callback?code=xyz&state=testState');
+      expect(refreshDispatch).toHaveBeenLastCalledWith('tunnel-refresh-token');
+    } finally {
+      delete process.env.QUICKBOOKS_OAUTH_PUBLIC_CALLBACK;
+    }
+  }, 15000);
 });

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -12,6 +12,9 @@
  *    callback redirect, even when QUICKBOOKS_REDIRECT_URI points elsewhere
  *    (e.g. the OAuth playground). Intuit rejects the code exchange if the
  *    redirect_uri differs from the one used in the authorize request.
+ * 3. That default is overridable by QUICKBOOKS_OAUTH_PUBLIC_CALLBACK, for
+ *    production apps where Intuit will not register a localhost redirect and
+ *    a public tunnel fronts the local callback server.
  */
 import { jest } from '@jest/globals';
 
@@ -111,6 +114,14 @@ async function untilCallbackRegistered(timeoutMs = 2000): Promise<void> {
 }
 
 describe('QuickbooksClient.authenticate', () => {
+  // dotenv loads the developer's real .env at import time with override: true,
+  // so a QUICKBOOKS_OAUTH_PUBLIC_CALLBACK set there would leak into the tests
+  // that pin the localhost default. Clear it here — after the import above —
+  // and let the test that needs it set it explicitly.
+  beforeEach(() => {
+    delete process.env.QUICKBOOKS_OAUTH_PUBLIC_CALLBACK;
+  });
+
   it('refreshes silently without starting the interactive flow when the refresh token works', async () => {
     refreshDispatch.mockResolvedValueOnce({
       token: { access_token: 'access-1', expires_in: 3600, refresh_token: 'rotated-1' },


### PR DESCRIPTION
## Problem

`startOAuthFlow()` hardcodes `http://localhost:8000/callback` as the `redirect_uri` for both the authorize and the exchange step. Intuit refuses to register a localhost redirect for **production** keys, so the authorize request fails before a callback can ever arrive — `npm run auth` is unusable against a production company as shipped.

## Change

Adds an opt-in `QUICKBOOKS_OAUTH_PUBLIC_CALLBACK`. When set, it is used as the `redirect_uri` for **both** authorize and exchange (they must match or Intuit rejects the exchange), while the callback still lands on the local server on port 8000 by way of a tunnel (ngrok et al) forwarding to it.

Deliberately opt-in rather than derived from `QUICKBOOKS_REDIRECT_URI`: that variable may legitimately point somewhere the local server never sees — e.g. the OAuth Playground used for manual token generation — and the existing localhost default protects that case. The default path is unchanged.

The flow now also logs the environment and the `redirect_uri` in use, since a `redirect_uri` mismatch is the most common failure mode here and was previously invisible.

## Testing

`npm test` is green: 605 tests across 32 suites, coverage thresholds intact.

- New unit test asserts the tunnel URL is used for the OAuth client config *and* carried through the exchange.
- The pre-existing test pinning the localhost default still passes — but it needed an isolation fix (second commit): `dotenv` loads the developer's real `.env` at import time with `override: true`, so a `QUICKBOOKS_OAUTH_PUBLIC_CALLBACK` set there leaked into that test and failed it locally. It is now cleared in `beforeEach` (after the dynamic import — a top-level `delete` would be undone by dotenv), and the override test sets it explicitly.

Also documents the variable in `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
