### PR TITLE
fix: honor QUICKBOOKS_REDIRECT_URI in the interactive OAuth flow

### DIFF
--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -107,16 +107,19 @@ export class QuickbooksClient {
     this.isAuthenticating = true;
     const port = 8000;
 
-    // The local server below receives the callback, so the authorize/exchange
-    // pair must use the localhost redirect even when QUICKBOOKS_REDIRECT_URI
-    // points elsewhere (e.g. the OAuth playground used for manual token
-    // generation). Intuit rejects the exchange if the redirect_uri does not
-    // match the one used in the authorize request.
+    // The authorize/exchange pair must use whatever redirect_uri is actually
+    // registered on the Intuit app — Intuit rejects the exchange if it doesn't
+    // match the one used in the authorize request. For sandbox that's normally
+    // http://localhost:8000/callback; for production Intuit rejects localhost
+    // outright, so QUICKBOOKS_REDIRECT_URI is expected to be a public HTTPS URL
+    // (e.g. an ngrok tunnel) that forwards to this same local port. The local
+    // listener below always binds to `port` regardless of this value.
+    const oauthRedirectUri = process.env.QUICKBOOKS_REDIRECT_URI || `http://localhost:${port}/callback`;
     const flowClient = new OAuthClient({
       clientId: this.clientId,
       clientSecret: this.clientSecret,
       environment: this.environment,
-      redirectUri: `http://localhost:${port}/callback`,
+      redirectUri: oauthRedirectUri,
     });
 
     return new Promise((resolve, reject) => {

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -8,16 +8,18 @@
  *    stored refresh token is rejected (e.g. invalid_grant after the token
  *    was rotated by another consumer, expired past the 100-day window, or
  *    was revoked).
- * 2. The interactive flow must authorize AND exchange with the localhost
- *    callback redirect, even when QUICKBOOKS_REDIRECT_URI points elsewhere
- *    (e.g. the OAuth playground). Intuit rejects the code exchange if the
- *    redirect_uri differs from the one used in the authorize request.
+ * 2. The interactive flow must authorize AND exchange using whatever
+ *    QUICKBOOKS_REDIRECT_URI is configured (e.g. the OAuth playground, or a
+ *    production HTTPS tunnel) rather than a hardcoded localhost redirect —
+ *    Intuit rejects both the exchange (mismatched redirect_uri) and, for
+ *    production apps, the authorize request itself if it's a bare localhost
+ *    URL.
  */
 import { jest } from '@jest/globals';
 
 // The module under test validates env at import time. Set deterministic
 // values before importing it. QUICKBOOKS_REDIRECT_URI deliberately points
-// away from localhost to prove the flow ignores it.
+// away from localhost to prove the flow actually uses it.
 process.env.QUICKBOOKS_CLIENT_ID = 'test-client-id';
 process.env.QUICKBOOKS_CLIENT_SECRET = 'test-client-secret';
 process.env.QUICKBOOKS_REFRESH_TOKEN = 'stale-refresh-token';
@@ -124,7 +126,7 @@ describe('QuickbooksClient.authenticate', () => {
     expect(callbackHandler).toBeUndefined();
   });
 
-  it('falls back to the interactive OAuth flow when the refresh token is rejected, and uses the localhost redirect', async () => {
+  it('falls back to the interactive OAuth flow when the refresh token is rejected, and uses QUICKBOOKS_REDIRECT_URI', async () => {
     // Force the next authenticate() to attempt a refresh.
     (quickbooksClient as unknown as { accessTokenExpiry?: Date }).accessTokenExpiry = new Date(0);
 
@@ -149,11 +151,13 @@ describe('QuickbooksClient.authenticate', () => {
 
     await authPromise;
 
-    // A second OAuthClient was constructed for the flow, with the localhost
-    // redirect (NOT the playground URI from the environment).
+    // A second OAuthClient was constructed for the flow, using
+    // QUICKBOOKS_REDIRECT_URI from the environment (NOT a hardcoded
+    // localhost redirect) — required for production apps, which Intuit
+    // rejects a bare localhost redirect_uri for outright.
     expect(oauthInstances).toHaveLength(2);
     const flowClient = oauthInstances[1];
-    expect(flowClient.cfg.redirectUri).toBe('http://localhost:8000/callback');
+    expect(flowClient.cfg.redirectUri).toBe(process.env.QUICKBOOKS_REDIRECT_URI);
 
     // The code exchange went through the flow client, so authorize and
     // exchange used the same redirect_uri.


### PR DESCRIPTION
## Problem

The interactive flow's authorize/exchange pair always used a hardcoded `http://localhost:8000/callback`, ignoring `QUICKBOOKS_REDIRECT_URI` — even though the README documents pointing that env var at a public tunnel (e.g. ngrok) for exactly this flow.

This breaks production apps outright: Intuit rejects a bare localhost `redirect_uri` for production (non-sandbox) apps, so `npm run auth` had no way to complete for a production QuickBooks company, regardless of what `QUICKBOOKS_REDIRECT_URI` was set to. Sandbox apps happened to work only because Intuit is lenient about localhost there.

## Fix

Use `QUICKBOOKS_REDIRECT_URI` when set, falling back to the previous localhost default otherwise (sandbox behavior is unchanged). The local listener still always binds to port 8000 — `QUICKBOOKS_REDIRECT_URI` just needs to be something that forwards to that port (ngrok, a reverse proxy, Intuit's OAuth Playground redirect for manual token generation, etc.).

## Tests

- Updated the existing auth flow test's assertions and docstring, which previously asserted (and documented as intentional) that the flow always used the hardcoded localhost redirect "even when QUICKBOOKS_REDIRECT_URI points elsewhere" — that was the bug this PR fixes, so the test now asserts the flow client's `redirectUri` matches `QUICKBOOKS_REDIRECT_URI`.
- Full suite (604 tests) passes.

## Note

This is independent of #122 (the OAuth state-validation fix) — both touch `startOAuthFlow()` but different, non-overlapping parts of it. Happy to rebase either on top of the other if you'd prefer them merged in a specific order.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>