### PR TITLE
fix: evaluate server-root denial before dot-segment rule in attachable file source

### DIFF
--- a/src/helpers/attachable-file-source.ts
+++ b/src/helpers/attachable-file-source.ts
@@ -104,6 +104,15 @@ function serverRootReal(): Promise<string> {
 }
 
 async function deniedReason(realPath: string): Promise<string | null> {
+  // Server-root check first: when the install tree itself lives under a
+  // dot-directory (e.g. a git worktree in .claude/worktrees/), every file in
+  // it would otherwise trip the dot-segment rule and mask this more specific
+  // reason.
+  const rootReal = await serverRootReal();
+  const rel = path.relative(normalizeForCompare(rootReal), normalizeForCompare(realPath));
+  if (!rel.startsWith("..") && !path.isAbsolute(rel)) {
+    return "files inside the MCP server's own directory are not attachable";
+  }
   const segments = realPath.split(path.sep);
   if (segments.some((s) => s.startsWith(".") && s !== "." && s !== "..")) {
     return "dotfiles and dot-directories are not attachable";
@@ -111,11 +120,6 @@ async function deniedReason(realPath: string): Promise<string | null> {
   const base = path.basename(realPath).toLowerCase();
   if (base.endsWith(".env") || DENIED_BASENAMES.has(base)) {
     return "credential files are not attachable";
-  }
-  const rootReal = await serverRootReal();
-  const rel = path.relative(normalizeForCompare(rootReal), normalizeForCompare(realPath));
-  if (!rel.startsWith("..") && !path.isAbsolute(rel)) {
-    return "files inside the MCP server's own directory are not attachable";
   }
   return null;
 }


### PR DESCRIPTION
## Problem

`deniedReason()` in `src/helpers/attachable-file-source.ts` checks the dot-segment rule before the server-root rule. When the server's install tree itself lives under a dot-directory (e.g. a git worktree checked out in `.claude/worktrees/...`), every file inside it trips the generic "dotfiles and dot-directories are not attachable" rule first, masking the more specific "files inside the MCP server's own directory" denial. This makes the unit test *denies files inside the MCP server's own directory* fail from such checkouts, and drops the server-root branch from coverage, breaking the 100% global threshold.

## Fix

Evaluate the server-root rule first. This changes only message priority — the exact same set of paths is denied. Files in the server's own tree now always get the specific (and more accurate) denial reason regardless of where the checkout lives, making both the test and the branch coverage deterministic. The dotfile and credential-file rules remain exercised by the existing tests, whose fixtures live in a dot-free temp directory outside the server root.

## Verification

- Full suite: 629 tests pass, 100% statements/branches/functions/lines on `attachable-file-source.ts`
- Verified from a checkout under `.claude/worktrees/...` that previously reproduced the failure
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)