### PR TITLE
fix(security): validate OAuth state parameter to prevent CSRF

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import QuickBooks from "node-quickbooks";
 import OAuthClient from "intuit-oauth";
 import http from 'http';
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -128,6 +129,13 @@ export class QuickbooksClient {
       // (RFC 6749 §4.1.2). Only the first callback may exchange the code.
       let codeExchangeStarted = false;
 
+      // Random per-run value, not guessable from the public repo. Bound to this
+      // authorize request and checked against every callback before we exchange
+      // anything, so a stranger who gets their own valid code for this client_id
+      // (client IDs aren't secret) can't hijack the callback and have their
+      // tokens written into our .env instead of ours.
+      const expectedState = crypto.randomBytes(24).toString('hex');
+
       // Create temporary server for OAuth callback
       const server = http.createServer(async (req, res) => {
         console.log(`[auth-server] ${req.method} ${req.url}`);
@@ -137,6 +145,18 @@ export class QuickbooksClient {
         if (!req.url?.startsWith('/callback')) {
           res.writeHead(404, { 'Content-Type': 'text/plain' });
           res.end('Not Found. Waiting for QuickBooks OAuth callback at /callback');
+          return;
+        }
+
+        // Reject any callback whose state doesn't match this run's authorize
+        // request, before touching codeExchangeStarted, so a spoofed/scanner
+        // hit can't consume the one-shot exchange lock and lock out the real
+        // callback that follows it.
+        const incomingState = new URL(req.url, `http://localhost:${port}`).searchParams.get('state');
+        if (incomingState !== expectedState) {
+          console.log(`[auth-server] Rejected callback with mismatched state (got: ${incomingState ?? 'none'})`);
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Invalid or missing state parameter.');
           return;
         }
 
@@ -222,7 +242,7 @@ export class QuickbooksClient {
         // Generate authorization URL with proper type assertion
         const authUri = flowClient.authorizeUri({
           scope: [OAuthClient.scopes.Accounting as string],
-          state: 'testState'
+          state: expectedState
         }).toString();
 
         console.log('\n=== QuickBooks Authorization ===');

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -110,6 +110,18 @@ async function untilCallbackRegistered(timeoutMs = 2000): Promise<void> {
   }
 }
 
+// server.listen()'s callback (where authorizeUri() is called) runs on a
+// setImmediate scheduled AFTER http.createServer() already set callbackHandler
+// synchronously, so untilCallbackRegistered() alone can resolve before
+// authorizeUri() has actually been invoked. Poll for that call separately.
+async function untilAuthorizeUriCalled(client: MockOAuth, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (client.authorizeUri.mock.calls.length === 0) {
+    if (Date.now() - start > timeoutMs) throw new Error('authorizeUri() was never called');
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
 describe('QuickbooksClient.authenticate', () => {
   it('refreshes silently without starting the interactive flow when the refresh token works', async () => {
     refreshDispatch.mockResolvedValueOnce({
@@ -141,13 +153,7 @@ describe('QuickbooksClient.authenticate', () => {
 
     const authPromise = quickbooksClient.authenticate();
 
-    // Simulate the user completing authorization in the browser: Intuit
-    // redirects to the local callback server.
     await untilCallbackRegistered();
-    const res = { writeHead: jest.fn(), end: jest.fn() };
-    await callbackHandler!({ url: '/callback?code=abc&state=testState', method: 'GET' }, res);
-
-    await authPromise;
 
     // A second OAuthClient was constructed for the flow, with the localhost
     // redirect (NOT the playground URI from the environment).
@@ -155,13 +161,49 @@ describe('QuickbooksClient.authenticate', () => {
     const flowClient = oauthInstances[1];
     expect(flowClient.cfg.redirectUri).toBe('http://localhost:8000/callback');
 
+    // The state actually used is a random per-run value, not a fixed literal —
+    // read it off the authorizeUri() call so the simulated callback matches it.
+    await untilAuthorizeUriCalled(flowClient);
+    const { state } = (flowClient.authorizeUri.mock.calls[0][0] as { state: string; scope: string[] });
+    expect(state).toEqual(expect.stringMatching(/^[0-9a-f]{48}$/));
+
+    // Simulate the user completing authorization in the browser: Intuit
+    // redirects to the local callback server with that same state echoed back.
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    await callbackHandler!({ url: `/callback?code=abc&state=${state}`, method: 'GET' }, res);
+
+    await authPromise;
+
     // The code exchange went through the flow client, so authorize and
     // exchange used the same redirect_uri.
-    expect(flowClient.createToken).toHaveBeenCalledWith('/callback?code=abc&state=testState');
+    expect(flowClient.createToken).toHaveBeenCalledWith(`/callback?code=abc&state=${state}`);
     expect(oauthInstances[0].createToken).not.toHaveBeenCalled();
 
     // The flow's new refresh token was then exchanged for an access token.
     expect(refreshDispatch).toHaveBeenLastCalledWith('flow-refresh-token');
     expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
   }, 15000);
+
+  it('rejects a callback whose state does not match the one from this run\'s authorize request', async () => {
+    // Force the next authenticate() to attempt a refresh, same setup as above.
+    (quickbooksClient as unknown as { accessTokenExpiry?: Date }).accessTokenExpiry = new Date(0);
+    refreshDispatch.mockRejectedValueOnce(new Error('invalid_grant'));
+    // Reset so untilCallbackRegistered() below waits for THIS run's handler
+    // rather than immediately observing the previous test's leftover value.
+    callbackHandler = undefined;
+
+    // Don't await — the flow is left waiting for a (never-arriving) valid callback.
+    void quickbooksClient.authenticate().catch(() => {});
+
+    await untilCallbackRegistered();
+
+    // Someone hitting the callback with a guessed/spoofed or stale state —
+    // e.g. a replayed URL, or another concurrent auth attempt — must be
+    // rejected with 400, and the code must never reach createToken().
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    await callbackHandler!({ url: '/callback?code=abc&state=not-the-real-state', method: 'GET' }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(400, { 'Content-Type': 'text/plain' });
+    expect(createTokenDispatch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem

The interactive auth flow (`startOAuthFlow` in `quickbooks-client.ts`) authorized with a hardcoded `state: 'testState'` and never validated the `state` param on the callback. That means any request to `http://localhost:8000/callback?code=...&state=testState` during an active auth window would be exchanged for tokens — regardless of whether the code actually came from the browser flow the user initiated. This is a classic OAuth CSRF gap (RFC 6749 §10.12): the `state` value existed but wasn't serving its purpose.

The local callback server also binds to all interfaces (`::`) so ngrok can reach it, which widens the window during which this mattered — the server is briefly reachable from more than just the loopback interface while an auth attempt is in progress.

## Fix

- Generate a random 24-byte per-run `state` value (`crypto.randomBytes(24).toString('hex')`) and use it in the authorize request.
- Reject any `/callback` request whose `state` doesn't match before the auth code is ever exchanged (400 response), checked *before* the duplicate-callback guard so a spoofed/scanner hit can't consume the one-shot exchange lock and block the real callback.

## Tests

- Updated the existing auth flow test, which asserted against the old fixed `'testState'` literal — it now reads the actual generated state off the mocked `authorizeUri()` call and uses that in the simulated callback (this also fixed a latent test race: `untilCallbackRegistered()` could resolve before `authorizeUri()` had actually been called, since `http.createServer()` sets the callback handler synchronously while the `listen()` callback where `authorizeUri()` runs is deferred to a separate microtask).
- Added a new test asserting a callback with a mismatched `state` is rejected with 400 and never reaches `createToken()`.
- Full suite (605 tests) passes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>