### PR TITLE
fix: persist rotated refresh token to a tokens.json sidecar (fixes #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,10 @@ If upgrading from the original Intuit implementation:
 
 ## [Unreleased]
 
+### Fixed
+
+- Rotated refresh tokens are now persisted to a `tokens.json` sidecar file (in addition to `.env`), so env-var-based deployments (Docker, MCP host `env` config blocks) don't silently lose token rotation on restart. Override the sidecar location with `QUICKBOOKS_TOKEN_STORE_PATH`. (#117)
+
 ### Planned
 
 - Integration tests with QuickBooks sandbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,7 +325,7 @@ If upgrading from the original Intuit implementation:
 
 ### Fixed
 
-- Rotated refresh tokens are now persisted to a `tokens.json` sidecar file (in addition to `.env`), so env-var-based deployments (Docker, MCP host `env` config blocks) don't silently lose token rotation on restart. Override the sidecar location with `QUICKBOOKS_TOKEN_STORE_PATH`. (#117)
+- Rotated refresh tokens can now be persisted to a relocatable `tokens.json` store (in addition to `.env`) via `QUICKBOOKS_TOKEN_STORE_PATH` — for deployments where the install root itself doesn't survive restarts (e.g. some ephemeral-container setups), point this at a persistent volume so rotation isn't lost. (#117)
 
 ### Planned
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ QUICKBOOKS_REALM_ID=your_realm_id
 # QUICKBOOKS_DISABLE_WRITE=true    # suppress create_* tools
 # QUICKBOOKS_DISABLE_UPDATE=true   # suppress update_* tools
 # QUICKBOOKS_DISABLE_DELETE=true   # suppress delete_* tools
+
+# Optional: override where the rotated-refresh-token sidecar is stored (default: install root)
+# QUICKBOOKS_TOKEN_STORE_PATH=/path/to/tokens.json
 ```
 
 `.env` is gitignored so your real credentials stay local.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ QUICKBOOKS_REALM_ID=your_realm_id
 # QUICKBOOKS_DISABLE_UPDATE=true   # suppress update_* tools
 # QUICKBOOKS_DISABLE_DELETE=true   # suppress delete_* tools
 
-# Optional: override where the rotated-refresh-token sidecar is stored (default: install root)
+# Optional: relocate the rotated-refresh-token store off the install root — set this to a path
+# on a persistent volume if your deployment's install root is read-only or ephemeral (e.g. some
+# container setups). Default: alongside .env in the install root, which already persists rotation
+# across restarts on any deployment where that directory itself persists.
 # QUICKBOOKS_TOKEN_STORE_PATH=/path/to/tokens.json
 ```
 

--- a/docs/superpowers/plans/2026-08-09-token-sidecar-persistence.md
+++ b/docs/superpowers/plans/2026-08-09-token-sidecar-persistence.md
@@ -1,0 +1,823 @@
+# Token Sidecar Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist a rotated QuickBooks refresh token somewhere the server both owns and re-reads, so env-var-based deployments (the normal MCP host config shape) don't silently lose rotation on restart — fixes #117.
+
+**Architecture:** A new sidecar file, `tokens.json`, colocated with `.env` in the install root. A pure `resolveRefreshToken()` function implements the "descended from" chain-trust rule (a stale sidecar can't override a manually-pasted new token). `QuickbooksClient` calls it at module init and writes the sidecar on every rotation and on first-run OAuth completion, alongside the existing `.env` write.
+
+**Tech Stack:** TypeScript (Node ESM/NodeNext), Jest with `jest.unstable_mockModule` for fs mocking, existing `fs`/`path` Node built-ins (no new dependencies).
+
+## Global Constraints
+
+- Sidecar path: `QUICKBOOKS_TOKEN_STORE_PATH` env override, else `<install-root>/tokens.json` (same install-root resolution `.env` already uses: `path.join(__dirname, '..', '..', 'tokens.json')` from `src/clients/`).
+- Sidecar write is atomic: temp file + `renameSync`, mode `0o600`; symlinked `tokens.json` writes through to the `realpathSync` target (dangling-symlink relative targets resolve against the link's own directory, not `process.cwd()`) — same pattern as the existing `.env` write in `saveTokensToEnv`.
+- Sidecar read never throws: missing file → `null` silently; corrupt JSON or permission error → `null` + a logged warning.
+- No persistence failure (either `.env` or sidecar) may fail `authenticate()`/`refreshAccessToken()` — the in-memory token stays valid for the running process regardless.
+- `descendedFrom` never changes value once a chain starts, except when the host-supplied `QUICKBOOKS_REFRESH_TOKEN` itself changes (operator manual re-auth), which resets the chain.
+
+---
+
+### Task 1: `resolveRefreshToken()` — pure chain-trust logic
+
+**Files:**
+- Create: `src/clients/token-sidecar.ts`
+- Test: `tests/unit/clients/token-sidecar-resolve.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface TokenSidecar {
+    refreshToken: string;
+    realmId?: string;
+    descendedFrom: string;
+    updatedAt: string;
+  }
+
+  export interface ResolvedTokens {
+    refreshToken: string | undefined;
+    realmId: string | undefined;
+    chainRoot: string | undefined;
+  }
+
+  export function resolveRefreshToken(
+    configuredToken: string | undefined,
+    configuredRealmId: string | undefined,
+    sidecar: TokenSidecar | null
+  ): ResolvedTokens
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/clients/token-sidecar-resolve.test.ts`:
+
+```ts
+import { resolveRefreshToken } from '../../../src/clients/token-sidecar';
+
+describe('resolveRefreshToken', () => {
+  it('uses the configured token when no sidecar exists', () => {
+    const result = resolveRefreshToken('host-token', '12345', null);
+    expect(result).toEqual({ refreshToken: 'host-token', realmId: '12345', chainRoot: 'host-token' });
+  });
+
+  it('trusts the sidecar when its chain root matches the configured token', () => {
+    const sidecar = { refreshToken: 'rotated-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken('host-token', '12345', sidecar);
+    expect(result).toEqual({ refreshToken: 'rotated-token', realmId: '99999', chainRoot: 'host-token' });
+  });
+
+  it('falls back to the sidecar realmId only when the sidecar itself omits one', () => {
+    const sidecar = { refreshToken: 'rotated-token', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken('host-token', '12345', sidecar);
+    expect(result.realmId).toBe('12345');
+  });
+
+  it('ignores a stale sidecar when the configured token has changed (manual re-auth)', () => {
+    const sidecar = { refreshToken: 'rotated-token', realmId: '99999', descendedFrom: 'old-host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken('new-host-token', '12345', sidecar);
+    expect(result).toEqual({ refreshToken: 'new-host-token', realmId: '12345', chainRoot: 'new-host-token' });
+  });
+
+  it('does not trust a sidecar when there is no configured token to compare against', () => {
+    const sidecar = { refreshToken: 'rotated-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken(undefined, undefined, sidecar);
+    expect(result).toEqual({ refreshToken: undefined, realmId: undefined, chainRoot: undefined });
+  });
+
+  it('handles no configured token and no sidecar (fresh OAuth needed)', () => {
+    const result = resolveRefreshToken(undefined, undefined, null);
+    expect(result).toEqual({ refreshToken: undefined, realmId: undefined, chainRoot: undefined });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/token-sidecar-resolve.test.ts`
+Expected: FAIL — `Cannot find module '../../../src/clients/token-sidecar'`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/clients/token-sidecar.ts`:
+
+```ts
+export interface TokenSidecar {
+  refreshToken: string;
+  realmId?: string;
+  descendedFrom: string;
+  updatedAt: string;
+}
+
+export interface ResolvedTokens {
+  refreshToken: string | undefined;
+  realmId: string | undefined;
+  chainRoot: string | undefined;
+}
+
+// Implements the "descended from" chain-trust rule from the #117 design:
+// a sidecar is only trusted while its chain root still matches the token
+// the host config currently supplies. If an operator pastes a new token
+// into their host config (manual re-auth), the chain resets and the
+// configured value wins — a stale sidecar can never silently override that.
+export function resolveRefreshToken(
+  configuredToken: string | undefined,
+  configuredRealmId: string | undefined,
+  sidecar: TokenSidecar | null
+): ResolvedTokens {
+  if (sidecar && configuredToken && sidecar.descendedFrom === configuredToken) {
+    return {
+      refreshToken: sidecar.refreshToken,
+      realmId: sidecar.realmId ?? configuredRealmId,
+      chainRoot: sidecar.descendedFrom,
+    };
+  }
+  return {
+    refreshToken: configuredToken,
+    realmId: configuredRealmId,
+    chainRoot: configuredToken,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/token-sidecar-resolve.test.ts`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/clients/token-sidecar.ts tests/unit/clients/token-sidecar-resolve.test.ts
+git commit -m "feat(token-sidecar): add pure chain-trust resolution logic"
+```
+
+---
+
+### Task 2: `loadTokenSidecar()` / `saveTokenSidecar()` — file I/O
+
+**Files:**
+- Modify: `src/clients/token-sidecar.ts`
+- Test: `tests/unit/clients/token-sidecar-io.test.ts`
+
+**Interfaces:**
+- Consumes: `TokenSidecar` (Task 1)
+- Produces:
+  ```ts
+  export function getSidecarPath(): string
+  export function loadTokenSidecar(): TokenSidecar | null
+  export function saveTokenSidecar(data: TokenSidecar): void
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/clients/token-sidecar-io.test.ts`:
+
+```ts
+import { jest } from '@jest/globals';
+
+let lstatBehavior: 'regular' | 'symlink' | 'throws' = 'regular';
+let realpathBehavior: 'ok' | 'enoent' = 'ok';
+let readFileBehavior: 'ok' | 'enoent' | 'corrupt' | 'eacces' = 'ok';
+const REAL_PATH = '/persistent-volume/tokens.json';
+let readlinkTarget = '/fresh-pvc/tokens.json';
+
+const writeFileSyncSpy = jest.fn<(p: string, data: string, options?: any) => void>();
+const renameSyncSpy = jest.fn<(o: string, n: string) => void>();
+const mkdirSyncSpy = jest.fn<(p: string, options?: any) => void>();
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => {
+      if (readFileBehavior === 'enoent') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      if (readFileBehavior === 'eacces') throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      if (readFileBehavior === 'corrupt') return '{ not valid json';
+      return JSON.stringify({ refreshToken: 'stored-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' });
+    }),
+    writeFileSync: writeFileSyncSpy,
+    renameSync: renameSyncSpy,
+    unlinkSync: jest.fn(),
+    mkdirSync: mkdirSyncSpy,
+    lstatSync: jest.fn(() => {
+      if (lstatBehavior === 'throws') throw new Error('EACCES');
+      return { isSymbolicLink: () => lstatBehavior === 'symlink' };
+    }),
+    realpathSync: jest.fn(() => {
+      if (realpathBehavior === 'enoent') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return REAL_PATH;
+    }),
+    readlinkSync: jest.fn(() => readlinkTarget),
+  },
+}));
+
+const { loadTokenSidecar, saveTokenSidecar } = await import('../../../src/clients/token-sidecar');
+
+describe('loadTokenSidecar', () => {
+  beforeEach(() => {
+    readFileBehavior = 'ok';
+    consoleErrorSpy.mockClear();
+  });
+
+  it('returns null silently when the file does not exist', () => {
+    readFileBehavior = 'enoent';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the parsed sidecar when the file is valid JSON', () => {
+    expect(loadTokenSidecar()).toEqual({
+      refreshToken: 'stored-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z',
+    });
+  });
+
+  it('returns null and logs a warning on corrupt JSON', () => {
+    readFileBehavior = 'corrupt';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read token sidecar'));
+  });
+
+  it('returns null and logs a warning on a permission error', () => {
+    readFileBehavior = 'eacces';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read token sidecar'));
+  });
+});
+
+describe('saveTokenSidecar', () => {
+  const data = { refreshToken: 'new-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+
+  beforeEach(() => {
+    writeFileSyncSpy.mockClear();
+    renameSyncSpy.mockClear();
+    mkdirSyncSpy.mockClear();
+    lstatBehavior = 'regular';
+    realpathBehavior = 'ok';
+    readlinkTarget = '/fresh-pvc/tokens.json';
+  });
+
+  it('creates the parent directory before writing', () => {
+    saveTokenSidecar(data);
+    expect(mkdirSyncSpy).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+  });
+
+  it('uses atomic temp+rename for a regular file', () => {
+    saveTokenSidecar(data);
+    expect(renameSyncSpy).toHaveBeenCalled();
+    const [tmpPath, destPath] = renameSyncSpy.mock.calls[0];
+    expect(tmpPath).toContain('tokens.json.tmp.');
+    expect(destPath).toContain('tokens.json');
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      expect.stringContaining('tokens.json.tmp.'),
+      expect.stringContaining('"refreshToken": "new-token"'),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+
+  it('writes through a symlink target via realpathSync (no rename)', () => {
+    lstatBehavior = 'symlink';
+    saveTokenSidecar(data);
+    expect(renameSyncSpy).not.toHaveBeenCalled();
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      REAL_PATH,
+      expect.stringContaining('"refreshToken": "new-token"'),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+
+  it('resolves a dangling symlink via readlinkSync fallback', () => {
+    lstatBehavior = 'symlink';
+    realpathBehavior = 'enoent';
+    readlinkTarget = '/fresh-pvc/tokens.json';
+    saveTokenSidecar(data);
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      '/fresh-pvc/tokens.json',
+      expect.any(String),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/token-sidecar-io.test.ts`
+Expected: FAIL — `loadTokenSidecar`/`saveTokenSidecar` not exported
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Append to `src/clients/token-sidecar.ts` (add these imports at the top of the file, above the existing interfaces):
+
+```ts
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+```
+
+Add at the bottom of `src/clients/token-sidecar.ts`:
+
+```ts
+export function getSidecarPath(): string {
+  return process.env.QUICKBOOKS_TOKEN_STORE_PATH || path.join(__dirname, '..', '..', 'tokens.json');
+}
+
+export function loadTokenSidecar(): TokenSidecar | null {
+  try {
+    const raw = fs.readFileSync(getSidecarPath(), 'utf-8');
+    return JSON.parse(raw) as TokenSidecar;
+  } catch (e: any) {
+    if (e?.code === 'ENOENT') return null;
+    console.error(`[qbo-client] Failed to read token sidecar, ignoring: ${e?.message ?? e}`);
+    return null;
+  }
+}
+
+function isSymbolicLink(filePath: string): boolean {
+  try {
+    return fs.lstatSync(filePath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+// Atomic-write pattern mirrors QuickbooksClient.saveTokensToEnv (same
+// symlink/dangling-symlink handling, same rationale — see that method's
+// comments for why a persistent-volume-mounted symlink needs write-through
+// rather than rename).
+export function saveTokenSidecar(data: TokenSidecar): void {
+  const tokenPath = getSidecarPath();
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+
+  const content = JSON.stringify(data, null, 2) + '\n';
+
+  if (isSymbolicLink(tokenPath)) {
+    let realPath: string;
+    try {
+      realPath = fs.realpathSync(tokenPath);
+    } catch (e: any) {
+      if (e?.code === 'ENOENT') {
+        const linkTarget = fs.readlinkSync(tokenPath);
+        realPath = path.isAbsolute(linkTarget)
+          ? linkTarget
+          : path.resolve(path.dirname(tokenPath), linkTarget);
+      } else {
+        throw e;
+      }
+    }
+    fs.writeFileSync(realPath, content, { mode: 0o600 });
+  } else {
+    const tmpPath = `${tokenPath}.tmp.${process.pid}`;
+    try {
+      fs.writeFileSync(tmpPath, content, { mode: 0o600 });
+      fs.renameSync(tmpPath, tokenPath);
+    } catch (err) {
+      try { fs.unlinkSync(tmpPath); } catch { /* best effort */ }
+      throw err;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/token-sidecar-io.test.ts`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/clients/token-sidecar.ts tests/unit/clients/token-sidecar-io.test.ts
+git commit -m "feat(token-sidecar): add sidecar file read/write with atomic+symlink handling"
+```
+
+---
+
+### Task 3: Wire sidecar-aware resolution into `QuickbooksClient` startup
+
+**Files:**
+- Modify: `src/clients/quickbooks-client.ts`
+- Test: `tests/unit/clients/quickbooks-client.sidecar-startup.test.ts`
+
+**Interfaces:**
+- Consumes: `loadTokenSidecar`, `resolveRefreshToken`, `TokenSidecar` (Tasks 1-2)
+- Produces: `QuickbooksClient` gains a `tokenChainRoot?: string` private field, set from a new `tokenChainRoot` constructor config property.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/clients/quickbooks-client.sidecar-startup.test.ts`:
+
+```ts
+import { jest } from '@jest/globals';
+
+process.env.QUICKBOOKS_CLIENT_ID = 'test-client-id';
+process.env.QUICKBOOKS_CLIENT_SECRET = 'test-client-secret';
+process.env.QUICKBOOKS_REFRESH_TOKEN = 'host-token';
+process.env.QUICKBOOKS_REALM_ID = '12345';
+process.env.QUICKBOOKS_ENVIRONMENT = 'sandbox';
+process.env.QUICKBOOKS_REDIRECT_URI = 'http://localhost:8000/callback';
+
+const sidecarContent = JSON.stringify({
+  refreshToken: 'rotated-from-sidecar',
+  realmId: '99999',
+  descendedFrom: 'host-token',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+});
+
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => sidecarContent),
+    existsSync: jest.fn(() => true),
+    writeFileSync: jest.fn(),
+    renameSync: jest.fn(),
+    unlinkSync: jest.fn(),
+    mkdirSync: jest.fn(),
+    lstatSync: jest.fn(() => ({ isSymbolicLink: () => false })),
+  },
+}));
+
+jest.unstable_mockModule('intuit-oauth', () => {
+  class MockOAuthClient {
+    static scopes = { Accounting: 'com.intuit.quickbooks.accounting' };
+    refreshUsingToken = jest.fn();
+    createToken = jest.fn();
+    authorizeUri = jest.fn(() => 'https://mock');
+    constructor(_cfg: Record<string, unknown>) {}
+  }
+  return { default: MockOAuthClient };
+});
+
+jest.unstable_mockModule('node-quickbooks', () => ({
+  default: class MockQuickBooks { constructor(..._args: unknown[]) {} },
+}));
+
+jest.unstable_mockModule('open', () => ({ default: jest.fn(async () => undefined) }));
+
+jest.unstable_mockModule('http', () => ({
+  default: { createServer: jest.fn(() => ({ listen: jest.fn(), close: jest.fn(), on: jest.fn(), address: jest.fn() })) },
+}));
+
+const { quickbooksClient } = await import('../../../src/clients/quickbooks-client');
+
+describe('QuickbooksClient startup sidecar resolution', () => {
+  it('uses the trusted sidecar refresh token instead of the raw configured env value', () => {
+    expect((quickbooksClient as unknown as { refreshToken?: string }).refreshToken).toBe('rotated-from-sidecar');
+  });
+
+  it('uses the sidecar realmId when the chain is trusted', () => {
+    expect((quickbooksClient as unknown as { realmId?: string }).realmId).toBe('99999');
+  });
+
+  it('sets tokenChainRoot to the descendedFrom value from the trusted sidecar', () => {
+    expect((quickbooksClient as unknown as { tokenChainRoot?: string }).tokenChainRoot).toBe('host-token');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/quickbooks-client.sidecar-startup.test.ts`
+Expected: FAIL — `refreshToken` is `'host-token'` (raw env value), not `'rotated-from-sidecar'`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/clients/quickbooks-client.ts`, add the import alongside the existing top-of-file imports:
+
+```ts
+import { loadTokenSidecar, resolveRefreshToken } from './token-sidecar.js';
+```
+
+Replace this block:
+
+```ts
+const client_id = process.env.QUICKBOOKS_CLIENT_ID;
+const client_secret = process.env.QUICKBOOKS_CLIENT_SECRET;
+const refresh_token = process.env.QUICKBOOKS_REFRESH_TOKEN;
+const realm_id = process.env.QUICKBOOKS_REALM_ID;
+const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'sandbox';
+```
+
+with:
+
+```ts
+const client_id = process.env.QUICKBOOKS_CLIENT_ID;
+const client_secret = process.env.QUICKBOOKS_CLIENT_SECRET;
+const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'sandbox';
+
+// A rotated refresh token may live in the sidecar file rather than the
+// host-supplied env var — see token-sidecar.ts for the chain-trust rule
+// that decides which one wins (#117).
+const tokenSidecar = loadTokenSidecar();
+const resolvedTokens = resolveRefreshToken(
+  process.env.QUICKBOOKS_REFRESH_TOKEN,
+  process.env.QUICKBOOKS_REALM_ID,
+  tokenSidecar
+);
+const refresh_token = resolvedTokens.refreshToken;
+const realm_id = resolvedTokens.realmId;
+const token_chain_root = resolvedTokens.chainRoot;
+```
+
+Add the `tokenChainRoot` field and constructor param. In the `QuickbooksClient` class, next to the existing `private refreshToken?: string;`:
+
+```ts
+  private tokenChainRoot?: string;
+```
+
+In the constructor's `config` parameter type, add `tokenChainRoot?: string;` next to `refreshToken?: string;`, and in the constructor body next to `this.refreshToken = config.refreshToken;`:
+
+```ts
+    this.tokenChainRoot = config.tokenChainRoot;
+```
+
+At the bottom of the file, update the `quickbooksClient` construction to pass it through:
+
+```ts
+export const quickbooksClient = new QuickbooksClient({
+  clientId: client_id,
+  clientSecret: client_secret,
+  refreshToken: refresh_token,
+  realmId: realm_id,
+  environment: environment,
+  redirectUri: redirect_uri,
+  tokenChainRoot: token_chain_root,
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/quickbooks-client.sidecar-startup.test.ts`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Run the full existing suite to check for regressions**
+
+Run: `npm test`
+Expected: PASS — `quickbooks-client.auth.test.ts` mocks `fs.readFileSync` to always throw ENOENT, so `loadTokenSidecar()` returns `null` there and `resolveRefreshToken` falls through to the raw `'stale-refresh-token'` env value, unchanged from today's behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/clients/quickbooks-client.ts tests/unit/clients/quickbooks-client.sidecar-startup.test.ts
+git commit -m "feat(quickbooks-client): resolve refresh token via sidecar chain-trust at startup"
+```
+
+---
+
+### Task 4: Persist rotated tokens to the sidecar on refresh
+
+**Files:**
+- Modify: `src/clients/quickbooks-client.ts`
+- Modify: `tests/unit/clients/save-tokens-to-env.test.ts`
+
+**Interfaces:**
+- Consumes: `saveTokenSidecar`, `TokenSidecar` (Task 2); `this.tokenChainRoot` (Task 3)
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/unit/clients/save-tokens-to-env.test.ts`, add `saveTokenSidecar` behavior to the existing `fs` mock (it already mocks `writeFileSync`/`renameSync`/etc. — add `mkdirSync: jest.fn()` to the mock object alongside the existing keys), then add a new test at the end of the `describe` block:
+
+```ts
+  it('also persists the rotated token to the sidecar file with an unchanged chain root', async () => {
+    lstatBehavior = 'regular';
+
+    await quickbooksClient.authenticate();
+
+    const sidecarCall = writeFileSyncSpy.mock.calls.find(([p]) => String(p).includes('tokens.json.tmp.'));
+    expect(sidecarCall).toBeDefined();
+    const [, content] = sidecarCall!;
+    const parsed = JSON.parse(content as string);
+    expect(parsed.refreshToken).toBe(`rotated-${tokenCounter}`);
+    expect(parsed.descendedFrom).toBe('initial-token');
+  });
+
+  it('keeps descendedFrom unchanged across two successive rotations', async () => {
+    lstatBehavior = 'regular';
+
+    await quickbooksClient.authenticate();
+    (quickbooksClient as any).accessTokenExpiry = new Date(0);
+    (quickbooksClient as any).authInFlight = undefined;
+    tokenCounter++;
+    refreshDispatch.mockResolvedValue({
+      token: { access_token: `access-${tokenCounter}`, expires_in: 3600, refresh_token: `rotated-${tokenCounter}` },
+    });
+    await quickbooksClient.authenticate();
+
+    const sidecarCalls = writeFileSyncSpy.mock.calls.filter(([p]) => String(p).includes('tokens.json.tmp.'));
+    const lastCall = sidecarCalls[sidecarCalls.length - 1];
+    const parsed = JSON.parse(lastCall[1] as string);
+    expect(parsed.refreshToken).toBe(`rotated-${tokenCounter}`);
+    expect(parsed.descendedFrom).toBe('initial-token');
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/save-tokens-to-env.test.ts`
+Expected: FAIL — no `tokens.json.tmp.` write found (sidecar isn't written yet)
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/clients/quickbooks-client.ts`, add the import next to the one added in Task 3:
+
+```ts
+import { loadTokenSidecar, resolveRefreshToken, saveTokenSidecar } from './token-sidecar.js';
+```
+
+In `refreshAccessToken()`, inside the `if (newRefreshToken && newRefreshToken !== this.refreshToken)` block, immediately after the existing `saveTokensToEnv()` try/catch, add a second independent try/catch:
+
+```ts
+        const newRefreshToken = token.refresh_token;
+        if (newRefreshToken && newRefreshToken !== this.refreshToken) {
+          this.refreshToken = newRefreshToken;
+          try {
+            this.saveTokensToEnv();
+            console.error('[qbo-client] Refresh token rotated and persisted to .env');
+          } catch (persistErr) {
+            console.error('[qbo-client] Failed to persist rotated refresh token:', persistErr);
+          }
+          try {
+            saveTokenSidecar({
+              refreshToken: newRefreshToken,
+              realmId: this.realmId,
+              descendedFrom: this.tokenChainRoot ?? newRefreshToken,
+              updatedAt: new Date().toISOString(),
+            });
+          } catch (persistErr) {
+            console.error('[qbo-client] Failed to persist rotated refresh token to sidecar:', persistErr);
+          }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/save-tokens-to-env.test.ts`
+Expected: PASS (all tests in the file, including the two new ones)
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/clients/quickbooks-client.ts tests/unit/clients/save-tokens-to-env.test.ts
+git commit -m "feat(quickbooks-client): persist rotated refresh token to sidecar on rotation"
+```
+
+---
+
+### Task 5: Persist to the sidecar on first-run OAuth completion
+
+**Files:**
+- Modify: `src/clients/quickbooks-client.ts`
+- Modify: `tests/unit/clients/quickbooks-client.auth.test.ts`
+
+**Interfaces:**
+- Consumes: `saveTokenSidecar` (Task 2)
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/unit/clients/quickbooks-client.auth.test.ts`, first give the test file a named spy for `writeFileSync` so assertions can inspect its calls. Replace:
+
+```ts
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => {
+      throw enoent();
+    }),
+    existsSync: jest.fn(() => false),
+    writeFileSync: jest.fn(),
+    renameSync: jest.fn(),
+    unlinkSync: jest.fn(),
+  },
+}));
+```
+
+with:
+
+```ts
+const writeFileSyncSpy = jest.fn();
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => {
+      throw enoent();
+    }),
+    existsSync: jest.fn(() => false),
+    writeFileSync: writeFileSyncSpy,
+    renameSync: jest.fn(),
+    unlinkSync: jest.fn(),
+    mkdirSync: jest.fn(),
+  },
+}));
+```
+
+Then, at the end of the `'falls back to the interactive OAuth flow...'` test (after the existing assertions, before its closing `});`), add:
+
+```ts
+    // The first-run OAuth completion also seeds the sidecar so the very
+    // next rotation has a chain root to compare against.
+    const sidecarCall = writeFileSyncSpy.mock.calls.find(([p]: [string]) => p.includes('tokens.json.tmp.'));
+    expect(sidecarCall).toBeDefined();
+    const sidecarContent = JSON.parse(sidecarCall![1] as string);
+    expect(sidecarContent.refreshToken).toBe('flow-refresh-token');
+    expect(sidecarContent.descendedFrom).toBe('flow-refresh-token');
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/quickbooks-client.auth.test.ts`
+Expected: FAIL — no `tokens.json.tmp.` write found
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/clients/quickbooks-client.ts`, inside `startOAuthFlow()`'s callback success handler, after the existing:
+
+```ts
+            // Save tokens
+            this.refreshToken = tokens.refresh_token;
+            this.realmId = tokens.realmId;
+            this.saveTokensToEnv();
+```
+
+add:
+
+```ts
+            if (this.refreshToken) {
+              this.tokenChainRoot = this.refreshToken;
+              try {
+                saveTokenSidecar({
+                  refreshToken: this.refreshToken,
+                  realmId: this.realmId,
+                  descendedFrom: this.tokenChainRoot,
+                  updatedAt: new Date().toISOString(),
+                });
+              } catch (persistErr) {
+                console.error('[qbo-client] Failed to persist new refresh token to sidecar:', persistErr);
+              }
+            }
+```
+
+(Placed after `this.saveTokensToEnv()`, matching that call's existing lack of its own try/catch at this call site — a failure here still falls into the outer handler's `catch (error)` block and returns the existing 500 response, unchanged from today's behavior for `.env`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/clients/quickbooks-client.auth.test.ts`
+Expected: PASS (all tests, including the extended one)
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/clients/quickbooks-client.ts tests/unit/clients/quickbooks-client.auth.test.ts
+git commit -m "feat(quickbooks-client): seed token sidecar on first-run OAuth completion"
+```
+
+---
+
+### Task 6: Document the sidecar in README and CHANGELOG
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Check the current README for its env var documentation section**
+
+Run: `grep -n "QUICKBOOKS_REFRESH_TOKEN\|## " README.md | head -30`
+
+Find the table or section documenting `QUICKBOOKS_*` env vars.
+
+- [ ] **Step 2: Add `QUICKBOOKS_TOKEN_STORE_PATH` to that section**
+
+Add a row/entry (matching whatever format the existing env var docs use — table row or bullet):
+
+```
+`QUICKBOOKS_TOKEN_STORE_PATH` — optional. Overrides where the rotated-refresh-token sidecar (`tokens.json`) is stored. Defaults to the install root, alongside `.env`. See #117 for why this exists: env-var-based deployments (the normal MCP host config shape) can't read a rotated token back out of `.env`, so the server also persists it here and re-reads it at startup.
+```
+
+- [ ] **Step 3: Add a CHANGELOG entry**
+
+Check `CHANGELOG.md`'s existing entry format (`head -30 CHANGELOG.md`) and add a new entry following that same format:
+
+```
+- Fix: rotated refresh tokens are now also persisted to a `tokens.json` sidecar file (in addition to `.env`), so env-var-based deployments (Docker, MCP host `env` config blocks) don't silently lose token rotation on restart. Override the sidecar location with `QUICKBOOKS_TOKEN_STORE_PATH`. (#117)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: document token sidecar and QUICKBOOKS_TOKEN_STORE_PATH"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** storage location/format (Task 1-2), startup resolution (Task 3), persistence on rotation (Task 4), first-run OAuth persistence (Task 5), error handling/atomic write mechanics (Task 2), testing (Tasks 1-5 each ship their own tests), README/docs (Task 6). All five design sections have a task.
+- **Type consistency:** `TokenSidecar`, `ResolvedTokens`, `resolveRefreshToken`, `loadTokenSidecar`, `saveTokenSidecar`, `getSidecarPath`, `tokenChainRoot` are named identically everywhere they appear across tasks.
+- **No placeholders:** every step has real code, real test assertions, real commands.

--- a/docs/superpowers/plans/2026-08-09-token-sidecar-persistence.md
+++ b/docs/superpowers/plans/2026-08-09-token-sidecar-persistence.md
@@ -758,7 +758,7 @@ add:
             }
 ```
 
-(Placed after `this.saveTokensToEnv()`, matching that call's existing lack of its own try/catch at this call site — a failure here still falls into the outer handler's `catch (error)` block and returns the existing 500 response, unchanged from today's behavior for `.env`.)
+(Placed after `this.saveTokensToEnv()`, wrapped in its own try/catch — a failure here is logged and swallowed, matching Task 4's rotation-path pattern and the Global Constraint that no persistence failure may block authenticate()/refreshAccessToken(). Correction: an earlier draft of this note claimed the opposite — that a failure here would propagate to the outer catch and return a 500 — which contradicted the code above it. Verified during Task 5's review; ruling: the try/catch is correct, the prose was wrong.)
 
 - [ ] **Step 4: Run test to verify it passes**
 

--- a/docs/superpowers/specs/2026-08-08-simpro-mcp-colocation-design.md
+++ b/docs/superpowers/specs/2026-08-08-simpro-mcp-colocation-design.md
@@ -1,0 +1,56 @@
+# Design: Co-locate simpro-mcp into intuit-qbo-mcp
+
+## Problem
+
+Two separate MCP servers exist for Nexus Communications Technology's stack:
+
+- `intuit-qbo-mcp` (this repo) — 12.5k LOC, per-domain hand-written QBO tools, interactive OAuth + refresh-token rotation, full test suite, npm-published package.
+- `~/Documents/NXSCT/simpro-mcp` — small (3 src files), generic CRUD passthrough for simPRO's REST API (7 tools total, parameterized by a `resource` string), no test suite.
+
+Operators currently need two separate MCP host config entries to use both. There's also a broader goal — cross-system reconciliation tooling (jobs invoiced in simPRO but missing in QBO, payment mismatches) — that depends on both tool sets living in one process first. That reconciliation work is out of scope here; this spec only covers co-location, the foundation it needs.
+
+## Approach
+
+Absorb simpro-mcp into this repo rather than standing up a third repo or the reverse direction (absorbing qbo-mcp into simpro-mcp, rejected given qbo-mcp's size/maturity/test coverage). Both already use `@modelcontextprotocol/sdk` with compatible `registerTool`/`tool` APIs — no SDK version conflict blocks this.
+
+## Repo layout & porting plan
+
+simpro-mcp's generic 7-tool shape (`simpro_list_companies`, `simpro_list`, `simpro_get`, `simpro_create`, `simpro_update`, `simpro_delete`, `simpro_request`) is the right design for simPRO's 300+ endpoint surface — porting it doesn't fight that shape, it's still 7 files.
+
+- `src/simpro/client.ts` — ported from `simpro-client.ts`, adapted to this repo's error-handling convention (structured `{isError, error}` returns, matching `create-quickbooks-customer.handler.ts`, not throw-and-catch-in-index).
+- `src/simpro/config.ts` — ported as-is. Env vars stay `SIMPRO_*`, no collision with `QUICKBOOKS_*`.
+- `src/tools/simpro-*.tool.ts` — 7 files, same `ToolDefinition` shape as existing QBO tools, registered via the existing `RegisterTool(server, ...)` call in `index.ts`.
+- The original `~/Documents/NXSCT/simpro-mcp` repo is retired once ported (or left archived — outside this repo's concern).
+
+## Auth, config, server identity
+
+No auth merging needed — the two APIs' auth models stay fully independent, two client singletons in one process:
+
+- QBO: existing `QuickbooksClient` (interactive OAuth + refresh-token rotation, `QUICKBOOKS_*` env vars, plus the sidecar persistence from the #117 spec).
+- simPRO: confirmed live against the Nexus Communications Technology build (`nexusct.simprosuite.com`, company 0) — **API Key mode**, a static Bearer token (`Authorization: Bearer <access_token>`), no expiry/refresh cycle at all. Simpler than the OAuth2 client-credentials path originally assumed; `SIMPRO_ACCESS_TOKEN` static-token mode in the existing simpro-mcp client is the one that applies here, not the client-credentials branch.
+
+`QuickbooksMCPServer.GetServer()` is renamed from `"QuickBooks Online MCP Server"` to `"QuickBooks + simPRO MCP Server"`, since it now serves both tool sets from one process/one client config entry.
+
+simPRO connectivity is optional at startup — unlike QBO's env vars (which throw if `client_id`/`client_secret` missing), simPRO tools register unconditionally but fail per-call with a clear "simPRO not configured" error if `SIMPRO_BASE_URL`/credentials are absent. An operator using only the QBO side shouldn't have the server refuse to start because simPRO isn't configured.
+
+## Tool registration & destructive-op gating
+
+QBO tools are already gated behind `QUICKBOOKS_DISABLE_WRITE`/`UPDATE`/`DELETE` via prefix-based `getCrudCategory()` in `src/helpers/register-tool.ts`. simPRO's tool names don't fit that prefix convention, and `simpro_request` is a raw passthrough that can perform any HTTP verb — including destructive ones — through a single generic tool.
+
+- `PREFIX_CATEGORY_MAP`/`getCrudCategory` gets exact-name entries (not prefix) for `simpro_create` → WRITE, `simpro_update` → UPDATE, `simpro_delete` → DELETE.
+- New env vars mirroring the existing convention: `SIMPRO_DISABLE_WRITE`, `SIMPRO_DISABLE_UPDATE`, `SIMPRO_DISABLE_DELETE` — separate from `QUICKBOOKS_DISABLE_*` so an operator can lock down one system without the other.
+- `simpro_request` is gated by inspecting the `method` argument at call time, not registration time: `POST`→WRITE, `PATCH`/`PUT`→UPDATE, `DELETE`→DELETE, `GET`→unrestricted. The same disable check runs inside the handler before dispatching, since a single tool spans all four categories depending on the call.
+
+## Testing, build & docs
+
+- New `tests/unit/clients/simpro-client.test.ts` — mirrors the `quickbooks-client.auth.test.ts` pattern (`jest.unstable_mockModule`). Covers static-token auth (no refresh-cycle tests needed, unlike QBO — confirmed via live verification that this build uses API Key mode), 429 retry/backoff, and error passthrough.
+- New `tests/unit/tools/simpro-*.test.ts` — one per tool, same shape as existing `tests/unit/tools/*.test.ts` (schema validation, handler success/error paths, CRUD-gating via `SIMPRO_DISABLE_*`).
+- `package.json` unchanged structurally — still one `bin`, one `dist/index.js`; `tsc` picks up `src/simpro/**` automatically.
+- `README.md` gets a new env-var table for `SIMPRO_*` (mirroring the existing `QUICKBOOKS_*` table) and a tools table entry for the 7 simPRO tools.
+- `verify-readonly.mjs` (currently untracked/local, hardcodes a QBO-only tool list) is out of scope for this spec — its list would go stale for the simPRO side if relied on; extending it is optional, operator's call.
+- `CHANGELOG.md` entry per repo convention.
+
+## Out of scope
+
+- Cross-system reconciliation tools (job/payment mismatch detection between simPRO and QBO) — separate spec, sequenced after this one, once the merged server exists to build on.
+- The token sidecar persistence work (#117) — separate spec, already written (`2026-08-08-token-sidecar-persistence-design.md`).

--- a/docs/superpowers/specs/2026-08-08-token-sidecar-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-08-token-sidecar-persistence-design.md
@@ -1,0 +1,104 @@
+# Design: Token sidecar persistence (fixes #117)
+
+## Problem
+
+`19c90be` persists a rotated refresh token via `saveTokensToEnv()`, writing it into `.env`. For the normal MCP deployment shape — credentials supplied as environment variables through the host's own config (`claude_desktop_config.json`, `.mcp.json`, a container's `env` block) — that write is never read back:
+
+1. The server cannot write to the host's config file; it doesn't know where it lives, and it isn't `.env`.
+2. `dotenv.config()` never overrides a variable already present in `process.env`, so the host-supplied `QUICKBOOKS_REFRESH_TOKEN` always wins at the next startup.
+
+Rotation is silently lost on every restart. Once Intuit stops accepting the previously issued token, refresh fails with `invalid_grant` and the integration needs manual re-authentication — exactly the failure `19c90be` set out to prevent.
+
+## Approach
+
+Add a sidecar file, `tokens.json`, colocated with `.env` in the server's install root (same directory resolution `saveTokensToEnv` already uses, `__dirname/../../`). Override path via `QUICKBOOKS_TOKEN_STORE_PATH`.
+
+This placement (rather than `$HOME`) is deliberate: any deployment that already solves `.env` persistence — a symlink into a mounted volume, a container's persistent-volume mount (the exact case fixed for `.env` in #63) — gets `tokens.json` persistence for free, same directory, no additional mount config. A homedir-based sidecar would need its own separate persistence story, reintroducing the class of bug this fix addresses.
+
+This also matches existing codebase precedent: `src/helpers/attachable-file-source.ts` (merged in #97, unrelated PR) already denies uploads named `tokens.json` with the comment *"the server's own install tree (which holds `.env` and `tokens.json` for a QBO company)"* — the install-root sidecar was already anticipated.
+
+### Schema
+
+```json
+{
+  "refreshToken": "<latest rotated token>",
+  "realmId": "<latest realm id>",
+  "descendedFrom": "<refresh token value the chain started from>",
+  "updatedAt": "<ISO timestamp>"
+}
+```
+
+`descendedFrom` is the `QUICKBOOKS_REFRESH_TOKEN` value read from the host env/`.env` at the point the current rotation chain began. It stays fixed across rotations, and is the mechanism that keeps a stale sidecar from silently overriding a manual re-auth: if an operator pastes a new token into their host config, `descendedFrom` no longer matches, and the sidecar is ignored in favor of the freshly configured value.
+
+## Startup resolution
+
+Runs at module init, replacing today's direct `const refresh_token = process.env.QUICKBOOKS_REFRESH_TOKEN` read:
+
+```
+configuredToken = process.env.QUICKBOOKS_REFRESH_TOKEN   (post dotenv.config)
+sidecar = loadTokenSidecar()   // null on missing/corrupt/unreadable
+
+if sidecar && configuredToken && sidecar.descendedFrom === configuredToken:
+    resolvedRefreshToken = sidecar.refreshToken
+    resolvedRealmId      = sidecar.realmId ?? env realmId
+    chainRoot             = sidecar.descendedFrom      // trusted, unchanged
+else:
+    resolvedRefreshToken = configuredToken               // host config wins
+    chainRoot             = configuredToken               // chain reset
+```
+
+`chainRoot` is stored as a new private field on `QuickbooksClient` (`tokenChainRoot`), needed at rotation time to write `descendedFrom` correctly.
+
+First-run OAuth (no `configuredToken` at all) is unaffected by this block — falls through to the existing `startOAuthFlow()`. After OAuth succeeds, `tokenChainRoot` is set to the freshly obtained refresh token itself (there's no prior host-config value to compare against).
+
+## Persistence on rotation
+
+`refreshAccessToken()`, on new refresh token detected (unchanged trigger: `newRefreshToken !== this.refreshToken`):
+
+```
+this.refreshToken = newRefreshToken
+saveTokensToEnv()                                    // existing, unchanged
+saveTokenSidecar({
+  refreshToken: newRefreshToken,
+  realmId: this.realmId,
+  descendedFrom: this.tokenChainRoot,                 // unchanged across rotations
+  updatedAt: now
+})
+```
+
+Both writes are independently try/caught — same pattern as today's `.env` write: a disk failure logs and continues, never fails the refresh itself (the in-memory token is still valid for the running process).
+
+The `startOAuthFlow` success handler gets the same `saveTokenSidecar()` call added alongside its existing `saveTokensToEnv()`, with `descendedFrom` set to the newly obtained token.
+
+## Error handling & write mechanics
+
+Sidecar write mirrors `saveTokensToEnv`'s existing atomic pattern:
+
+- Regular file: temp file (`tokens.json.tmp.<pid>`) + `renameSync`, mode `0o600`.
+- Symlinked `tokens.json`: write through to the `realpathSync` target (same dangling-symlink fallback as `.env` — a relative `readlinkSync` target is resolved against the link's own directory, not `process.cwd()`).
+- `mkdirSync(dir, { recursive: true })` first if `QUICKBOOKS_TOKEN_STORE_PATH` points somewhere the install root doesn't already guarantee exists.
+
+Sidecar read (`loadTokenSidecar`, at module init):
+
+- File missing → returns `null` silently (expected on first run, or upgrading from a version without this feature).
+- JSON parse failure or permission error → returns `null`, logs a warning (`[qbo-client] Failed to read token sidecar, ignoring: <reason>`). Never throws — startup must not hard-fail because of a corrupt sidecar; falls back to `configuredToken`, same as the no-sidecar case.
+
+## Testing
+
+New `tests/unit/clients/token-sidecar.test.ts`, following the existing `jest.unstable_mockModule('fs', …)` pattern from `save-tokens-to-env.test.ts`:
+
+1. No sidecar file → resolves `configuredToken`, trust logic not engaged.
+2. Sidecar present, `descendedFrom === configuredToken` → resolves `sidecar.refreshToken` (chain trusted).
+3. Sidecar present, `descendedFrom !== configuredToken` (operator pasted new token) → `configuredToken` wins, stale sidecar ignored, chain reset.
+4. Corrupt sidecar JSON → falls back to `configuredToken`, doesn't throw, logs warning.
+5. Rotation writes sidecar with `descendedFrom` unchanged across multiple successive rotations.
+6. First-run OAuth (no `configuredToken`) → sidecar written post-flow with `descendedFrom` = newly obtained token.
+7. Symlinked `tokens.json` → write-through to target path (mirrors existing `.env` symlink tests; logic is shared with `saveTokensToEnv`, one case suffices).
+
+`tests/unit/clients/save-tokens-to-env.test.ts` is unaffected — it stays scoped to `.env` write behavior only.
+
+## Out of scope
+
+- The simpro-mcp / qbo-mcp server merge (separate spec, sequenced after this one per user request).
+- Issue #68 (dead stored token, no interactive fallback) — explicitly a different failure mode per the issue text.
+- Dependency vulnerabilities (#115), error-payload sanitization (#99), input validation (#98) — separate issues, own specs if pursued.

--- a/docs/superpowers/specs/2026-08-08-token-sidecar-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-08-token-sidecar-persistence-design.md
@@ -9,6 +9,8 @@
 
 Rotation is silently lost on every restart. Once Intuit stops accepting the previously issued token, refresh fails with `invalid_grant` and the integration needs manual re-authentication — exactly the failure `19c90be` set out to prevent.
 
+> **Correction (2026-08-09, post-implementation review):** Point 2 above does not hold for this codebase. `quickbooks-client.ts` has called `dotenv.config({ ..., override: true })` since commit `5c95064` (2026-06-01) — `.env` already wins over a host-supplied `QUICKBOOKS_REFRESH_TOKEN` at the next startup. So in any deployment where the install root itself is writable and persistent, the rotated token written to `.env` **is** read back and **does** beat the host config value; the bug described above does not occur there. The sidecar built from this spec adds no persistence in that common case — it changes nothing by default. Its real, narrower value is `QUICKBOOKS_TOKEN_STORE_PATH`: a relocatable store that lets an operator move token persistence off the install root entirely, for the case where the install root itself is read-only or doesn't survive restarts (e.g. some ephemeral-container deployments). The rest of this document (schema, chain-trust resolution, atomic-write handling) is accurate and unaffected by this correction; only the stated root cause above is wrong. See the final whole-branch review (`final-review.md`, finding I1) for the full analysis.
+
 ## Approach
 
 Add a sidecar file, `tokens.json`, colocated with `.env` in the server's install root (same directory resolution `saveTokensToEnv` already uses, `__dirname/../../`). Override path via `QUICKBOOKS_TOKEN_STORE_PATH`.

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import open from 'open';
-import { loadTokenSidecar, resolveRefreshToken } from './token-sidecar.js';
+import { loadTokenSidecar, resolveRefreshToken, saveTokenSidecar } from './token-sidecar.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -380,6 +380,16 @@ export class QuickbooksClient {
             // Don't fail the whole refresh just because we couldn't write to
             // disk; the in-memory token is still valid for this process.
             console.error('[qbo-client] Failed to persist rotated refresh token:', persistErr);
+          }
+          try {
+            saveTokenSidecar({
+              refreshToken: newRefreshToken,
+              realmId: this.realmId,
+              descendedFrom: this.tokenChainRoot ?? newRefreshToken,
+              updatedAt: new Date().toISOString(),
+            });
+          } catch (persistErr) {
+            console.error('[qbo-client] Failed to persist rotated refresh token to sidecar:', persistErr);
           }
         }
 

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -174,7 +174,11 @@ export class QuickbooksClient {
             // Save tokens
             this.refreshToken = tokens.refresh_token;
             this.realmId = tokens.realmId;
-            this.saveTokensToEnv();
+            try {
+              this.saveTokensToEnv();
+            } catch (persistErr) {
+              console.error('[qbo-client] Failed to persist new refresh token to .env:', persistErr);
+            }
 
             if (this.refreshToken) {
               this.tokenChainRoot = this.refreshToken;

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -176,6 +176,20 @@ export class QuickbooksClient {
             this.realmId = tokens.realmId;
             this.saveTokensToEnv();
 
+            if (this.refreshToken) {
+              this.tokenChainRoot = this.refreshToken;
+              try {
+                saveTokenSidecar({
+                  refreshToken: this.refreshToken,
+                  realmId: this.realmId,
+                  descendedFrom: this.tokenChainRoot,
+                  updatedAt: new Date().toISOString(),
+                });
+              } catch (persistErr) {
+                console.error('[qbo-client] Failed to persist new refresh token to sidecar:', persistErr);
+              }
+            }
+
             // Send success response
             res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end(`

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import open from 'open';
+import { loadTokenSidecar, resolveRefreshToken } from './token-sidecar.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -31,9 +32,20 @@ process.on('unhandledRejection', (reason) => {
 
 const client_id = process.env.QUICKBOOKS_CLIENT_ID;
 const client_secret = process.env.QUICKBOOKS_CLIENT_SECRET;
-const refresh_token = process.env.QUICKBOOKS_REFRESH_TOKEN;
-const realm_id = process.env.QUICKBOOKS_REALM_ID;
 const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'sandbox';
+
+// A rotated refresh token may live in the sidecar file rather than the
+// host-supplied env var — see token-sidecar.ts for the chain-trust rule
+// that decides which one wins (#117).
+const tokenSidecar = loadTokenSidecar();
+const resolvedTokens = resolveRefreshToken(
+  process.env.QUICKBOOKS_REFRESH_TOKEN,
+  process.env.QUICKBOOKS_REALM_ID,
+  tokenSidecar
+);
+const refresh_token = resolvedTokens.refreshToken;
+const realm_id = resolvedTokens.realmId;
+const token_chain_root = resolvedTokens.chainRoot;
 // Fix for Issue #5: Use env var with underscore (QUICKBOOKS_REDIRECT_URI)
 const redirect_uri = process.env.QUICKBOOKS_REDIRECT_URI || 'http://localhost:8000/callback';
 
@@ -50,6 +62,7 @@ export class QuickbooksClient {
   private readonly clientId: string;
   private readonly clientSecret: string;
   private refreshToken?: string;
+  private tokenChainRoot?: string;
   private realmId?: string;
   private readonly environment: string;
   private accessToken?: string;
@@ -76,6 +89,7 @@ export class QuickbooksClient {
     clientId: string;
     clientSecret: string;
     refreshToken?: string;
+    tokenChainRoot?: string;
     realmId?: string;
     environment: string;
     redirectUri: string;
@@ -83,6 +97,7 @@ export class QuickbooksClient {
     this.clientId = config.clientId;
     this.clientSecret = config.clientSecret;
     this.refreshToken = config.refreshToken;
+    this.tokenChainRoot = config.tokenChainRoot;
     this.realmId = config.realmId;
     this.environment = config.environment;
     this.redirectUri = config.redirectUri;
@@ -495,4 +510,5 @@ export const quickbooksClient = new QuickbooksClient({
   realmId: realm_id,
   environment: environment,
   redirectUri: redirect_uri,
+  tokenChainRoot: token_chain_root,
 });

--- a/src/clients/token-sidecar.ts
+++ b/src/clients/token-sidecar.ts
@@ -48,7 +48,11 @@ export function getSidecarPath(): string {
 export function loadTokenSidecar(): TokenSidecar | null {
   try {
     const raw = fs.readFileSync(getSidecarPath(), 'utf-8');
-    return JSON.parse(raw) as TokenSidecar;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.refreshToken !== 'string' || typeof parsed?.descendedFrom !== 'string') {
+      return null;
+    }
+    return parsed as TokenSidecar;
   } catch (e: any) {
     if (e?.code === 'ENOENT') return null;
     console.error(`[qbo-client] Failed to read token sidecar, ignoring: ${e?.message ?? e}`);

--- a/src/clients/token-sidecar.ts
+++ b/src/clients/token-sidecar.ts
@@ -1,0 +1,36 @@
+export interface TokenSidecar {
+  refreshToken: string;
+  realmId?: string;
+  descendedFrom: string;
+  updatedAt: string;
+}
+
+export interface ResolvedTokens {
+  refreshToken: string | undefined;
+  realmId: string | undefined;
+  chainRoot: string | undefined;
+}
+
+// Implements the "descended from" chain-trust rule from the #117 design:
+// a sidecar is only trusted while its chain root still matches the token
+// the host config currently supplies. If an operator pastes a new token
+// into their host config (manual re-auth), the chain resets and the
+// configured value wins — a stale sidecar can never silently override that.
+export function resolveRefreshToken(
+  configuredToken: string | undefined,
+  configuredRealmId: string | undefined,
+  sidecar: TokenSidecar | null
+): ResolvedTokens {
+  if (sidecar && configuredToken && sidecar.descendedFrom === configuredToken) {
+    return {
+      refreshToken: sidecar.refreshToken,
+      realmId: sidecar.realmId ?? configuredRealmId,
+      chainRoot: sidecar.descendedFrom,
+    };
+  }
+  return {
+    refreshToken: configuredToken,
+    realmId: configuredRealmId,
+    chainRoot: configuredToken,
+  };
+}

--- a/src/clients/token-sidecar.ts
+++ b/src/clients/token-sidecar.ts
@@ -1,3 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export interface TokenSidecar {
   refreshToken: string;
   realmId?: string;
@@ -33,4 +39,64 @@ export function resolveRefreshToken(
     realmId: configuredRealmId,
     chainRoot: configuredToken,
   };
+}
+
+export function getSidecarPath(): string {
+  return process.env.QUICKBOOKS_TOKEN_STORE_PATH || path.join(__dirname, '..', '..', 'tokens.json');
+}
+
+export function loadTokenSidecar(): TokenSidecar | null {
+  try {
+    const raw = fs.readFileSync(getSidecarPath(), 'utf-8');
+    return JSON.parse(raw) as TokenSidecar;
+  } catch (e: any) {
+    if (e?.code === 'ENOENT') return null;
+    console.error(`[qbo-client] Failed to read token sidecar, ignoring: ${e?.message ?? e}`);
+    return null;
+  }
+}
+
+function isSymbolicLink(filePath: string): boolean {
+  try {
+    return fs.lstatSync(filePath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+// Atomic-write pattern mirrors QuickbooksClient.saveTokensToEnv (same
+// symlink/dangling-symlink handling, same rationale — see that method's
+// comments for why a persistent-volume-mounted symlink needs write-through
+// rather than rename).
+export function saveTokenSidecar(data: TokenSidecar): void {
+  const tokenPath = getSidecarPath();
+  fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+
+  const content = JSON.stringify(data, null, 2) + '\n';
+
+  if (isSymbolicLink(tokenPath)) {
+    let realPath: string;
+    try {
+      realPath = fs.realpathSync(tokenPath);
+    } catch (e: any) {
+      if (e?.code === 'ENOENT') {
+        const linkTarget = fs.readlinkSync(tokenPath);
+        realPath = path.isAbsolute(linkTarget)
+          ? linkTarget
+          : path.resolve(path.dirname(tokenPath), linkTarget);
+      } else {
+        throw e;
+      }
+    }
+    fs.writeFileSync(realPath, content, { mode: 0o600 });
+  } else {
+    const tmpPath = `${tokenPath}.tmp.${process.pid}`;
+    try {
+      fs.writeFileSync(tmpPath, content, { mode: 0o600 });
+      fs.renameSync(tmpPath, tokenPath);
+    } catch (err) {
+      try { fs.unlinkSync(tmpPath); } catch { /* best effort */ }
+      throw err;
+    }
+  }
 }

--- a/tests/unit/clients/quickbooks-client.auth.test.ts
+++ b/tests/unit/clients/quickbooks-client.auth.test.ts
@@ -87,15 +87,17 @@ jest.unstable_mockModule('http', () => ({
 }));
 
 const enoent = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+const writeFileSyncSpy = jest.fn<(p: string, data: string, options?: any) => void>();
 jest.unstable_mockModule('fs', () => ({
   default: {
     readFileSync: jest.fn(() => {
       throw enoent();
     }),
     existsSync: jest.fn(() => false),
-    writeFileSync: jest.fn(),
+    writeFileSync: writeFileSyncSpy,
     renameSync: jest.fn(),
     unlinkSync: jest.fn(),
+    mkdirSync: jest.fn(),
   },
 }));
 
@@ -163,5 +165,13 @@ describe('QuickbooksClient.authenticate', () => {
     // The flow's new refresh token was then exchanged for an access token.
     expect(refreshDispatch).toHaveBeenLastCalledWith('flow-refresh-token');
     expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+
+    // The first-run OAuth completion also seeds the sidecar so the very
+    // next rotation has a chain root to compare against.
+    const sidecarCall = writeFileSyncSpy.mock.calls.find(([p]) => String(p).includes('tokens.json.tmp.'));
+    expect(sidecarCall).toBeDefined();
+    const sidecarContent = JSON.parse(sidecarCall![1] as string);
+    expect(sidecarContent.refreshToken).toBe('flow-refresh-token');
+    expect(sidecarContent.descendedFrom).toBe('flow-refresh-token');
   }, 15000);
 });

--- a/tests/unit/clients/quickbooks-client.sidecar-startup.test.ts
+++ b/tests/unit/clients/quickbooks-client.sidecar-startup.test.ts
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+
+process.env.QUICKBOOKS_CLIENT_ID = 'test-client-id';
+process.env.QUICKBOOKS_CLIENT_SECRET = 'test-client-secret';
+process.env.QUICKBOOKS_REFRESH_TOKEN = 'host-token';
+process.env.QUICKBOOKS_REALM_ID = '12345';
+process.env.QUICKBOOKS_ENVIRONMENT = 'sandbox';
+process.env.QUICKBOOKS_REDIRECT_URI = 'http://localhost:8000/callback';
+
+const sidecarContent = JSON.stringify({
+  refreshToken: 'rotated-from-sidecar',
+  realmId: '99999',
+  descendedFrom: 'host-token',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+});
+
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => sidecarContent),
+    existsSync: jest.fn(() => true),
+    writeFileSync: jest.fn(),
+    renameSync: jest.fn(),
+    unlinkSync: jest.fn(),
+    mkdirSync: jest.fn(),
+    lstatSync: jest.fn(() => ({ isSymbolicLink: () => false })),
+  },
+}));
+
+jest.unstable_mockModule('intuit-oauth', () => {
+  class MockOAuthClient {
+    static scopes = { Accounting: 'com.intuit.quickbooks.accounting' };
+    refreshUsingToken = jest.fn();
+    createToken = jest.fn();
+    authorizeUri = jest.fn(() => 'https://mock');
+    constructor(_cfg: Record<string, unknown>) {}
+  }
+  return { default: MockOAuthClient };
+});
+
+jest.unstable_mockModule('node-quickbooks', () => ({
+  default: class MockQuickBooks { constructor(..._args: unknown[]) {} },
+}));
+
+jest.unstable_mockModule('open', () => ({ default: jest.fn(async () => undefined) }));
+
+jest.unstable_mockModule('http', () => ({
+  default: { createServer: jest.fn(() => ({ listen: jest.fn(), close: jest.fn(), on: jest.fn(), address: jest.fn() })) },
+}));
+
+const { quickbooksClient } = await import('../../../src/clients/quickbooks-client');
+
+describe('QuickbooksClient startup sidecar resolution', () => {
+  it('uses the trusted sidecar refresh token instead of the raw configured env value', () => {
+    expect((quickbooksClient as unknown as { refreshToken?: string }).refreshToken).toBe('rotated-from-sidecar');
+  });
+
+  it('uses the sidecar realmId when the chain is trusted', () => {
+    expect((quickbooksClient as unknown as { realmId?: string }).realmId).toBe('99999');
+  });
+
+  it('sets tokenChainRoot to the descendedFrom value from the trusted sidecar', () => {
+    expect((quickbooksClient as unknown as { tokenChainRoot?: string }).tokenChainRoot).toBe('host-token');
+  });
+});

--- a/tests/unit/clients/save-tokens-to-env.test.ts
+++ b/tests/unit/clients/save-tokens-to-env.test.ts
@@ -49,6 +49,7 @@ jest.unstable_mockModule('fs', () => ({
       return REAL_PATH;
     }),
     readlinkSync: jest.fn(() => readlinkTarget),
+    mkdirSync: jest.fn(),
   },
 }));
 
@@ -185,5 +186,37 @@ describe('saveTokensToEnv (via authenticate)', () => {
     // authenticate() catches saveTokensToEnv errors (line 336-338 in source)
     // and logs them; it should NOT throw.
     await expect(quickbooksClient.authenticate()).resolves.not.toThrow();
+  });
+
+  it('also persists the rotated token to the sidecar file with an unchanged chain root', async () => {
+    lstatBehavior = 'regular';
+
+    await quickbooksClient.authenticate();
+
+    const sidecarCall = writeFileSyncSpy.mock.calls.find(([p]) => String(p).includes('tokens.json.tmp.'));
+    expect(sidecarCall).toBeDefined();
+    const [, content] = sidecarCall!;
+    const parsed = JSON.parse(content as string);
+    expect(parsed.refreshToken).toBe(`rotated-${tokenCounter}`);
+    expect(parsed.descendedFrom).toBe('initial-token');
+  });
+
+  it('keeps descendedFrom unchanged across two successive rotations', async () => {
+    lstatBehavior = 'regular';
+
+    await quickbooksClient.authenticate();
+    (quickbooksClient as any).accessTokenExpiry = new Date(0);
+    (quickbooksClient as any).authInFlight = undefined;
+    tokenCounter++;
+    refreshDispatch.mockResolvedValue({
+      token: { access_token: `access-${tokenCounter}`, expires_in: 3600, refresh_token: `rotated-${tokenCounter}` },
+    });
+    await quickbooksClient.authenticate();
+
+    const sidecarCalls = writeFileSyncSpy.mock.calls.filter(([p]) => String(p).includes('tokens.json.tmp.'));
+    const lastCall = sidecarCalls[sidecarCalls.length - 1];
+    const parsed = JSON.parse(lastCall[1] as string);
+    expect(parsed.refreshToken).toBe(`rotated-${tokenCounter}`);
+    expect(parsed.descendedFrom).toBe('initial-token');
   });
 });

--- a/tests/unit/clients/token-sidecar-io.test.ts
+++ b/tests/unit/clients/token-sidecar-io.test.ts
@@ -9,6 +9,7 @@ let readlinkTarget = '/fresh-pvc/tokens.json';
 const writeFileSyncSpy = jest.fn<(p: string, data: string, options?: any) => void>();
 const renameSyncSpy = jest.fn<(o: string, n: string) => void>();
 const mkdirSyncSpy = jest.fn<(p: string, options?: any) => void>();
+const unlinkSyncSpy = jest.fn<(p: string) => void>();
 let consoleErrorSpy: ReturnType<typeof jest.spyOn>;
 
 jest.unstable_mockModule('fs', () => ({
@@ -21,7 +22,7 @@ jest.unstable_mockModule('fs', () => ({
     }),
     writeFileSync: writeFileSyncSpy,
     renameSync: renameSyncSpy,
-    unlinkSync: jest.fn(),
+    unlinkSync: unlinkSyncSpy,
     mkdirSync: mkdirSyncSpy,
     lstatSync: jest.fn(() => {
       if (lstatBehavior === 'throws') throw new Error('EACCES');
@@ -75,6 +76,7 @@ describe('saveTokenSidecar', () => {
     writeFileSyncSpy.mockClear();
     renameSyncSpy.mockClear();
     mkdirSyncSpy.mockClear();
+    unlinkSyncSpy.mockClear();
     lstatBehavior = 'regular';
     realpathBehavior = 'ok';
     readlinkTarget = '/fresh-pvc/tokens.json';
@@ -119,5 +121,27 @@ describe('saveTokenSidecar', () => {
       expect.any(String),
       expect.objectContaining({ mode: 0o600 }),
     );
+  });
+
+  it('resolves a RELATIVE dangling-symlink target against the link directory', () => {
+    lstatBehavior = 'symlink';
+    realpathBehavior = 'enoent';
+    readlinkTarget = '../vol/tokens.json';
+    saveTokenSidecar(data);
+    expect(renameSyncSpy).not.toHaveBeenCalled();
+    const writtenPath = writeFileSyncSpy.mock.calls[0][0] as string;
+    expect(writtenPath).not.toBe('../vol/tokens.json');
+    expect(writtenPath.startsWith('/')).toBe(true);
+    expect(writtenPath.endsWith('/vol/tokens.json')).toBe(true);
+  });
+
+  it('cleans up the temp file and re-throws when the write fails', () => {
+    const writeErr = new Error('ENOSPC');
+    writeFileSyncSpy.mockImplementationOnce(() => {
+      throw writeErr;
+    });
+    expect(() => saveTokenSidecar(data)).toThrow(writeErr);
+    expect(unlinkSyncSpy).toHaveBeenCalledWith(expect.stringContaining('tokens.json.tmp.'));
+    expect(renameSyncSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/clients/token-sidecar-io.test.ts
+++ b/tests/unit/clients/token-sidecar-io.test.ts
@@ -9,7 +9,7 @@ let readlinkTarget = '/fresh-pvc/tokens.json';
 const writeFileSyncSpy = jest.fn<(p: string, data: string, options?: any) => void>();
 const renameSyncSpy = jest.fn<(o: string, n: string) => void>();
 const mkdirSyncSpy = jest.fn<(p: string, options?: any) => void>();
-const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+let consoleErrorSpy: ReturnType<typeof jest.spyOn>;
 
 jest.unstable_mockModule('fs', () => ({
   default: {
@@ -40,7 +40,7 @@ const { loadTokenSidecar, saveTokenSidecar } = await import('../../../src/client
 describe('loadTokenSidecar', () => {
   beforeEach(() => {
     readFileBehavior = 'ok';
-    consoleErrorSpy.mockClear();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   it('returns null silently when the file does not exist', () => {

--- a/tests/unit/clients/token-sidecar-io.test.ts
+++ b/tests/unit/clients/token-sidecar-io.test.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 
 let lstatBehavior: 'regular' | 'symlink' | 'throws' = 'regular';
 let realpathBehavior: 'ok' | 'enoent' = 'ok';
-let readFileBehavior: 'ok' | 'enoent' | 'corrupt' | 'eacces' = 'ok';
+let readFileBehavior: 'ok' | 'enoent' | 'corrupt' | 'eacces' | 'wrong-shape' | 'no-message' = 'ok';
 const REAL_PATH = '/persistent-volume/tokens.json';
 let readlinkTarget = '/fresh-pvc/tokens.json';
 
@@ -17,7 +17,9 @@ jest.unstable_mockModule('fs', () => ({
     readFileSync: jest.fn(() => {
       if (readFileBehavior === 'enoent') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       if (readFileBehavior === 'eacces') throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      if (readFileBehavior === 'no-message') throw {};
       if (readFileBehavior === 'corrupt') return '{ not valid json';
+      if (readFileBehavior === 'wrong-shape') return JSON.stringify({ foo: 'bar' });
       return JSON.stringify({ refreshToken: 'stored-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' });
     }),
     writeFileSync: writeFileSyncSpy,
@@ -64,6 +66,18 @@ describe('loadTokenSidecar', () => {
 
   it('returns null and logs a warning on a permission error', () => {
     readFileBehavior = 'eacces';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read token sidecar'));
+  });
+
+  it('returns null for validly-parsed JSON with the wrong shape', () => {
+    readFileBehavior = 'wrong-shape';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the raw error value when it has no message', () => {
+    readFileBehavior = 'no-message';
     expect(loadTokenSidecar()).toBeNull();
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read token sidecar'));
   });

--- a/tests/unit/clients/token-sidecar-io.test.ts
+++ b/tests/unit/clients/token-sidecar-io.test.ts
@@ -1,0 +1,123 @@
+import { jest } from '@jest/globals';
+
+let lstatBehavior: 'regular' | 'symlink' | 'throws' = 'regular';
+let realpathBehavior: 'ok' | 'enoent' = 'ok';
+let readFileBehavior: 'ok' | 'enoent' | 'corrupt' | 'eacces' = 'ok';
+const REAL_PATH = '/persistent-volume/tokens.json';
+let readlinkTarget = '/fresh-pvc/tokens.json';
+
+const writeFileSyncSpy = jest.fn<(p: string, data: string, options?: any) => void>();
+const renameSyncSpy = jest.fn<(o: string, n: string) => void>();
+const mkdirSyncSpy = jest.fn<(p: string, options?: any) => void>();
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    readFileSync: jest.fn(() => {
+      if (readFileBehavior === 'enoent') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      if (readFileBehavior === 'eacces') throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      if (readFileBehavior === 'corrupt') return '{ not valid json';
+      return JSON.stringify({ refreshToken: 'stored-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' });
+    }),
+    writeFileSync: writeFileSyncSpy,
+    renameSync: renameSyncSpy,
+    unlinkSync: jest.fn(),
+    mkdirSync: mkdirSyncSpy,
+    lstatSync: jest.fn(() => {
+      if (lstatBehavior === 'throws') throw new Error('EACCES');
+      return { isSymbolicLink: () => lstatBehavior === 'symlink' };
+    }),
+    realpathSync: jest.fn(() => {
+      if (realpathBehavior === 'enoent') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return REAL_PATH;
+    }),
+    readlinkSync: jest.fn(() => readlinkTarget),
+  },
+}));
+
+const { loadTokenSidecar, saveTokenSidecar } = await import('../../../src/clients/token-sidecar');
+
+describe('loadTokenSidecar', () => {
+  beforeEach(() => {
+    readFileBehavior = 'ok';
+    consoleErrorSpy.mockClear();
+  });
+
+  it('returns null silently when the file does not exist', () => {
+    readFileBehavior = 'enoent';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the parsed sidecar when the file is valid JSON', () => {
+    expect(loadTokenSidecar()).toEqual({
+      refreshToken: 'stored-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z',
+    });
+  });
+
+  it('returns null and logs a warning on corrupt JSON', () => {
+    readFileBehavior = 'corrupt';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read token sidecar'));
+  });
+
+  it('returns null and logs a warning on a permission error', () => {
+    readFileBehavior = 'eacces';
+    expect(loadTokenSidecar()).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read token sidecar'));
+  });
+});
+
+describe('saveTokenSidecar', () => {
+  const data = { refreshToken: 'new-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+
+  beforeEach(() => {
+    writeFileSyncSpy.mockClear();
+    renameSyncSpy.mockClear();
+    mkdirSyncSpy.mockClear();
+    lstatBehavior = 'regular';
+    realpathBehavior = 'ok';
+    readlinkTarget = '/fresh-pvc/tokens.json';
+  });
+
+  it('creates the parent directory before writing', () => {
+    saveTokenSidecar(data);
+    expect(mkdirSyncSpy).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+  });
+
+  it('uses atomic temp+rename for a regular file', () => {
+    saveTokenSidecar(data);
+    expect(renameSyncSpy).toHaveBeenCalled();
+    const [tmpPath, destPath] = renameSyncSpy.mock.calls[0];
+    expect(tmpPath).toContain('tokens.json.tmp.');
+    expect(destPath).toContain('tokens.json');
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      expect.stringContaining('tokens.json.tmp.'),
+      expect.stringContaining('"refreshToken": "new-token"'),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+
+  it('writes through a symlink target via realpathSync (no rename)', () => {
+    lstatBehavior = 'symlink';
+    saveTokenSidecar(data);
+    expect(renameSyncSpy).not.toHaveBeenCalled();
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      REAL_PATH,
+      expect.stringContaining('"refreshToken": "new-token"'),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+
+  it('resolves a dangling symlink via readlinkSync fallback', () => {
+    lstatBehavior = 'symlink';
+    realpathBehavior = 'enoent';
+    readlinkTarget = '/fresh-pvc/tokens.json';
+    saveTokenSidecar(data);
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      '/fresh-pvc/tokens.json',
+      expect.any(String),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+  });
+});

--- a/tests/unit/clients/token-sidecar-io.test.ts
+++ b/tests/unit/clients/token-sidecar-io.test.ts
@@ -82,6 +82,10 @@ describe('saveTokenSidecar', () => {
     readlinkTarget = '/fresh-pvc/tokens.json';
   });
 
+  afterEach(() => {
+    delete process.env.QUICKBOOKS_TOKEN_STORE_PATH;
+  });
+
   it('creates the parent directory before writing', () => {
     saveTokenSidecar(data);
     expect(mkdirSyncSpy).toHaveBeenCalledWith(expect.any(String), { recursive: true });
@@ -143,5 +147,15 @@ describe('saveTokenSidecar', () => {
     expect(() => saveTokenSidecar(data)).toThrow(writeErr);
     expect(unlinkSyncSpy).toHaveBeenCalledWith(expect.stringContaining('tokens.json.tmp.'));
     expect(renameSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('honors QUICKBOOKS_TOKEN_STORE_PATH for both the parent dir and the write target', () => {
+    process.env.QUICKBOOKS_TOKEN_STORE_PATH = '/vol/tokens.json';
+    saveTokenSidecar(data);
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/vol', { recursive: true });
+    expect(renameSyncSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/vol/tokens.json.tmp.'),
+      '/vol/tokens.json',
+    );
   });
 });

--- a/tests/unit/clients/token-sidecar-resolve.test.ts
+++ b/tests/unit/clients/token-sidecar-resolve.test.ts
@@ -1,0 +1,37 @@
+import { resolveRefreshToken } from '../../../src/clients/token-sidecar';
+
+describe('resolveRefreshToken', () => {
+  it('uses the configured token when no sidecar exists', () => {
+    const result = resolveRefreshToken('host-token', '12345', null);
+    expect(result).toEqual({ refreshToken: 'host-token', realmId: '12345', chainRoot: 'host-token' });
+  });
+
+  it('trusts the sidecar when its chain root matches the configured token', () => {
+    const sidecar = { refreshToken: 'rotated-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken('host-token', '12345', sidecar);
+    expect(result).toEqual({ refreshToken: 'rotated-token', realmId: '99999', chainRoot: 'host-token' });
+  });
+
+  it('falls back to the sidecar realmId only when the sidecar itself omits one', () => {
+    const sidecar = { refreshToken: 'rotated-token', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken('host-token', '12345', sidecar);
+    expect(result.realmId).toBe('12345');
+  });
+
+  it('ignores a stale sidecar when the configured token has changed (manual re-auth)', () => {
+    const sidecar = { refreshToken: 'rotated-token', realmId: '99999', descendedFrom: 'old-host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken('new-host-token', '12345', sidecar);
+    expect(result).toEqual({ refreshToken: 'new-host-token', realmId: '12345', chainRoot: 'new-host-token' });
+  });
+
+  it('does not trust a sidecar when there is no configured token to compare against', () => {
+    const sidecar = { refreshToken: 'rotated-token', realmId: '99999', descendedFrom: 'host-token', updatedAt: '2026-08-01T00:00:00.000Z' };
+    const result = resolveRefreshToken(undefined, undefined, sidecar);
+    expect(result).toEqual({ refreshToken: undefined, realmId: undefined, chainRoot: undefined });
+  });
+
+  it('handles no configured token and no sidecar (fresh OAuth needed)', () => {
+    const result = resolveRefreshToken(undefined, undefined, null);
+    expect(result).toEqual({ refreshToken: undefined, realmId: undefined, chainRoot: undefined });
+  });
+});


### PR DESCRIPTION
## Summary

- Rotated OAuth refresh tokens are now also persisted to a `tokens.json` sidecar file, colocated with `.env` in the install root, in addition to the existing `.env` write.
- A "descended from" chain-trust rule (`resolveRefreshToken` in `src/clients/token-sidecar.ts`) means the sidecar is only trusted while its recorded chain root still matches the refresh token currently supplied via host config/`.env` — so a stale sidecar can never silently override an operator's manual re-auth.
- New `QUICKBOOKS_TOKEN_STORE_PATH` env var lets operators relocate the sidecar off the install root — the actual scenario this branch fixes is a **non-persistent or read-only install root** (some ephemeral-container setups), since this codebase's existing `dotenv.config({ override: true })` (predates this PR, commit 5c95064) already makes `.env` win over host env vars whenever the install root itself persists across restarts. README/CHANGELOG/design-doc wording was corrected during review to reflect this accurately rather than overclaiming a blanket Docker fix.
- All sidecar writes (rotation path and first-run OAuth path) are independently try/caught — a persistence failure can never fail `authenticate()`/`refreshAccessToken()`.
- Atomic writes (temp file + rename, mode `0600`) with the same symlink/dangling-symlink handling already used for `.env` (see #63).

## Test plan

- [x] `npm test` — 627/628 passing. The 1 failure is a pre-existing, unrelated test (`attachable-file-source.test.ts` › "denies files inside the MCP server's own directory") that reproduces identically on `main` outside any worktree — confirmed a worktree-path artifact, not caused by this branch.
- [x] New unit tests for chain-trust resolution, sidecar file I/O (atomic write, symlink/dangling-symlink write-through, corrupt/malformed-JSON handling, `QUICKBOOKS_TOKEN_STORE_PATH` override), startup resolution wiring, rotation persistence, and first-run OAuth persistence.
- [x] `token-sidecar.ts` reaches 100% statement/branch/function/line coverage.

Design spec: `docs/superpowers/specs/2026-08-08-token-sidecar-persistence-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-09-token-sidecar-persistence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)