### PR TITLE
Merge upstream/main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.6.0",
+                "@modelcontextprotocol/sdk": "^1.30.0",
                 "dotenv": "^16.4.7",
                 "intuit-oauth": "^4.0.0",
                 "node-quickbooks": "^2.0.43",
-                "open": "^9.1.0",
-                "zod": "^3.24.2"
+                "open": "^9.1.0"
             },
             "bin": {
                 "qbo-mcp-server": "dist/index.js"
@@ -32,7 +31,11 @@
                 "shx": "^0.3.4",
                 "ts-jest": "^29.4.6",
                 "typescript": "^5.8.2",
-                "typescript-eslint": "^8.26.1"
+                "typescript-eslint": "^8.26.1",
+                "zod": "4.3.6"
+            },
+            "peerDependencies": {
+                "zod": "^4.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -755,6 +758,18 @@
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@hono/node-server": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+            "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "hono": "^4"
             }
         },
         "node_modules/@humanfs/core": {
@@ -1882,26 +1897,66 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.0.tgz",
-            "integrity": "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+            "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+            "license": "MIT",
             "dependencies": {
-                "ajv": "^6.12.6",
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
                 "cors": "^2.8.5",
                 "cross-spawn": "^7.0.5",
                 "eventsource": "^3.0.2",
                 "eventsource-parser": "^3.0.0",
-                "express": "^5.0.1",
-                "express-rate-limit": "^7.5.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
-                "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.24.1"
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
             }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.12",
@@ -2680,6 +2735,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
             "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
             "dependencies": {
                 "mime-types": "^3.0.0",
                 "negotiator": "^1.0.0"
@@ -2723,6 +2779,45 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
             }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
         },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
@@ -2982,22 +3077,40 @@
             "integrity": "sha512-sCXkOlWh201V9KAs6lXtzbPQHmVhys/wC0I1vaCjZzZtiskEeNJljIRqirGJ+M+WOf/KL7P7KSpUaqaR6BCq7w=="
         },
         "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
-                "debug": "^4.4.0",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/bplist-parser": {
@@ -3120,6 +3233,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -3140,6 +3254,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "get-intrinsic": "^1.3.0"
@@ -3364,20 +3479,23 @@
             "dev": true
         },
         "node_modules/content-disposition": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-            "dependencies": {
-                "safe-buffer": "5.2.1"
-            },
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/content-type": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3393,6 +3511,7 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3401,6 +3520,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
             "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.6.0"
             }
@@ -3584,6 +3704,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -3649,7 +3770,8 @@
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.267",
@@ -3687,6 +3809,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -3755,7 +3878,8 @@
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -3949,6 +4073,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4023,17 +4148,19 @@
             }
         },
         "node_modules/express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
+                "body-parser": "^2.2.1",
                 "content-disposition": "^1.0.0",
                 "content-type": "^1.0.5",
                 "cookie": "^0.7.1",
                 "cookie-signature": "^1.2.1",
                 "debug": "^4.4.0",
+                "depd": "^2.0.0",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
@@ -4064,9 +4191,14 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+            "version": "8.6.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+            "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "ip-address": "^10.2.0"
+            },
             "engines": {
                 "node": ">= 16"
             },
@@ -4133,6 +4265,22 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-parser": {
             "version": "4.5.3",
@@ -4208,9 +4356,10 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
                 "encodeurl": "^2.0.0",
@@ -4220,7 +4369,11 @@
                 "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/find-up": {
@@ -4358,6 +4511,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4366,6 +4520,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
             "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4640,6 +4795,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hono": {
+            "version": "4.12.32",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+            "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4648,26 +4812,23 @@
             "license": "MIT"
         },
         "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/http-errors/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "engines": {
-                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/http-signature": {
@@ -4693,14 +4854,19 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ignore": {
@@ -4799,10 +4965,20 @@
                 "node": ">=10"
             }
         },
+        "node_modules/ip-address": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+            "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -4913,7 +5089,8 @@
         "node_modules/is-promise": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "3.0.0",
@@ -5852,6 +6029,15 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/jose": {
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+            "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5911,6 +6097,12 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -6165,17 +6357,23 @@
             }
         },
         "node_modules/media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/merge-descriptors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
             "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6214,19 +6412,25 @@
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/mimic-fn": {
@@ -6302,6 +6506,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
             "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -6398,6 +6603,7 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6409,6 +6615,7 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -6562,6 +6769,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -6623,9 +6831,10 @@
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
@@ -6798,6 +7007,7 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
             "dependencies": {
                 "forwarded": "0.2.0",
                 "ipaddr.js": "1.9.1"
@@ -6853,11 +7063,13 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -6921,40 +7133,31 @@
             }
         },
         "node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/raw-body": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-            "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.7.0",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/raw-body/node_modules/iconv-lite": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-            "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/react-is": {
@@ -7103,6 +7306,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/resolve": {
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -7174,6 +7386,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
             "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
                 "depd": "^2.0.0",
@@ -7353,30 +7566,36 @@
             }
         },
         "node_modules/send": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
             "dependencies": {
-                "debug": "^4.3.5",
+                "debug": "^4.4.3",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
                 "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "mime-types": "^3.0.1",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
                 "ms": "^2.1.3",
                 "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
-                "statuses": "^2.0.1"
+                "statuses": "^2.0.2"
             },
             "engines": {
                 "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
             "dependencies": {
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
@@ -7385,12 +7604,17 @@
             },
             "engines": {
                 "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -7445,13 +7669,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -7463,12 +7688,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7481,6 +7707,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7498,6 +7725,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -7622,6 +7850,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
             "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -7860,6 +8089,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.6"
             }
@@ -8030,16 +8260,34 @@
             }
         },
         "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "license": "MIT",
             "dependencies": {
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "media-typer": "^1.1.0",
                 "mime-types": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/typescript": {
@@ -8118,6 +8366,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8487,19 +8736,21 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "license": "ISC",
             "peerDependencies": {
-                "zod": "^3.24.1"
+                "zod": "^3.25.28 || ^4"
             }
         }
     },
@@ -9000,6 +9251,12 @@
                 "@eslint/core": "^0.16.0",
                 "levn": "^0.4.1"
             }
+        },
+        "@hono/node-server": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+            "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+            "requires": {}
         },
         "@humanfs/core": {
             "version": "0.19.1",
@@ -9819,22 +10076,45 @@
             }
         },
         "@modelcontextprotocol/sdk": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.0.tgz",
-            "integrity": "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+            "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
             "requires": {
-                "ajv": "^6.12.6",
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
                 "cors": "^2.8.5",
                 "cross-spawn": "^7.0.5",
                 "eventsource": "^3.0.2",
                 "eventsource-parser": "^3.0.0",
-                "express": "^5.0.1",
-                "express-rate-limit": "^7.5.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
-                "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.24.1"
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.20.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+                    "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.3",
+                        "fast-uri": "^3.0.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
             }
         },
         "@napi-rs/wasm-runtime": {
@@ -10373,6 +10653,32 @@
                 "uri-js": "^4.2.2"
             }
         },
+        "ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "requires": {
+                "ajv": "^8.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.20.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+                    "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.3",
+                        "fast-uri": "^3.0.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
+            }
+        },
         "ansi-escapes": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -10562,19 +10868,26 @@
             "integrity": "sha512-sCXkOlWh201V9KAs6lXtzbPQHmVhys/wC0I1vaCjZzZtiskEeNJljIRqirGJ+M+WOf/KL7P7KSpUaqaR6BCq7w=="
         },
         "body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "requires": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
-                "debug": "^4.4.0",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "dependencies": {
+                "content-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+                    "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+                }
             }
         },
         "bplist-parser": {
@@ -10820,12 +11133,9 @@
             "dev": true
         },
         "content-disposition": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-            "requires": {
-                "safe-buffer": "5.2.1"
-            }
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
         },
         "content-type": {
             "version": "1.0.5",
@@ -11265,17 +11575,18 @@
             }
         },
         "express": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "requires": {
                 "accepts": "^2.0.0",
-                "body-parser": "^2.2.0",
+                "body-parser": "^2.2.1",
                 "content-disposition": "^1.0.0",
                 "content-type": "^1.0.5",
                 "cookie": "^0.7.1",
                 "cookie-signature": "^1.2.1",
                 "debug": "^4.4.0",
+                "depd": "^2.0.0",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
@@ -11299,10 +11610,13 @@
             }
         },
         "express-rate-limit": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
-            "requires": {}
+            "version": "8.6.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+            "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+            "requires": {
+                "debug": "^4.4.3",
+                "ip-address": "^10.2.0"
+            }
         },
         "extend": {
             "version": "3.0.2",
@@ -11353,6 +11667,11 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "fast-uri": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
         },
         "fast-xml-parser": {
             "version": "4.5.3",
@@ -11409,9 +11728,9 @@
             "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
         },
         "finalhandler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
             "requires": {
                 "debug": "^4.4.0",
                 "encodeurl": "^2.0.0",
@@ -11692,6 +12011,11 @@
                 "function-bind": "^1.1.2"
             }
         },
+        "hono": {
+            "version": "4.12.32",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+            "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg=="
+        },
         "html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -11699,22 +12023,15 @@
             "dev": true
         },
         "http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "requires": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            },
-            "dependencies": {
-                "statuses": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-                    "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-                }
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             }
         },
         "http-signature": {
@@ -11733,9 +12050,9 @@
             "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="
         },
         "iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             }
@@ -11806,6 +12123,11 @@
                 "rsa-pem-from-mod-exp": "^0.8.4",
                 "winston": "^3.1.0"
             }
+        },
+        "ip-address": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+            "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -12546,6 +12868,11 @@
                 }
             }
         },
+        "jose": {
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+            "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA=="
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12593,6 +12920,11 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -12802,9 +13134,9 @@
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
         },
         "media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="
         },
         "merge-descriptors": {
             "version": "2.0.0",
@@ -12838,9 +13170,9 @@
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
         },
         "mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "requires": {
                 "mime-db": "^1.54.0"
             }
@@ -13118,9 +13450,9 @@
             }
         },
         "path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
         },
         "performance-now": {
             "version": "2.1.0",
@@ -13270,11 +13602,12 @@
             "dev": true
         },
         "qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "requires": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             }
         },
         "query-string": {
@@ -13305,29 +13638,19 @@
             "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ=="
         },
         "range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="
         },
         "raw-body": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-            "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
             "requires": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.7.0",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-                    "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3.0.0"
-                    }
-                }
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
             }
         },
         "react-is": {
@@ -13442,6 +13765,11 @@
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "resolve": {
             "version": "1.22.10",
@@ -13597,27 +13925,27 @@
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
         },
         "send": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
             "requires": {
-                "debug": "^4.3.5",
+                "debug": "^4.4.3",
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
                 "etag": "^1.8.1",
                 "fresh": "^2.0.0",
-                "http-errors": "^2.0.0",
-                "mime-types": "^3.0.1",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
                 "ms": "^2.1.3",
                 "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
-                "statuses": "^2.0.1"
+                "statuses": "^2.0.2"
             }
         },
         "serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
             "requires": {
                 "encodeurl": "^2.0.0",
                 "escape-html": "^1.0.3",
@@ -13665,24 +13993,24 @@
             }
         },
         "side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "requires": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             }
         },
         "side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "requires": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             }
         },
         "side-channel-map": {
@@ -14037,13 +14365,20 @@
             "dev": true
         },
         "type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "requires": {
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "media-typer": "^1.1.0",
                 "mime-types": "^3.0.0"
+            },
+            "dependencies": {
+                "content-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+                    "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+                }
             }
         },
         "typescript": {
@@ -14353,14 +14688,14 @@
             "dev": true
         },
         "zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
         },
         "zod-to-json-schema": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-            "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
             "requires": {}
         }
     }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
         "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.6.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "dotenv": "^16.4.7",
         "intuit-oauth": "^4.0.0",
         "node-quickbooks": "^2.0.43",
-        "open": "^9.1.0",
-        "zod": "^3.24.2"
+        "open": "^9.1.0"
+    },
+    "peerDependencies": {
+        "zod": "^4.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -41,6 +43,7 @@
         "shx": "^0.3.4",
         "ts-jest": "^29.4.6",
         "typescript": "^5.8.2",
-        "typescript-eslint": "^8.26.1"
+        "typescript-eslint": "^8.26.1",
+        "zod": "4.3.6"
     }
 }

--- a/src/clients/quickbooks-client.ts
+++ b/src/clients/quickbooks-client.ts
@@ -1,11 +1,12 @@
 import dotenv from "dotenv";
 import QuickBooks from "node-quickbooks";
 import OAuthClient from "intuit-oauth";
-import http from 'http';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import open from 'open';
+import { AsyncLocalStorage } from "node:async_hooks";
+import http from "http";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import open from "open";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -18,28 +19,48 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // placeholders a host app (e.g. Claude Desktop) may inject via its env config.
 // This prevents the server from starting with blank REFRESH_TOKEN / REALM_ID
 // even when the host config has those keys set to "".
-dotenv.config({ path: path.join(__dirname, '..', '..', '.env'), override: true });
+dotenv.config({
+  path: path.join(__dirname, "..", "..", ".env"),
+  override: true,
+});
 
 // Register once at module level — registering inside startOAuthFlow() would
 // accumulate duplicate handlers on every OAuth call.
-process.on('uncaughtException', (err) => {
-  console.error('[auth-server] uncaughtException:', err);
+process.on("uncaughtException", (err) => {
+  console.error("[auth-server] uncaughtException:", err);
 });
-process.on('unhandledRejection', (reason) => {
-  console.error('[auth-server] unhandledRejection:', reason);
+process.on("unhandledRejection", (reason) => {
+  console.error("[auth-server] unhandledRejection:", reason);
 });
 
 const client_id = process.env.QUICKBOOKS_CLIENT_ID;
 const client_secret = process.env.QUICKBOOKS_CLIENT_SECRET;
 const refresh_token = process.env.QUICKBOOKS_REFRESH_TOKEN;
 const realm_id = process.env.QUICKBOOKS_REALM_ID;
-const environment = process.env.QUICKBOOKS_ENVIRONMENT || 'sandbox';
+const environment = process.env.QUICKBOOKS_ENVIRONMENT || "sandbox";
 // Fix for Issue #5: Use env var with underscore (QUICKBOOKS_REDIRECT_URI)
-const redirect_uri = process.env.QUICKBOOKS_REDIRECT_URI || 'http://localhost:8000/callback';
+const redirect_uri =
+  process.env.QUICKBOOKS_REDIRECT_URI || "http://localhost:8000/callback";
 
-// Only throw error if client_id or client_secret is missing
-if (!client_id || !client_secret || !redirect_uri) {
-  throw Error("Client ID, Client Secret and Redirect URI must be set in environment variables");
+export type InjectedQuickbooksContext = {
+  quickbooks: QuickBooks;
+  accessToken: string;
+  realmId: string;
+  isSandbox: boolean;
+};
+
+const injectedQuickbooksContextStorage =
+  new AsyncLocalStorage<InjectedQuickbooksContext>();
+
+export function runWithQuickbooksContext<T>(
+  context: InjectedQuickbooksContext,
+  fn: () => Promise<T> | T,
+): Promise<T> | T {
+  return injectedQuickbooksContextStorage.run(context, fn);
+}
+
+function getInjectedQuickbooksContext(): InjectedQuickbooksContext | undefined {
+  return injectedQuickbooksContextStorage.getStore();
 }
 
 // ── QuickbooksClient ─────────────────────────────────────────────────────────
@@ -65,7 +86,10 @@ export class QuickbooksClient {
   // Shared in-flight refresh promise so that concurrent callers all await the
   // same network request rather than racing to use (and rotate) the refresh
   // token simultaneously.
-  private refreshInFlight?: Promise<{ access_token: string; expires_in: number }>;
+  private refreshInFlight?: Promise<{
+    access_token: string;
+    expires_in: number;
+  }>;
 
   // Shared in-flight authenticate promise. Guards the cold-start path so two
   // concurrent first callers cannot both pass the freshness check and both
@@ -96,10 +120,15 @@ export class QuickbooksClient {
 
   private isTokenExpiredOrExpiringSoon(): boolean {
     if (!this.accessToken || !this.accessTokenExpiry) return true;
-    return this.accessTokenExpiry <= new Date(Date.now() + QuickbooksClient.TOKEN_REFRESH_BUFFER_MS);
+    return (
+      this.accessTokenExpiry <=
+      new Date(Date.now() + QuickbooksClient.TOKEN_REFRESH_BUFFER_MS)
+    );
   }
 
   private async startOAuthFlow(): Promise<void> {
+    assertOAuthConfig();
+
     if (this.isAuthenticating) {
       return;
     }
@@ -126,9 +155,11 @@ export class QuickbooksClient {
 
         // Respond to anything that isn't /callback so diagnostic probes (curl,
         // ngrok health checks, favicon requests, etc.) don't hang the server.
-        if (!req.url?.startsWith('/callback')) {
-          res.writeHead(404, { 'Content-Type': 'text/plain' });
-          res.end('Not Found. Waiting for QuickBooks OAuth callback at /callback');
+        if (!req.url?.startsWith("/callback")) {
+          res.writeHead(404, { "Content-Type": "text/plain" });
+          res.end(
+            "Not Found. Waiting for QuickBooks OAuth callback at /callback",
+          );
           return;
         }
 
@@ -143,7 +174,7 @@ export class QuickbooksClient {
             this.saveTokensToEnv();
 
             // Send success response
-            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.writeHead(200, { "Content-Type": "text/html" });
             res.end(`
               <html>
                 <body style="
@@ -169,8 +200,8 @@ export class QuickbooksClient {
               resolve();
             }, 1000);
           } catch (error) {
-            console.error('Error during token creation:', error);
-            res.writeHead(500, { 'Content-Type': 'text/html' });
+            console.error("Error during token creation:", error);
+            res.writeHead(500, { "Content-Type": "text/html" });
             res.end(`
               <html>
                 <body style="
@@ -196,20 +227,24 @@ export class QuickbooksClient {
 
       // Start server — bind to all interfaces (IPv4 + IPv6) so ngrok can reach it
       // regardless of whether it resolves `localhost` to 127.0.0.1 or ::1
-      server.listen(port, '::', async () => {
+      server.listen(port, "::", async () => {
         const addr = server.address();
-        console.log(`[auth-server] Listening on ${typeof addr === 'string' ? addr : `${addr?.address}:${addr?.port}`} (family: ${typeof addr === 'object' ? addr?.family : 'n/a'})`);
+        console.log(
+          `[auth-server] Listening on ${typeof addr === "string" ? addr : `${addr?.address}:${addr?.port}`} (family: ${typeof addr === "object" ? addr?.family : "n/a"})`,
+        );
 
         // Generate authorization URL with proper type assertion
-        const authUri = flowClient.authorizeUri({
-          scope: [OAuthClient.scopes.Accounting as string],
-          state: 'testState'
-        }).toString();
+        const authUri = flowClient
+          .authorizeUri({
+            scope: [OAuthClient.scopes.Accounting as string],
+            state: "testState",
+          })
+          .toString();
 
-        console.log('\n=== QuickBooks Authorization ===');
-        console.log('Open this URL in a browser to authorize:\n');
+        console.log("\n=== QuickBooks Authorization ===");
+        console.log("Open this URL in a browser to authorize:\n");
         console.log(authUri);
-        console.log('\nWaiting for callback...\n');
+        console.log("\nWaiting for callback...\n");
 
         // Attempt to open the browser automatically; ignore failures on headless systems
         try {
@@ -220,8 +255,8 @@ export class QuickbooksClient {
       });
 
       // Handle server errors
-      server.on('error', (error) => {
-        console.error('Server error:', error);
+      server.on("error", (error) => {
+        console.error("Server error:", error);
         this.isAuthenticating = false;
         reject(error);
       });
@@ -229,12 +264,14 @@ export class QuickbooksClient {
   }
 
   private saveTokensToEnv(): void {
-    const tokenPath = path.join(__dirname, '..', '..', '.env');
-    const envContent = fs.existsSync(tokenPath) ? fs.readFileSync(tokenPath, 'utf-8') : '';
-    const envLines = envContent.split('\n');
+    const tokenPath = path.join(__dirname, "..", "..", ".env");
+    const envContent = fs.existsSync(tokenPath)
+      ? fs.readFileSync(tokenPath, "utf-8")
+      : "";
+    const envLines = envContent.split("\n");
 
     const updateEnvVar = (name: string, value: string) => {
-      const index = envLines.findIndex(line => line.startsWith(`${name}=`));
+      const index = envLines.findIndex((line) => line.startsWith(`${name}=`));
       if (index !== -1) {
         envLines[index] = `${name}=${value}`;
       } else {
@@ -242,29 +279,36 @@ export class QuickbooksClient {
       }
     };
 
-    if (this.refreshToken) updateEnvVar('QUICKBOOKS_REFRESH_TOKEN', this.refreshToken);
-    if (this.realmId) updateEnvVar('QUICKBOOKS_REALM_ID', this.realmId);
+    if (this.refreshToken)
+      updateEnvVar("QUICKBOOKS_REFRESH_TOKEN", this.refreshToken);
+    if (this.realmId) updateEnvVar("QUICKBOOKS_REALM_ID", this.realmId);
 
     // Atomic write: write to a sibling temp file, then rename. On POSIX rename
     // is atomic within the same filesystem, so a crash mid-write cannot leave
     // .env half-written or empty.
     const tmpPath = `${tokenPath}.tmp.${process.pid}`;
     try {
-      fs.writeFileSync(tmpPath, envLines.join('\n'), { mode: 0o600 });
+      fs.writeFileSync(tmpPath, envLines.join("\n"), { mode: 0o600 });
       fs.renameSync(tmpPath, tokenPath);
     } catch (err) {
-      try { fs.unlinkSync(tmpPath); } catch { /* best effort */ }
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch {
+        /* best effort */
+      }
       throw err;
     }
   }
 
   async refreshAccessToken() {
+    assertOAuthConfig();
+
     if (!this.refreshToken) {
       await this.startOAuthFlow();
 
       // Verify we have a refresh token after OAuth flow
       if (!this.refreshToken) {
-        throw new Error('Failed to obtain refresh token from OAuth flow');
+        throw new Error("Failed to obtain refresh token from OAuth flow");
       }
     }
 
@@ -275,7 +319,9 @@ export class QuickbooksClient {
     this.refreshInFlight = (async () => {
       try {
         // At this point we know refreshToken is not undefined
-        const authResponse = await this.oauthClient.refreshUsingToken(this.refreshToken!);
+        const authResponse = await this.oauthClient.refreshUsingToken(
+          this.refreshToken!,
+        );
 
         // The intuit-oauth type declarations are incomplete — the runtime
         // token object also contains refresh_token, x_refresh_token_expires_in,
@@ -300,20 +346,30 @@ export class QuickbooksClient {
           this.refreshToken = newRefreshToken;
           try {
             this.saveTokensToEnv();
-            console.error('[qbo-client] Refresh token rotated and persisted to .env');
+            console.error(
+              "[qbo-client] Refresh token rotated and persisted to .env",
+            );
           } catch (persistErr) {
             // Don't fail the whole refresh just because we couldn't write to
             // disk; the in-memory token is still valid for this process.
-            console.error('[qbo-client] Failed to persist rotated refresh token:', persistErr);
+            console.error(
+              "[qbo-client] Failed to persist rotated refresh token:",
+              persistErr,
+            );
           }
         }
 
         // Surface the refresh token's own remaining lifetime for observability.
         // Intuit's refresh tokens last 100 days; warn when under 14 days.
         const refreshExpiresIn = token.x_refresh_token_expires_in;
-        if (typeof refreshExpiresIn === 'number' && refreshExpiresIn < 14 * 24 * 3600) {
+        if (
+          typeof refreshExpiresIn === "number" &&
+          refreshExpiresIn < 14 * 24 * 3600
+        ) {
           const days = Math.round(refreshExpiresIn / 86400);
-          console.error(`[qbo-client] WARNING: refresh token expires in ~${days} day(s). Re-run \`npm run auth\` before it expires.`);
+          console.error(
+            `[qbo-client] WARNING: refresh token expires in ~${days} day(s). Re-run \`npm run auth\` before it expires.`,
+          );
         }
 
         return {
@@ -332,6 +388,8 @@ export class QuickbooksClient {
   }
 
   async authenticate(): Promise<QuickBooks> {
+    assertOAuthConfig();
+
     if (this.authInFlight) {
       return this.authInFlight;
     }
@@ -343,7 +401,7 @@ export class QuickbooksClient {
 
           // Verify we have both tokens after OAuth flow
           if (!this.refreshToken || !this.realmId) {
-            throw new Error('Failed to obtain required tokens from OAuth flow');
+            throw new Error("Failed to obtain required tokens from OAuth flow");
           }
         }
 
@@ -355,8 +413,11 @@ export class QuickbooksClient {
             // A dead refresh token (rotated by another consumer, past the
             // 100-day window, or revoked) is recoverable: fall back to the
             // interactive OAuth flow instead of failing hard.
-            const message = error instanceof Error ? error.message : String(error);
-            console.error(`[qbo-client] Token refresh failed (${message}); falling back to interactive OAuth`);
+            const message =
+              error instanceof Error ? error.message : String(error);
+            console.error(
+              `[qbo-client] Token refresh failed (${message}); falling back to interactive OAuth`,
+            );
             this.refreshToken = undefined;
             this.accessToken = undefined;
             this.accessTokenExpiry = undefined;
@@ -373,11 +434,11 @@ export class QuickbooksClient {
           this.accessToken!,
           false, // no token secret for OAuth 2.0
           this.realmId!,
-          this.environment === 'sandbox',
+          this.environment === "sandbox",
           false, // debug?
-          null,  // minor version
-          '2.0', // oauth version
-          this.refreshToken
+          null, // minor version
+          "2.0", // oauth version
+          this.refreshToken,
         );
 
         return this.quickbooksInstance;
@@ -393,6 +454,11 @@ export class QuickbooksClient {
   // Checks token freshness on each invocation so handlers stay functional
   // across 60-minute token boundaries without server restarts.
   static async getInstance(): Promise<QuickBooks> {
+    const injectedContext = getInjectedQuickbooksContext();
+    if (injectedContext) {
+      return injectedContext.quickbooks;
+    }
+
     if (quickbooksClient.isTokenExpiredOrExpiringSoon()) {
       await quickbooksClient.authenticate();
     }
@@ -406,33 +472,59 @@ export class QuickbooksClient {
   // handlers that need to call QBO endpoints not wrapped by node-quickbooks
   // (e.g. POST /upload for binary attachments). Ensures token freshness on
   // every invocation, same as getInstance().
-  static async getAuthCredentials(): Promise<{ accessToken: string; realmId: string; isSandbox: boolean }> {
-    if (quickbooksClient.isTokenExpiredOrExpiringSoon() || !quickbooksClient.accessToken) {
+  static async getAuthCredentials(): Promise<{
+    accessToken: string;
+    realmId: string;
+    isSandbox: boolean;
+  }> {
+    const injectedContext = getInjectedQuickbooksContext();
+    if (injectedContext) {
+      return {
+        accessToken: injectedContext.accessToken,
+        realmId: injectedContext.realmId,
+        isSandbox: injectedContext.isSandbox,
+      };
+    }
+
+    if (
+      quickbooksClient.isTokenExpiredOrExpiringSoon() ||
+      !quickbooksClient.accessToken
+    ) {
       await quickbooksClient.authenticate();
     }
     if (!quickbooksClient.accessToken || !quickbooksClient.realmId) {
-      throw new Error('Quickbooks not authenticated');
+      throw new Error("Quickbooks not authenticated");
     }
     return {
       accessToken: quickbooksClient.accessToken,
       realmId: quickbooksClient.realmId,
-      isSandbox: quickbooksClient.environment === 'sandbox',
+      isSandbox: quickbooksClient.environment === "sandbox",
     };
   }
 
   getQuickbooks() {
     if (!this.quickbooksInstance) {
-      throw new Error('Quickbooks not authenticated. Call authenticate() first');
+      throw new Error(
+        "Quickbooks not authenticated. Call authenticate() first",
+      );
     }
     return this.quickbooksInstance;
   }
 }
 
 export const quickbooksClient = new QuickbooksClient({
-  clientId: client_id,
-  clientSecret: client_secret,
+  clientId: client_id ?? "injected-auth-client-id",
+  clientSecret: client_secret ?? "injected-auth-client-secret",
   refreshToken: refresh_token,
   realmId: realm_id,
   environment: environment,
   redirectUri: redirect_uri,
 });
+
+function assertOAuthConfig(): void {
+  if (!client_id || !client_secret || !redirect_uri) {
+    throw Error(
+      "Client ID, Client Secret and Redirect URI must be set in environment variables",
+    );
+  }
+}

--- a/src/helpers/register-tool.ts
+++ b/src/helpers/register-tool.ts
@@ -64,7 +64,7 @@ export function isToolDisabled(toolName: string): boolean {
  * Tools are categorized by their name prefix (e.g. create_, update_, delete_).
  * The corresponding environment variable (e.g. QUICKBOOKS_DISABLE_WRITE) determines if the tool is registered.
  */
-export function RegisterTool<T extends z.ZodType<any, any>>(
+export function RegisterTool<T extends z.ZodType>(
   server: McpServer,
   toolDefinition: ToolDefinition<T>
 ) {

--- a/src/tools/create-account.tool.ts
+++ b/src/tools/create-account.tool.ts
@@ -8,7 +8,7 @@ const toolDescription =
   "To create a sub‑account (nested under a parent), pass parent_id with the " +
   "parent account's Id; the new account's AccountType must match the parent's.";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   name: z.string().min(1),
   type: z.string().min(1),
   sub_type: z.string().optional(),

--- a/src/tools/create-attachable.tool.ts
+++ b/src/tools/create-attachable.tool.ts
@@ -6,7 +6,7 @@ const toolName = "create_attachable";
 const toolDescription =
   "Create an attachable (file attachment) in QuickBooks Online. File content can come from file_path (a file on the machine running this server — preferred for local files of any size), file_url (an https URL the server downloads), or base64_content (inline bytes — only practical for small files). Precedence: file_url/file_path (mutually exclusive) win over base64_content. With no file source, creates a metadata-only attachment record. Max file size 100 MB (QBO limit).";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   file_name: z.string().min(1).describe("File name including extension (e.g., 'receipt.pdf')."),
   note: z.string().optional().describe("Optional note describing the attachment."),
   category: z.string().optional().describe("Optional QBO attachment category."),
@@ -35,7 +35,7 @@ const toolSchema = z.object({
       "Base64-encoded file bytes, uploaded as multipart/form-data. Only practical for small files (a few KB) — prefer file_path or file_url for real documents. Ignored when file_path or file_url is provided. Maximum 100 MB decoded. Omit all three sources to create a metadata-only attachment record."
     ),
   attachable_ref: z
-    .object({
+    .strictObject({
       entity_ref_type: z.string().describe("Entity type (e.g., 'Invoice', 'Bill', 'Purchase')."),
       entity_ref_value: z.string().describe("Entity ID to attach to."),
       include_on_send: z

--- a/src/tools/create-class.tool.ts
+++ b/src/tools/create-class.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "create_class";
 const toolDescription = "Create a new class in QuickBooks Online for categorizing transactions.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   name: z.string().min(1).describe("Class name"),
   parent_ref: z.string().optional().describe("Parent class ID for sub-classes"),
 });

--- a/src/tools/create-credit-memo.tool.ts
+++ b/src/tools/create-credit-memo.tool.ts
@@ -5,22 +5,31 @@ import { z } from "zod";
 const toolName = "create_credit_memo";
 const toolDescription = "Create a credit memo (customer credit) in QuickBooks Online.";
 
-const lineItemSchema = z.object({
-  item_ref: z.string().min(1).describe("Item ID"),
-  qty: z.number().positive().describe("Quantity"),
-  unit_price: z.number().nonnegative().describe("Unit price"),
-  description: z.string().optional().describe("Line description"),
-  tax_code_ref: z.string().min(1).optional().describe("Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"),
-});
+const lineItemSchema = z.strictObject({
+    item_ref: z.string().min(1).describe("Item ID"),
+    qty: z.number().positive().describe("Quantity"),
+    unit_price: z.number().nonnegative().describe("Unit price"),
+    description: z.string().optional().describe("Line description"),
+    tax_code_ref: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"
+      ),
+  });
 
-const toolSchema = z.object({
-  customer_ref: z.string().min(1).describe("Customer ID"),
-  line_items: z.array(lineItemSchema).min(1).describe("Line items"),
-  txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
-  doc_number: z.string().optional().describe("Document number"),
-  private_note: z.string().optional().describe("Private note"),
-  global_tax_calculation: z.enum(["TaxExcluded", "TaxInclusive", "NotApplicable"]).optional().describe("Non-US companies only: whether unit prices exclude or include tax"),
-});
+const toolSchema = z.strictObject({
+    customer_ref: z.string().min(1).describe("Customer ID"),
+    line_items: z.array(lineItemSchema).min(1).describe("Line items"),
+    txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
+    doc_number: z.string().optional().describe("Document number"),
+    private_note: z.string().optional().describe("Private note"),
+    global_tax_calculation: z
+      .enum(["TaxExcluded", "TaxInclusive", "NotApplicable"])
+      .optional()
+      .describe("Non-US companies only: whether unit prices exclude or include tax"),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksCreditMemo(params);

--- a/src/tools/create-department.tool.ts
+++ b/src/tools/create-department.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "create_department";
 const toolDescription = "Create a new department in QuickBooks Online for location/department tracking.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   name: z.string().min(1).describe("Department name"),
   parent_ref: z.string().optional().describe("Parent department ID for sub-departments"),
 });

--- a/src/tools/create-deposit.tool.ts
+++ b/src/tools/create-deposit.tool.ts
@@ -5,18 +5,18 @@ import { z } from "zod";
 const toolName = "create_deposit";
 const toolDescription = "Create a bank deposit in QuickBooks Online.";
 
-const lineItemSchema = z.object({
-  amount: z.number().positive(),
-  account_ref: z.string().optional(),
-  description: z.string().optional(),
-});
+const lineItemSchema = z.strictObject({
+    amount: z.number().positive(),
+    account_ref: z.string().optional(),
+    description: z.string().optional(),
+  });
 
-const toolSchema = z.object({
-  deposit_to_account_ref: z.string().min(1).describe("Bank account ID to deposit to"),
-  line_items: z.array(lineItemSchema).min(1).describe("Deposit line items"),
-  txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
-  private_note: z.string().optional().describe("Private note"),
-});
+const toolSchema = z.strictObject({
+    deposit_to_account_ref: z.string().min(1).describe("Bank account ID to deposit to"),
+    line_items: z.array(lineItemSchema).min(1).describe("Deposit line items"),
+    txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
+    private_note: z.string().optional().describe("Private note"),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksDeposit(params);

--- a/src/tools/create-invoice.tool.ts
+++ b/src/tools/create-invoice.tool.ts
@@ -5,56 +5,58 @@ import { z } from "zod";
 const toolName = "create_invoice";
 const toolDescription = "Create an invoice in QuickBooks Online.";
 
-const lineItemSchema = z.object({
-  item_ref: z.string().min(1),
-  qty: z.number().positive(),
-  unit_price: z.number().nonnegative(),
-  description: z.string().optional(),
-  tax_code_ref: z
-    .string()
-    .min(1)
-    .optional()
-    .describe(
-      "Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"
-    ),
-  service_date: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("Date the service was performed (YYYY-MM-DD), shown per line on the invoice"),
-});
+// z.strictObject rejects unrecognized keys and emits additionalProperties:false in the
+// MCP JSON Schema (Zod 4 + SDK io:"input" omit that flag for plain z.object()).
+const lineItemSchema = z.strictObject({
+    item_ref: z.string().min(1),
+    qty: z.number().positive(),
+    unit_price: z.number().nonnegative(),
+    description: z.string().optional(),
+    tax_code_ref: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"
+      ),
+    service_date: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Date the service was performed (YYYY-MM-DD), shown per line on the invoice"),
+  });
 
-const linkedTxnSchema = z.object({
-  txn_id: z.string().min(1),
-  txn_type: z.string().min(1),
-});
+const linkedTxnSchema = z.strictObject({
+    txn_id: z.string().min(1),
+    txn_type: z.string().min(1),
+  });
 
-const toolSchema = z.object({
-  customer_ref: z.string().min(1),
-  line_items: z.array(lineItemSchema).min(1),
-  doc_number: z.string().optional(),
-  txn_date: z.string().optional(),
-  linked_txn: z.array(linkedTxnSchema).optional(),
-  global_tax_calculation: z
-    .enum(["TaxExcluded", "TaxInclusive", "NotApplicable"])
-    .optional()
-    .describe("Non-US companies only: whether unit prices exclude or include tax"),
-  customer_memo: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("Customer-facing message printed on the invoice (QBO CustomerMemo)"),
-  sales_term_ref: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("Sales term Id (use search_terms), e.g. Net 30. Falls back to the customer default if omitted"),
-  bill_email: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("Billing email address (QBO BillEmail). Falls back to the customer default if omitted"),
-});
+const toolSchema = z.strictObject({
+    customer_ref: z.string().min(1),
+    line_items: z.array(lineItemSchema).min(1),
+    doc_number: z.string().optional(),
+    txn_date: z.string().optional(),
+    linked_txn: z.array(linkedTxnSchema).optional(),
+    global_tax_calculation: z
+      .enum(["TaxExcluded", "TaxInclusive", "NotApplicable"])
+      .optional()
+      .describe("Non-US companies only: whether unit prices exclude or include tax"),
+    customer_memo: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Customer-facing message printed on the invoice (QBO CustomerMemo)"),
+    sales_term_ref: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Sales term Id (use search_terms), e.g. Net 30. Falls back to the customer default if omitted"),
+    bill_email: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Billing email address (QBO BillEmail). Falls back to the customer default if omitted"),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksInvoice(params);

--- a/src/tools/create-item.tool.ts
+++ b/src/tools/create-item.tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const toolName = "create_item";
 const toolDescription = "Create an item in QuickBooks Online.";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   name: z.string().min(1),
   type: z.string().min(1),
   income_account_ref: z.string().min(1),

--- a/src/tools/create-payment-method.tool.ts
+++ b/src/tools/create-payment-method.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "create_payment_method";
 const toolDescription = "Create a new payment method in QuickBooks Online (e.g., Cash, Check, Credit Card).";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   name: z.string().min(1).describe("Payment method name"),
   type: z.enum(["CREDIT_CARD", "NON_CREDIT_CARD"]).optional().describe("Payment method type"),
 });

--- a/src/tools/create-payment.tool.ts
+++ b/src/tools/create-payment.tool.ts
@@ -5,28 +5,44 @@ import { z } from "zod";
 const toolName = "create_payment";
 const toolDescription = "Create a payment (receive money from customer) in QuickBooks Online.";
 
-const linkedTxnSchema = z.object({
-  txn_id: z.string().describe("Transaction ID to apply payment to"),
-  txn_type: z.string().describe("Transaction type (e.g., Invoice)"),
-});
+const linkedTxnSchema = z.strictObject({
+    txn_id: z.string().describe("Transaction ID to apply payment to"),
+    txn_type: z.string().describe("Transaction type (e.g., Invoice)"),
+  });
 
-const lineSchema = z.object({
-  amount: z.number().describe("Amount to apply to this transaction"),
-  linked_txn: z.array(linkedTxnSchema).describe("Linked transactions"),
-});
+const lineSchema = z.strictObject({
+    amount: z.number().describe("Amount to apply to this transaction"),
+    linked_txn: z.array(linkedTxnSchema).describe("Linked transactions"),
+  });
 
-const toolSchema = z.object({
-  customer_ref: z.string().min(1).describe("Customer ID"),
-  total_amt: z.number().positive().describe("Total payment amount"),
-  payment_method_ref: z.string().optional().describe("Payment method ID"),
-  deposit_to_account_ref: z.string().optional().describe("Account to deposit to"),
-  txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
-  private_note: z.string().optional().describe("Private note"),
-  payment_ref_num: z.string().optional().describe("Reference no. for the payment, e.g. a bank transfer/transaction number (PaymentRefNum)"),
-  currency_ref: z.string().optional().describe("Reference to the currency (e.g. USD, GBP) in which all amounts on the payment are expressed. Required if multicurrency is enabled for the company (CurrencyRef)"),
-  exchange_rate: z.number().positive().optional().describe("The number of home-currency units it takes to equal one unit of the currency specified by currency_ref. Applicable if multicurrency is enabled for the company (ExchangeRate)"),
-  line: z.array(lineSchema).optional().describe("Line items linking to invoices"),
-});
+const toolSchema = z.strictObject({
+    customer_ref: z.string().min(1).describe("Customer ID"),
+    total_amt: z.number().positive().describe("Total payment amount"),
+    payment_method_ref: z.string().optional().describe("Payment method ID"),
+    deposit_to_account_ref: z.string().optional().describe("Account to deposit to"),
+    txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
+    private_note: z.string().optional().describe("Private note"),
+    payment_ref_num: z
+      .string()
+      .optional()
+      .describe(
+        "Reference no. for the payment, e.g. a bank transfer/transaction number (PaymentRefNum)"
+      ),
+    currency_ref: z
+      .string()
+      .optional()
+      .describe(
+        "Reference to the currency (e.g. USD, GBP) in which all amounts on the payment are expressed. Required if multicurrency is enabled for the company (CurrencyRef)"
+      ),
+    exchange_rate: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "The number of home-currency units it takes to equal one unit of the currency specified by currency_ref. Applicable if multicurrency is enabled for the company (ExchangeRate)"
+      ),
+    line: z.array(lineSchema).optional().describe("Line items linking to invoices"),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksPayment(params);

--- a/src/tools/create-purchase-order.tool.ts
+++ b/src/tools/create-purchase-order.tool.ts
@@ -5,20 +5,20 @@ import { z } from "zod";
 const toolName = "create_purchase_order";
 const toolDescription = "Create a purchase order in QuickBooks Online.";
 
-const lineItemSchema = z.object({
-  item_ref: z.string().min(1),
-  qty: z.number().positive(),
-  unit_price: z.number().nonnegative(),
-  description: z.string().optional(),
-});
+const lineItemSchema = z.strictObject({
+    item_ref: z.string().min(1),
+    qty: z.number().positive(),
+    unit_price: z.number().nonnegative(),
+    description: z.string().optional(),
+  });
 
-const toolSchema = z.object({
-  vendor_ref: z.string().min(1).describe("Vendor ID"),
-  line_items: z.array(lineItemSchema).min(1).describe("Line items"),
-  txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
-  doc_number: z.string().optional().describe("Document number"),
-  private_note: z.string().optional().describe("Private note"),
-});
+const toolSchema = z.strictObject({
+    vendor_ref: z.string().min(1).describe("Vendor ID"),
+    line_items: z.array(lineItemSchema).min(1).describe("Line items"),
+    txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
+    doc_number: z.string().optional().describe("Document number"),
+    private_note: z.string().optional().describe("Private note"),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksPurchaseOrder(params);

--- a/src/tools/create-refund-receipt.tool.ts
+++ b/src/tools/create-refund-receipt.tool.ts
@@ -5,24 +5,33 @@ import { z } from "zod";
 const toolName = "create_refund_receipt";
 const toolDescription = "Create a refund receipt (customer refund) in QuickBooks Online.";
 
-const lineItemSchema = z.object({
-  item_ref: z.string().min(1).describe("Item ID"),
-  qty: z.number().positive().describe("Quantity"),
-  unit_price: z.number().nonnegative().describe("Unit price"),
-  description: z.string().optional().describe("Line description"),
-  tax_code_ref: z.string().min(1).optional().describe("Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"),
-});
+const lineItemSchema = z.strictObject({
+    item_ref: z.string().min(1).describe("Item ID"),
+    qty: z.number().positive().describe("Quantity"),
+    unit_price: z.number().nonnegative().describe("Unit price"),
+    description: z.string().optional().describe("Line description"),
+    tax_code_ref: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"
+      ),
+  });
 
-const toolSchema = z.object({
-  customer_ref: z.string().min(1).describe("Customer ID"),
-  line_items: z.array(lineItemSchema).min(1).describe("Line items"),
-  payment_method_ref: z.string().optional().describe("Payment method ID"),
-  deposit_to_account_ref: z.string().optional().describe("Account to debit from"),
-  txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
-  doc_number: z.string().optional().describe("Document number"),
-  private_note: z.string().optional().describe("Private note"),
-  global_tax_calculation: z.enum(["TaxExcluded", "TaxInclusive", "NotApplicable"]).optional().describe("Non-US companies only: whether unit prices exclude or include tax"),
-});
+const toolSchema = z.strictObject({
+    customer_ref: z.string().min(1).describe("Customer ID"),
+    line_items: z.array(lineItemSchema).min(1).describe("Line items"),
+    payment_method_ref: z.string().optional().describe("Payment method ID"),
+    deposit_to_account_ref: z.string().optional().describe("Account to debit from"),
+    txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
+    doc_number: z.string().optional().describe("Document number"),
+    private_note: z.string().optional().describe("Private note"),
+    global_tax_calculation: z
+      .enum(["TaxExcluded", "TaxInclusive", "NotApplicable"])
+      .optional()
+      .describe("Non-US companies only: whether unit prices exclude or include tax"),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksRefundReceipt(params);

--- a/src/tools/create-sales-receipt.tool.ts
+++ b/src/tools/create-sales-receipt.tool.ts
@@ -5,24 +5,33 @@ import { z } from "zod";
 const toolName = "create_sales_receipt";
 const toolDescription = "Create a sales receipt (immediate payment sale) in QuickBooks Online.";
 
-const lineItemSchema = z.object({
-  item_ref: z.string().min(1).describe("Item ID"),
-  qty: z.number().positive().describe("Quantity"),
-  unit_price: z.number().nonnegative().describe("Unit price"),
-  description: z.string().optional().describe("Line description"),
-  tax_code_ref: z.string().min(1).optional().describe("Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"),
-});
+const lineItemSchema = z.strictObject({
+    item_ref: z.string().min(1).describe("Item ID"),
+    qty: z.number().positive().describe("Quantity"),
+    unit_price: z.number().nonnegative().describe("Unit price"),
+    description: z.string().optional().describe("Line description"),
+    tax_code_ref: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Tax code for this line: a TaxCode Id for non-US companies (use search_tax_codes), or 'TAX'/'NON' for US companies"
+      ),
+  });
 
-const toolSchema = z.object({
-  customer_ref: z.string().min(1).describe("Customer ID"),
-  line_items: z.array(lineItemSchema).min(1).describe("Line items"),
-  payment_method_ref: z.string().optional().describe("Payment method ID"),
-  deposit_to_account_ref: z.string().optional().describe("Account to deposit to"),
-  txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
-  doc_number: z.string().optional().describe("Document number"),
-  private_note: z.string().optional().describe("Private note"),
-  global_tax_calculation: z.enum(["TaxExcluded", "TaxInclusive", "NotApplicable"]).optional().describe("Non-US companies only: whether unit prices exclude or include tax"),
-});
+const toolSchema = z.strictObject({
+    customer_ref: z.string().min(1).describe("Customer ID"),
+    line_items: z.array(lineItemSchema).min(1).describe("Line items"),
+    payment_method_ref: z.string().optional().describe("Payment method ID"),
+    deposit_to_account_ref: z.string().optional().describe("Account to deposit to"),
+    txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
+    doc_number: z.string().optional().describe("Document number"),
+    private_note: z.string().optional().describe("Private note"),
+    global_tax_calculation: z
+      .enum(["TaxExcluded", "TaxInclusive", "NotApplicable"])
+      .optional()
+      .describe("Non-US companies only: whether unit prices exclude or include tax"),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksSalesReceipt(params);

--- a/src/tools/create-term.tool.ts
+++ b/src/tools/create-term.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "create_term";
 const toolDescription = "Create a new payment term in QuickBooks Online (e.g., Net 30, Due on Receipt).";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   name: z.string().min(1).describe("Term name (e.g., 'Net 30')"),
   due_days: z.number().optional().describe("Number of days until payment is due"),
   discount_days: z.number().optional().describe("Days to qualify for early payment discount"),

--- a/src/tools/create-time-activity.tool.ts
+++ b/src/tools/create-time-activity.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "create_time_activity";
 const toolDescription = "Create a time activity (time tracking entry) in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   name_of: z.enum(["Vendor", "Employee"]).describe("Whether time is for vendor or employee"),
   vendor_ref: z.string().optional().describe("Vendor ID (if name_of is Vendor)"),
   employee_ref: z.string().optional().describe("Employee ID (if name_of is Employee)"),

--- a/src/tools/create-transfer.tool.ts
+++ b/src/tools/create-transfer.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "create_transfer";
 const toolDescription = "Create a bank transfer between accounts in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   from_account_ref: z.string().min(1).describe("Source bank account ID"),
   to_account_ref: z.string().min(1).describe("Destination bank account ID"),
   amount: z.number().positive().describe("Transfer amount"),

--- a/src/tools/create-vendor-credit.tool.ts
+++ b/src/tools/create-vendor-credit.tool.ts
@@ -9,8 +9,7 @@ const toolDescription =
 // Shared with update-vendor-credit.tool.ts so the two tools can never drift
 // in what line shapes they accept. Amount allows 0 so existing credits with
 // legitimate 0.00 lines can round-trip through update's full-line replacement.
-export const vendorCreditLineItemSchema = z
-  .object({
+export const vendorCreditLineItemSchema = z.strictObject({
     amount: z.number().nonnegative(),
     description: z.string().optional(),
     account_ref: z.string().optional().describe("Expense account ID"),
@@ -42,14 +41,14 @@ export const globalTaxCalculationSchema = z
 
 const lineItemSchema = vendorCreditLineItemSchema;
 
-const toolSchema = z.object({
-  vendor_ref: z.string().min(1).describe("Vendor ID"),
-  line_items: z.array(lineItemSchema).min(1).describe("Line items"),
-  txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
-  doc_number: z.string().optional().describe("Document number"),
-  private_note: z.string().optional().describe("Private note"),
-  global_tax_calculation: globalTaxCalculationSchema.optional(),
-});
+const toolSchema = z.strictObject({
+    vendor_ref: z.string().min(1).describe("Vendor ID"),
+    line_items: z.array(lineItemSchema).min(1).describe("Line items"),
+    txn_date: z.string().optional().describe("Transaction date (YYYY-MM-DD)"),
+    doc_number: z.string().optional().describe("Document number"),
+    private_note: z.string().optional().describe("Private note"),
+    global_tax_calculation: globalTaxCalculationSchema.optional(),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await createQuickbooksVendorCredit(params);

--- a/src/tools/create-vendor.tool.ts
+++ b/src/tools/create-vendor.tool.ts
@@ -4,19 +4,19 @@ import { z } from "zod";
 
 const toolName = "create-vendor";
 const toolDescription = "Create a vendor in QuickBooks Online.";
-const toolSchema = z.object({
-  vendor: z.object({
+const toolSchema = z.strictObject({
+  vendor: z.strictObject({
     DisplayName: z.string(),
     GivenName: z.string().optional(),
     FamilyName: z.string().optional(),
     CompanyName: z.string().optional(),
-    PrimaryEmailAddr: z.object({
+    PrimaryEmailAddr: z.strictObject({
       Address: z.string().optional(),
     }).optional(),
-    PrimaryPhone: z.object({
+    PrimaryPhone: z.strictObject({
       FreeFormNumber: z.string().optional(),
     }).optional(),
-    BillAddr: z.object({
+    BillAddr: z.strictObject({
       Line1: z.string().optional(),
       City: z.string().optional(),
       Country: z.string().optional(),

--- a/src/tools/search-accounts.tool.ts
+++ b/src/tools/search-accounts.tool.ts
@@ -105,8 +105,8 @@ const advancedCriteriaSchema = z.object({
 
 // Runtime schema keeps full validation
 const RUNTIME_CRITERIA_SCHEMA = z.union([
-  z.record(z.any()),
-  z.array(z.record(z.any())),
+  z.record(z.string(), z.any()),
+  z.array(z.record(z.string(), z.any())),
   advancedCriteriaSchema,
 ]);
 

--- a/src/tools/search-invoices.tool.ts
+++ b/src/tools/search-invoices.tool.ts
@@ -91,8 +91,8 @@ const advancedCriteriaSchema = z.object({
 
 // Runtime schema used internally for validation
 const RUNTIME_CRITERIA_SCHEMA = z.union([
-  z.record(z.any()),
-  z.array(z.record(z.any())),
+  z.record(z.string(), z.any()),
+  z.array(z.record(z.string(), z.any())),
   advancedCriteriaSchema,
 ]);
 

--- a/src/tools/search-items.tool.ts
+++ b/src/tools/search-items.tool.ts
@@ -81,8 +81,8 @@ const advancedCriteriaSchema = z.object({
 
 // Runtime schema used internally for validation
 const RUNTIME_CRITERIA_SCHEMA = z.union([
-  z.record(z.any()),
-  z.array(z.record(z.any())),
+  z.record(z.string(), z.any()),
+  z.array(z.record(z.string(), z.any())),
   advancedCriteriaSchema,
 ]);
 

--- a/src/tools/update-account.tool.ts
+++ b/src/tools/update-account.tool.ts
@@ -7,7 +7,7 @@ const toolDescription = "Update an existing chart‑of‑accounts entry in Quick
 
 const toolSchema = z.object({
   account_id: z.string().min(1),
-  patch: z.record(z.any()),
+  patch: z.record(z.string(), z.any()),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/src/tools/update-attachable.tool.ts
+++ b/src/tools/update-attachable.tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const toolName = "update_attachable";
 const toolDescription =
   "Update an existing attachable's metadata (file name, note, category, content type) in QuickBooks Online. This is metadata-only: it CANNOT replace the uploaded file bytes. To attach a different or corrected file, create a new attachable (create_attachable with file_path) and delete the old one.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Attachable ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   file_name: z.string().optional().describe("Updated file name"),

--- a/src/tools/update-class.tool.ts
+++ b/src/tools/update-class.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "update_class";
 const toolDescription = "Update an existing class in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Class ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   name: z.string().optional().describe("Updated class name"),

--- a/src/tools/update-company-info.tool.ts
+++ b/src/tools/update-company-info.tool.ts
@@ -4,12 +4,12 @@ import { z } from "zod";
 
 const toolName = "update_company_info";
 const toolDescription = "Update the company information in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Company ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   company_name: z.string().optional().describe("Company name"),
   legal_name: z.string().optional().describe("Legal business name"),
-  company_addr: z.object({
+  company_addr: z.strictObject({
     line1: z.string().optional().describe("Address line 1"),
     city: z.string().optional().describe("City"),
     country_sub_division_code: z.string().optional().describe("State/Province code"),

--- a/src/tools/update-credit-memo.tool.ts
+++ b/src/tools/update-credit-memo.tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const toolName = "update_credit_memo";
 const toolDescription = "Update an existing credit memo in QuickBooks Online.";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Credit Memo ID"),
   sync_token: z.string().min(1).describe("Sync token for optimistic locking"),
   customer_ref: z.string().optional().describe("Customer ID"),

--- a/src/tools/update-department.tool.ts
+++ b/src/tools/update-department.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "update_department";
 const toolDescription = "Update an existing department in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Department ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   name: z.string().optional().describe("Updated department name"),

--- a/src/tools/update-deposit.tool.ts
+++ b/src/tools/update-deposit.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "update_deposit";
 const toolDescription = "Update a deposit in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Deposit ID"),
   sync_token: z.string().min(1).describe("Sync token"),
   private_note: z.string().optional().describe("Private note"),

--- a/src/tools/update-invoice.tool.ts
+++ b/src/tools/update-invoice.tool.ts
@@ -7,7 +7,7 @@ const toolDescription = "Update an existing invoice in Quickbooks by ID (sparse 
 
 const toolSchema = z.object({
   invoice_id: z.string().min(1),
-  patch: z.record(z.any()),
+  patch: z.record(z.string(), z.any()),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/src/tools/update-item.tool.ts
+++ b/src/tools/update-item.tool.ts
@@ -7,7 +7,7 @@ const toolDescription = "Update an existing item in Quickbooks by ID (sparse upd
 
 const toolSchema = z.object({
   item_id: z.string().min(1),
-  patch: z.record(z.any()),
+  patch: z.record(z.string(), z.any()),
 });
 
 const toolHandler = async ({ params }: any) => {

--- a/src/tools/update-payment-method.tool.ts
+++ b/src/tools/update-payment-method.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "update_payment_method";
 const toolDescription = "Update an existing payment method in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Payment method ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   name: z.string().optional().describe("Updated payment method name"),

--- a/src/tools/update-payment.tool.ts
+++ b/src/tools/update-payment.tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const toolName = "update_payment";
 const toolDescription = "Update an existing payment in QuickBooks Online.";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Payment ID"),
   sync_token: z.string().min(1).describe("Sync token for optimistic locking"),
   customer_ref: z.string().optional().describe("Customer ID"),

--- a/src/tools/update-purchase-order.tool.ts
+++ b/src/tools/update-purchase-order.tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const toolName = "update_purchase_order";
 const toolDescription = "Update an existing purchase order in QuickBooks Online.";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Purchase Order ID"),
   sync_token: z.string().min(1).describe("Sync token"),
   vendor_ref: z.string().optional().describe("Vendor ID"),

--- a/src/tools/update-refund-receipt.tool.ts
+++ b/src/tools/update-refund-receipt.tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const toolName = "update_refund_receipt";
 const toolDescription = "Update an existing refund receipt in QuickBooks Online.";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Refund Receipt ID"),
   sync_token: z.string().min(1).describe("Sync token for optimistic locking"),
   customer_ref: z.string().optional().describe("Customer ID"),

--- a/src/tools/update-sales-receipt.tool.ts
+++ b/src/tools/update-sales-receipt.tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const toolName = "update_sales_receipt";
 const toolDescription = "Update an existing sales receipt in QuickBooks Online.";
 
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Sales Receipt ID"),
   sync_token: z.string().min(1).describe("Sync token for optimistic locking"),
   customer_ref: z.string().optional().describe("Customer ID"),

--- a/src/tools/update-term.tool.ts
+++ b/src/tools/update-term.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "update_term";
 const toolDescription = "Update an existing payment term in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Term ID"),
   sync_token: z.string().min(1).describe("Sync token for concurrency"),
   name: z.string().optional().describe("Updated term name"),

--- a/src/tools/update-time-activity.tool.ts
+++ b/src/tools/update-time-activity.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "update_time_activity";
 const toolDescription = "Update a time activity in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Time Activity ID"),
   sync_token: z.string().min(1).describe("Sync token"),
   hours: z.number().optional().describe("Hours worked"),

--- a/src/tools/update-transfer.tool.ts
+++ b/src/tools/update-transfer.tool.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 const toolName = "update_transfer";
 const toolDescription = "Update a transfer in QuickBooks Online.";
-const toolSchema = z.object({
+const toolSchema = z.strictObject({
   id: z.string().min(1).describe("Transfer ID"),
   sync_token: z.string().min(1).describe("Sync token"),
   from_account_ref: z.string().optional().describe("Source account ID"),

--- a/src/tools/update-vendor-credit.tool.ts
+++ b/src/tools/update-vendor-credit.tool.ts
@@ -7,18 +7,18 @@ const toolName = "update_vendor_credit";
 const toolDescription =
   "Update a vendor credit in QuickBooks Online. Providing line_items REPLACES the entire line array (fetch the current vendor credit first if you only want to modify one line); lines support per-line tax_code_ref and class_ref like bills.";
 
-const toolSchema = z.object({
-  id: z.string().min(1).describe("Vendor Credit ID"),
-  sync_token: z.string().min(1).describe("Sync token (from the latest read of this vendor credit)"),
-  vendor_ref: z.string().optional().describe("Vendor ID"),
-  private_note: z.string().optional().describe("Private note"),
-  line_items: z
-    .array(vendorCreditLineItemSchema)
-    .min(1)
-    .optional()
-    .describe("Full replacement set of line items (replaces ALL existing lines)"),
-  global_tax_calculation: globalTaxCalculationSchema.optional(),
-});
+const toolSchema = z.strictObject({
+    id: z.string().min(1).describe("Vendor Credit ID"),
+    sync_token: z.string().min(1).describe("Sync token (from the latest read of this vendor credit)"),
+    vendor_ref: z.string().optional().describe("Vendor ID"),
+    private_note: z.string().optional().describe("Private note"),
+    line_items: z
+      .array(vendorCreditLineItemSchema)
+      .min(1)
+      .optional()
+      .describe("Full replacement set of line items (replaces ALL existing lines)"),
+    global_tax_calculation: globalTaxCalculationSchema.optional(),
+  });
 
 const toolHandler = async ({ params }: any) => {
   const response = await updateQuickbooksVendorCredit(params);

--- a/src/tools/update-vendor.tool.ts
+++ b/src/tools/update-vendor.tool.ts
@@ -4,21 +4,21 @@ import { z } from "zod";
 
 const toolName = "update-vendor";
 const toolDescription = "Update a vendor in QuickBooks Online.";
-const toolSchema = z.object({
-  vendor: z.object({
+const toolSchema = z.strictObject({
+  vendor: z.strictObject({
     Id: z.string(),
     SyncToken: z.string(),
     DisplayName: z.string(),
     GivenName: z.string().optional(),
     FamilyName: z.string().optional(),
     CompanyName: z.string().optional(),
-    PrimaryEmailAddr: z.object({
+    PrimaryEmailAddr: z.strictObject({
       Address: z.string().optional(),
     }).optional(),
-    PrimaryPhone: z.object({
+    PrimaryPhone: z.strictObject({
       FreeFormNumber: z.string().optional(),
     }).optional(),
-    BillAddr: z.object({
+    BillAddr: z.strictObject({
       Line1: z.string().optional(),
       City: z.string().optional(),
       Country: z.string().optional(),

--- a/src/types/tool-definition.ts
+++ b/src/types/tool-definition.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-export interface ToolDefinition<T extends z.ZodType<any, any>> {
+export interface ToolDefinition<T extends z.ZodType> {
   name: string;
   description: string;
   schema: T;

--- a/tests/unit/clients/quickbooks-client.injected-context.test.ts
+++ b/tests/unit/clients/quickbooks-client.injected-context.test.ts
@@ -1,0 +1,116 @@
+import { jest } from "@jest/globals";
+
+process.env.QUICKBOOKS_CLIENT_ID = "";
+process.env.QUICKBOOKS_CLIENT_SECRET = "";
+process.env.QUICKBOOKS_REFRESH_TOKEN = "";
+process.env.QUICKBOOKS_REALM_ID = "";
+process.env.QUICKBOOKS_ENVIRONMENT = "sandbox";
+process.env.QUICKBOOKS_REDIRECT_URI = "";
+
+jest.unstable_mockModule("node-quickbooks", () => ({
+  default: class MockQuickBooks {
+    constructor(..._args: unknown[]) {}
+  },
+}));
+
+jest.unstable_mockModule("intuit-oauth", () => ({
+  default: class MockOAuthClient {
+    static scopes: { Accounting: string } = {
+      Accounting: "com.intuit.quickbooks.accounting",
+    };
+    constructor(_cfg: Record<string, unknown>) {}
+  },
+}));
+
+jest.unstable_mockModule("open", () => ({
+  default: jest.fn(async () => undefined),
+}));
+jest.unstable_mockModule("fs", () => ({
+  default: {
+    readFileSync: jest.fn(),
+    existsSync: jest.fn(() => false),
+    writeFileSync: jest.fn(),
+    renameSync: jest.fn(),
+    unlinkSync: jest.fn(),
+  },
+}));
+
+const { QuickbooksClient, runWithQuickbooksContext } =
+  await import("../../../src/clients/quickbooks-client");
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+describe("runWithQuickbooksContext", () => {
+  it("keeps injected QuickBooks instances and credentials isolated across interleaved async work", async () => {
+    const firstCanContinue = createDeferred();
+    const secondStarted = createDeferred();
+    const firstQuickbooks = { marker: "first" };
+    const secondQuickbooks = { marker: "second" };
+
+    const firstRun = runWithQuickbooksContext(
+      {
+        quickbooks: firstQuickbooks as never,
+        accessToken: "first-access-token",
+        realmId: "first-realm",
+        isSandbox: true,
+      },
+      async () => {
+        expect(await QuickbooksClient.getInstance()).toBe(firstQuickbooks);
+        expect(await QuickbooksClient.getAuthCredentials()).toEqual({
+          accessToken: "first-access-token",
+          realmId: "first-realm",
+          isSandbox: true,
+        });
+
+        await secondStarted.promise;
+        await firstCanContinue.promise;
+
+        expect(await QuickbooksClient.getInstance()).toBe(firstQuickbooks);
+        expect(await QuickbooksClient.getAuthCredentials()).toEqual({
+          accessToken: "first-access-token",
+          realmId: "first-realm",
+          isSandbox: true,
+        });
+      },
+    );
+
+    const secondRun = runWithQuickbooksContext(
+      {
+        quickbooks: secondQuickbooks as never,
+        accessToken: "second-access-token",
+        realmId: "second-realm",
+        isSandbox: false,
+      },
+      async () => {
+        secondStarted.resolve();
+
+        expect(await QuickbooksClient.getInstance()).toBe(secondQuickbooks);
+        expect(await QuickbooksClient.getAuthCredentials()).toEqual({
+          accessToken: "second-access-token",
+          realmId: "second-realm",
+          isSandbox: false,
+        });
+
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(await QuickbooksClient.getInstance()).toBe(secondQuickbooks);
+        expect(await QuickbooksClient.getAuthCredentials()).toEqual({
+          accessToken: "second-access-token",
+          realmId: "second-realm",
+          isSandbox: false,
+        });
+
+        firstCanContinue.resolve();
+      },
+    );
+
+    await Promise.all([firstRun, secondRun]);
+  });
+});

--- a/tests/unit/clients/quickbooks-client.injected-context.test.ts
+++ b/tests/unit/clients/quickbooks-client.injected-context.test.ts
@@ -37,6 +37,8 @@ jest.unstable_mockModule("fs", () => ({
 
 const { QuickbooksClient, runWithQuickbooksContext } =
   await import("../../../src/clients/quickbooks-client");
+const { getQuickbooksVendor } =
+  await import("../../../src/handlers/get-quickbooks-vendor.handler");
 
 function createDeferred() {
   let resolve!: () => void;
@@ -113,4 +115,129 @@ describe("runWithQuickbooksContext", () => {
 
     await Promise.all([firstRun, secondRun]);
   });
+
+  it("keeps many concurrent injected contexts isolated across repeated awaits", async () => {
+    const contextCount = 50;
+    const iterationsPerContext = 6;
+    const readyCount = createCounter(contextCount);
+    const releaseAll = createDeferred();
+
+    const runs = Array.from({ length: contextCount }, async (_, index) => {
+      const quickbooks = { marker: `quickbooks-${index}` };
+      const isSandbox = index % 2 === 0;
+
+      return runWithQuickbooksContext(
+        {
+          quickbooks: quickbooks as never,
+          accessToken: `access-token-${index}`,
+          realmId: `realm-${index}`,
+          isSandbox,
+        },
+        async () => {
+          readyCount.increment();
+          await releaseAll.promise;
+
+          for (
+            let iteration = 0;
+            iteration < iterationsPerContext;
+            iteration += 1
+          ) {
+            expect(await QuickbooksClient.getInstance()).toBe(quickbooks);
+            expect(await QuickbooksClient.getAuthCredentials()).toEqual({
+              accessToken: `access-token-${index}`,
+              realmId: `realm-${index}`,
+              isSandbox,
+            });
+
+            await new Promise((resolve) => setImmediate(resolve));
+          }
+        },
+      );
+    });
+
+    await readyCount.promise;
+    releaseAll.resolve();
+    await Promise.all(runs);
+  });
+
+  it("keeps real handler calls isolated across concurrent injected contexts", async () => {
+    const firstCanCallback = createDeferred();
+    const secondCanCallback = createDeferred();
+    const firstQuickbooks = {
+      getVendor: jest.fn(
+        (_id: string, callback: (err: null, vendor: unknown) => void) => {
+          void firstCanCallback.promise.then(() => {
+            callback(null, { Id: "first-vendor", source: "first" });
+          });
+        },
+      ),
+    };
+    const secondQuickbooks = {
+      getVendor: jest.fn(
+        (_id: string, callback: (err: null, vendor: unknown) => void) => {
+          void secondCanCallback.promise.then(() => {
+            callback(null, { Id: "second-vendor", source: "second" });
+          });
+        },
+      ),
+    };
+
+    const firstRun = runWithQuickbooksContext(
+      {
+        quickbooks: firstQuickbooks as never,
+        accessToken: "first-access-token",
+        realmId: "first-realm",
+        isSandbox: true,
+      },
+      () => getQuickbooksVendor("first-vendor"),
+    );
+    const secondRun = runWithQuickbooksContext(
+      {
+        quickbooks: secondQuickbooks as never,
+        accessToken: "second-access-token",
+        realmId: "second-realm",
+        isSandbox: false,
+      },
+      () => getQuickbooksVendor("second-vendor"),
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    secondCanCallback.resolve();
+    firstCanCallback.resolve();
+
+    await expect(firstRun).resolves.toMatchObject({
+      isError: false,
+      result: { Id: "first-vendor", source: "first" },
+    });
+    await expect(secondRun).resolves.toMatchObject({
+      isError: false,
+      result: { Id: "second-vendor", source: "second" },
+    });
+    expect(firstQuickbooks.getVendor).toHaveBeenCalledWith(
+      "first-vendor",
+      expect.any(Function),
+    );
+    expect(secondQuickbooks.getVendor).toHaveBeenCalledWith(
+      "second-vendor",
+      expect.any(Function),
+    );
+  });
 });
+
+function createCounter(target: number) {
+  let count = 0;
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return {
+    promise,
+    increment: () => {
+      count += 1;
+      if (count === target) {
+        resolve();
+      }
+    },
+  };
+}

--- a/tests/unit/clients/quickbooks-client.injected-context.test.ts
+++ b/tests/unit/clients/quickbooks-client.injected-context.test.ts
@@ -50,6 +50,63 @@ function createDeferred() {
 }
 
 describe("runWithQuickbooksContext", () => {
+  it("returns synchronous callback values without losing injected context", () => {
+    const quickbooks = { marker: "sync" };
+
+    const result = runWithQuickbooksContext(
+      {
+        quickbooks: quickbooks as never,
+        accessToken: "sync-access-token",
+        realmId: "sync-realm",
+        isSandbox: true,
+      },
+      () => "sync-result",
+    );
+
+    expect(result).toBe("sync-result");
+  });
+
+  it("restores the outer injected context after a nested context exits", async () => {
+    const outerQuickbooks = { marker: "outer" };
+    const innerQuickbooks = { marker: "inner" };
+
+    await runWithQuickbooksContext(
+      {
+        quickbooks: outerQuickbooks as never,
+        accessToken: "outer-access-token",
+        realmId: "outer-realm",
+        isSandbox: true,
+      },
+      async () => {
+        expect(await QuickbooksClient.getInstance()).toBe(outerQuickbooks);
+
+        await runWithQuickbooksContext(
+          {
+            quickbooks: innerQuickbooks as never,
+            accessToken: "inner-access-token",
+            realmId: "inner-realm",
+            isSandbox: false,
+          },
+          async () => {
+            expect(await QuickbooksClient.getInstance()).toBe(innerQuickbooks);
+            expect(await QuickbooksClient.getAuthCredentials()).toEqual({
+              accessToken: "inner-access-token",
+              realmId: "inner-realm",
+              isSandbox: false,
+            });
+          },
+        );
+
+        expect(await QuickbooksClient.getInstance()).toBe(outerQuickbooks);
+        expect(await QuickbooksClient.getAuthCredentials()).toEqual({
+          accessToken: "outer-access-token",
+          realmId: "outer-realm",
+          isSandbox: true,
+        });
+      },
+    );
+  });
+
   it("keeps injected QuickBooks instances and credentials isolated across interleaved async work", async () => {
     const firstCanContinue = createDeferred();
     const secondStarted = createDeferred();
@@ -221,6 +278,32 @@ describe("runWithQuickbooksContext", () => {
       "second-vendor",
       expect.any(Function),
     );
+  });
+
+  it("formats handler errors from the injected QuickBooks instance", async () => {
+    const quickbooks = {
+      getVendor: jest.fn(
+        (_id: string, callback: (err: Error, vendor: null) => void) => {
+          callback(new Error("vendor lookup failed"), null);
+        },
+      ),
+    };
+
+    const result = await runWithQuickbooksContext(
+      {
+        quickbooks: quickbooks as never,
+        accessToken: "error-access-token",
+        realmId: "error-realm",
+        isSandbox: true,
+      },
+      () => getQuickbooksVendor("missing-vendor"),
+    );
+
+    expect(result).toEqual({
+      result: null,
+      isError: true,
+      error: "Error: vendor lookup failed",
+    });
   });
 });
 

--- a/tests/unit/tools/create-invoice.tool.test.ts
+++ b/tests/unit/tools/create-invoice.tool.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { mockQuickbooksClient, mockQuickbooksClientClass } from "../../mocks/quickbooks.mock.js";
+
+const mockCreateInvoice = jest.fn() as jest.MockedFunction<
+  (params: any) => Promise<{ isError: boolean; error?: string; result?: unknown }>
+>;
+
+jest.unstable_mockModule("../../../src/clients/quickbooks-client", () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+jest.unstable_mockModule("../../../src/handlers/create-quickbooks-invoice.handler.js", () => ({
+  createQuickbooksInvoice: mockCreateInvoice,
+}));
+
+const { CreateInvoiceTool } = await import("../../../src/tools/create-invoice.tool.js");
+const { toJsonSchemaCompat } = await import(
+  "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js"
+);
+const { objectFromShape } = await import("@modelcontextprotocol/sdk/server/zod-compat.js");
+
+const validParams = {
+  customer_ref: "1",
+  line_items: [{ item_ref: "2", qty: 1, unit_price: 10 }],
+};
+
+const handler = CreateInvoiceTool.handler as (args: any) => Promise<any>;
+
+describe("create_invoice schema", () => {
+  it("accepts a valid payload", () => {
+    const result = CreateInvoiceTool.schema.safeParse(validParams);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown top-level keys (e.g. due_date typo)", () => {
+    const result = CreateInvoiceTool.schema.safeParse({
+      ...validParams,
+      due_date: "2026-01-01",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("rejects unknown keys on line_items", () => {
+    const result = CreateInvoiceTool.schema.safeParse({
+      customer_ref: "1",
+      line_items: [{ item_ref: "2", qty: 1, unit_price: 10, typo_field: true }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("emits additionalProperties:false via the MCP JSON Schema path", () => {
+    // MCP registers tools as { params: schema } and converts with io:"input".
+    // Plain z.object() omits additionalProperties:false in that mode; z.strictObject restores it.
+    const jsonSchema = toJsonSchemaCompat(
+      objectFromShape({ params: CreateInvoiceTool.schema })
+    ) as {
+      properties?: {
+        params?: {
+          additionalProperties?: boolean;
+          properties?: {
+            line_items?: {
+              items?: { additionalProperties?: boolean };
+            };
+          };
+        };
+      };
+    };
+
+    expect(jsonSchema.properties?.params?.additionalProperties).toBe(false);
+    expect(
+      jsonSchema.properties?.params?.properties?.line_items?.items?.additionalProperties
+    ).toBe(false);
+  });
+});
+
+describe("create_invoice handler", () => {
+  beforeEach(() => {
+    mockCreateInvoice.mockReset();
+  });
+
+  it("returns the created invoice on success", async () => {
+    mockCreateInvoice.mockResolvedValue({ isError: false, result: { Id: "9" } });
+    const result = await handler({ params: validParams });
+    expect(result.content[0].text).toContain("Invoice created successfully");
+    expect(result.content[1].text).toContain('"Id": "9"');
+  });
+
+  it("returns an error message on failure", async () => {
+    mockCreateInvoice.mockResolvedValue({ isError: true, error: "boom" });
+    const result = await handler({ params: validParams });
+    expect(result.content[0].text).toContain("Error creating invoice: boom");
+  });
+});

--- a/tests/unit/tools/strict-object-schemas.tool.test.ts
+++ b/tests/unit/tools/strict-object-schemas.tool.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { mockQuickbooksClient, mockQuickbooksClientClass } from "../../mocks/quickbooks.mock.js";
+
+const mockCreateVendor = jest.fn() as jest.MockedFunction<
+  (vendor: any) => Promise<{ isError: boolean; error?: string; result?: unknown }>
+>;
+const mockUpdatePayment = jest.fn() as jest.MockedFunction<
+  (params: any) => Promise<{ isError: boolean; error?: string; result?: unknown }>
+>;
+
+jest.unstable_mockModule("../../../src/clients/quickbooks-client", () => ({
+  quickbooksClient: mockQuickbooksClient,
+  QuickbooksClient: mockQuickbooksClientClass,
+}));
+
+jest.unstable_mockModule("../../../src/handlers/create-quickbooks-vendor.handler.js", () => ({
+  createQuickbooksVendor: mockCreateVendor,
+}));
+
+jest.unstable_mockModule("../../../src/handlers/update-quickbooks-payment.handler.js", () => ({
+  updateQuickbooksPayment: mockUpdatePayment,
+}));
+
+const { CreateVendorTool } = await import("../../../src/tools/create-vendor.tool.js");
+const { UpdatePaymentTool } = await import("../../../src/tools/update-payment.tool.js");
+const { toJsonSchemaCompat } = await import(
+  "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js"
+);
+const { objectFromShape } = await import("@modelcontextprotocol/sdk/server/zod-compat.js");
+
+describe("create_vendor schema", () => {
+  const validParams = {
+    vendor: {
+      DisplayName: "Acme Supplies",
+      BillAddr: { City: "Austin" },
+    },
+  };
+
+  it("accepts a valid payload", () => {
+    expect(CreateVendorTool.schema.safeParse(validParams).success).toBe(true);
+  });
+
+  it("rejects unknown top-level keys", () => {
+    const result = CreateVendorTool.schema.safeParse({
+      ...validParams,
+      due_date: "2026-01-01",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("rejects unknown nested keys on BillAddr", () => {
+    const result = CreateVendorTool.schema.safeParse({
+      vendor: {
+        DisplayName: "Acme Supplies",
+        BillAddr: { City: "Austin", street_typo: "123 Main" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("emits additionalProperties:false via the MCP JSON Schema path", () => {
+    const jsonSchema = toJsonSchemaCompat(
+      objectFromShape({ params: CreateVendorTool.schema })
+    ) as {
+      properties?: {
+        params?: {
+          additionalProperties?: boolean;
+          properties?: {
+            vendor?: {
+              additionalProperties?: boolean;
+              properties?: {
+                BillAddr?: { additionalProperties?: boolean };
+              };
+            };
+          };
+        };
+      };
+    };
+
+    expect(jsonSchema.properties?.params?.additionalProperties).toBe(false);
+    expect(jsonSchema.properties?.params?.properties?.vendor?.additionalProperties).toBe(false);
+    expect(
+      jsonSchema.properties?.params?.properties?.vendor?.properties?.BillAddr?.additionalProperties
+    ).toBe(false);
+  });
+});
+
+describe("create_vendor handler", () => {
+  const createHandler = CreateVendorTool.handler as (args: any) => Promise<any>;
+
+  beforeEach(() => {
+    mockCreateVendor.mockReset();
+  });
+
+  it("returns the created vendor on success", async () => {
+    mockCreateVendor.mockResolvedValue({ isError: false, result: { Id: "3", DisplayName: "Acme" } });
+    const result = await createHandler({
+      params: { vendor: { DisplayName: "Acme" } },
+    });
+    expect(result.content[0].text).toContain('"Id":"3"');
+  });
+
+  it("returns an error message on failure", async () => {
+    mockCreateVendor.mockResolvedValue({ isError: true, error: "duplicate name" });
+    const result = await createHandler({
+      params: { vendor: { DisplayName: "Acme" } },
+    });
+    expect(result.content[0].text).toContain("Error creating vendor: duplicate name");
+  });
+});
+
+describe("update_payment schema", () => {
+  const validParams = {
+    id: "1",
+    sync_token: "0",
+    private_note: "memo",
+  };
+
+  it("accepts a valid sparse update", () => {
+    expect(UpdatePaymentTool.schema.safeParse(validParams).success).toBe(true);
+  });
+
+  it("rejects unknown keys (e.g. due_date typo)", () => {
+    const result = UpdatePaymentTool.schema.safeParse({
+      ...validParams,
+      due_date: "2026-01-01",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+});
+
+describe("update_payment handler", () => {
+  const updateHandler = UpdatePaymentTool.handler as (args: any) => Promise<any>;
+
+  beforeEach(() => {
+    mockUpdatePayment.mockReset();
+  });
+
+  it("returns the updated payment on success", async () => {
+    mockUpdatePayment.mockResolvedValue({ isError: false, result: { Id: "1", SyncToken: "1" } });
+    const result = await updateHandler({
+      params: { id: "1", sync_token: "0" },
+    });
+    expect(result.content[0].text).toContain("Payment updated successfully");
+    expect(result.content[1].text).toContain('"SyncToken": "1"');
+  });
+
+  it("returns an error message on failure", async () => {
+    mockUpdatePayment.mockResolvedValue({ isError: true, error: "stale sync token" });
+    const result = await updateHandler({
+      params: { id: "1", sync_token: "0" },
+    });
+    expect(result.content[0].text).toContain("Error updating payment: stale sync token");
+  });
+});


### PR DESCRIPTION
## Summary
- Bring Intuit `upstream/main` into this fork: configurable token store path, resilient token refresh, OAuth CSRF state validation, `get_preferences`, and the `update_deposit` fix.
- Keep this fork’s Zod 4 peer dependency and isolated-auth `AsyncLocalStorage` context; combine both with upstream’s token-store and production re-auth behavior.
- Take upstream’s `node-quickbooks` overrides for `fast-xml-parser` and `underscore`, but omit `uuid@11.1.1` while this lockfile is still on `node-quickbooks@2.0.46` (that override breaks `request`’s `require('uuid/v4')`).

## Test plan
- [ ] `npm test` — 651 tests passed locally after the merge
- [ ] Confirm injected-auth context still works (`runWithQuickbooksContext` / getInstance)
- [ ] Confirm sandbox token refresh + OAuth CSRF state rejection still work
- [ ] Confirm `get_preferences` is registered and `update_deposit` still sends a full deposit object
- [ ] Confirm `node-quickbooks` still loads (`require('node-quickbooks')`) with the current lockfile