### PR TITLE
fix: update_deposit fails on every call with "DepositToAccountRef missing"

### DIFF
--- a/src/handlers/update-quickbooks-deposit.handler.ts
+++ b/src/handlers/update-quickbooks-deposit.handler.ts
@@ -11,7 +11,17 @@ export interface UpdateDepositInput {
 export async function updateQuickbooksDeposit(data: UpdateDepositInput): Promise<ToolResponse<any>> {
   try {
     const quickbooks = await QuickbooksClient.getInstance();
-    const payload: any = { Id: data.id, SyncToken: data.sync_token, sparse: true };
+
+    // QBO rejects a sparse Deposit update that omits DepositToAccountRef (and
+    // other required fields) — unlike Purchase, sparse=true isn't honored here.
+    // Fetch the current record and send a full object back instead.
+    const current: any = await new Promise((resolve, reject) => {
+      (quickbooks as any).getDeposit(data.id, (err: any, deposit: any) => {
+        if (err) reject(err); else resolve(deposit);
+      });
+    });
+
+    const payload: any = { ...current, SyncToken: data.sync_token };
     if (data.private_note) payload.PrivateNote = data.private_note;
 
     return new Promise((resolve) => {

--- a/tests/unit/handlers/deposit-transfer.handlers.test.ts
+++ b/tests/unit/handlers/deposit-transfer.handlers.test.ts
@@ -117,6 +117,9 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should update a deposit', async () => {
+      mockQuickBooksInstance.getDeposit.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '1', SyncToken: '0', DepositToAccountRef: { value: '35' }, Line: [] })
+      );
       mockQuickBooksInstance.updateDeposit.mockImplementation((payload: any, cb: any) => cb(null, {}));
 
       const result = await updateQuickbooksDeposit({ id: '1', sync_token: '0' });
@@ -125,6 +128,9 @@ describe('Deposit and Transfer Handlers', () => {
     });
 
     it('should update a deposit with all optional fields', async () => {
+      mockQuickBooksInstance.getDeposit.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '1', SyncToken: '0', DepositToAccountRef: { value: '35' }, Line: [] })
+      );
       mockQuickBooksInstance.updateDeposit.mockImplementation((payload: any, cb: any) => cb(null, {}));
 
       const result = await updateQuickbooksDeposit({
@@ -136,6 +142,40 @@ describe('Deposit and Transfer Handlers', () => {
       expect(result.isError).toBe(false);
     });
 
+    it('should fetch the current deposit and send a full (non-sparse) object, preserving fields the caller did not touch', async () => {
+      // Regression guard: the old handler sent { Id, SyncToken, sparse: true }
+      // and nothing else, which QBO rejects with "DepositToAccountRef missing"
+      // on every single call, since Deposit doesn't honor sparse=true the way
+      // Purchase does. The fix fetches the current record and merges onto it.
+      mockQuickBooksInstance.getDeposit.mockImplementation((id: any, cb: any) => {
+        expect(id).toBe('42');
+        cb(null, {
+          Id: '42',
+          SyncToken: '3',
+          DepositToAccountRef: { value: '35', name: 'Checking' },
+          Line: [{ Id: '1', Amount: 100, DetailType: 'DepositLineDetail', DepositLineDetail: {} }],
+        });
+      });
+
+      let captured: any;
+      mockQuickBooksInstance.updateDeposit.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, payload);
+      });
+
+      const result = await updateQuickbooksDeposit({ id: '42', sync_token: '4', private_note: 'note' });
+
+      expect(result.isError).toBe(false);
+      // Untouched fields carried over from the fetched record.
+      expect(captured.DepositToAccountRef).toEqual({ value: '35', name: 'Checking' });
+      expect(captured.Line).toEqual([{ Id: '1', Amount: 100, DetailType: 'DepositLineDetail', DepositLineDetail: {} }]);
+      // The caller-supplied sync_token wins over the one on the fetched record.
+      expect(captured.SyncToken).toBe('4');
+      expect(captured.PrivateNote).toBe('note');
+      // No sparse flag — QBO does not honor sparse=true for Deposit.
+      expect(captured.sparse).toBeUndefined();
+    });
+
     it('should update a deposit - authentication error', async () => {
       (mockQuickbooksClientClass.getInstance as any).mockRejectedValue(new Error('Auth failed'));
 
@@ -145,7 +185,21 @@ describe('Deposit and Transfer Handlers', () => {
       expect(result.error).toContain('Auth failed');
     });
 
+    it('should update a deposit - error fetching the current deposit', async () => {
+      mockQuickBooksInstance.getDeposit.mockImplementation((_id: any, cb: any) =>
+        cb(new Error('Not found'), null)
+      );
+
+      const result = await updateQuickbooksDeposit({ id: '999', sync_token: '0' });
+
+      expect(result.isError).toBe(true);
+      expect(result.error).toContain('Not found');
+    });
+
     it('should update a deposit - API error', async () => {
+      mockQuickBooksInstance.getDeposit.mockImplementation((_id: any, cb: any) =>
+        cb(null, { Id: '1', SyncToken: '0', DepositToAccountRef: { value: '35' }, Line: [] })
+      );
       mockQuickBooksInstance.updateDeposit.mockImplementation((payload: any, cb: any) =>
         cb(new Error('Update failed'), null)
       );


### PR DESCRIPTION
## Problem

`update_deposit` sent `{ Id, SyncToken, sparse: true }` and nothing else. Unlike `Purchase`, QuickBooks Online does not honor `sparse=true` for `Deposit` updates — it requires the full object, including `DepositToAccountRef` and `Line`, on every update call. The result was that `update_deposit` failed with `"DepositToAccountRef missing"` on literally every invocation, regardless of input, making the tool entirely non-functional as shipped.

## Fix

Fetch the current deposit via `getDeposit` first, then merge the caller's changes (`SyncToken`, `PrivateNote`, etc.) onto the full fetched object before calling `updateDeposit`, instead of sending a bare sparse patch.

## Tests

`update_deposit` had no existing dedicated regression coverage for this path, so I added it:
- A test asserting the handler fetches the current deposit and sends a **full, non-sparse** object back, preserving fields the caller didn't touch (`DepositToAccountRef`, `Line`) while applying the caller's `SyncToken`/`PrivateNote`.
- A test for `getDeposit` itself failing (propagates as a normal error response).
- Updated the pre-existing happy-path tests to mock `getDeposit` (previously unmocked, which would now hang since the handler calls it before `updateDeposit`).
- Full suite (606 tests) passes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>