### PR TITLE
fix: create_deposit sends the wrong shape for Line[].DepositLineDetail.Entity

### DIFF
--- a/src/handlers/create-quickbooks-deposit.handler.ts
+++ b/src/handlers/create-quickbooks-deposit.handler.ts
@@ -27,7 +27,10 @@ export async function createQuickbooksDeposit(data: CreateDepositInput): Promise
         DetailType: "DepositLineDetail",
         DepositLineDetail: {
           AccountRef: l.account_ref ? { value: l.account_ref } : undefined,
-          Entity: l.entity_ref ? { Type: l.entity_ref.type, EntityRef: { value: l.entity_ref.value } } : undefined,
+          // QBO's actual Deposit.Line[].DepositLineDetail.Entity shape is
+          // flat ({value, type}), confirmed against a live GET response —
+          // not the nested {Type, EntityRef} shape this used to send.
+          Entity: l.entity_ref ? { value: l.entity_ref.value, type: l.entity_ref.type } : undefined,
         },
       })),
     };

--- a/tests/unit/handlers/deposit-transfer.handlers.test.ts
+++ b/tests/unit/handlers/deposit-transfer.handlers.test.ts
@@ -64,6 +64,25 @@ describe('Deposit and Transfer Handlers', () => {
       expect(result.result).toEqual(mockDeposit);
     });
 
+    it('should send the Entity field in the flat {value, type} shape QBO actually expects', async () => {
+      // Regression guard: this used to send a nested { Type, EntityRef: { value } }
+      // shape, which QBO silently ignores — entity_ref never actually reached
+      // the created deposit's line. Confirmed against a live GET response that
+      // QBO's real Deposit.Line[].DepositLineDetail.Entity shape is flat.
+      let captured: any;
+      mockQuickBooksInstance.createDeposit.mockImplementation((payload: any, cb: any) => {
+        captured = payload;
+        cb(null, payload);
+      });
+
+      await createQuickbooksDeposit({
+        deposit_to_account_ref: 'account-1',
+        line_items: [{ amount: 1000, entity_ref: { type: 'Customer', value: 'cust-1' } }],
+      });
+
+      expect(captured.Line[0].DepositLineDetail.Entity).toEqual({ value: 'cust-1', type: 'Customer' });
+    });
+
     it('should create a deposit - API error', async () => {
       mockQuickBooksInstance.createDeposit.mockImplementation((payload: any, cb: any) =>
         cb(new Error('Create failed'), null)


### PR DESCRIPTION
## Problem

`create_deposit` built `Entity` as a nested `{ Type, EntityRef: { value } }` object. QBO's actual schema for `Deposit.Line[].DepositLineDetail.Entity` is flat: `{ value, type }` — confirmed against a live GET response for an existing deposit. QBO silently ignores the unrecognized nested shape (no error), so `entity_ref` (the customer/vendor tied to a deposit line) never actually reached the created record.

## Fix

Send the flat `{ value, type }` shape instead.

## Tests

- Added a test capturing the payload sent to `createDeposit` and asserting `Line[0].DepositLineDetail.Entity` matches the flat shape.
- Full suite (605 tests) passes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>