### PR TITLE
feat: report unsupported tool parameters instead of dropping them silently

### DIFF
--- a/src/helpers/register-tool.ts
+++ b/src/helpers/register-tool.ts
@@ -64,15 +64,100 @@ export function isToolDisabled(toolName: string): boolean {
  * Tools are categorized by their name prefix (e.g. create_, update_, delete_).
  * The corresponding environment variable (e.g. QUICKBOOKS_DISABLE_WRITE) determines if the tool is registered.
  */
+/**
+ * Unsupported-parameter reporting.
+ *
+ * Tool schemas are strict zod objects, so a parameter a tool does not declare is
+ * SILENTLY DISCARDED during validation: the call succeeds, the value never
+ * reaches QuickBooks, and the caller has no way to find out. In practice this
+ * surfaced as an invoice sent to a customer with a blank Ship Date — the caller
+ * passed `ship_date`, `create_invoice` did not declare it, and nothing said so.
+ *
+ * Hard-failing on unknown keys would turn a harmless stray parameter into a
+ * failed transaction, so instead the schema is registered permissively (unknown
+ * keys survive validation and can therefore be seen), the wrapper STRIPS them
+ * before the handler runs, and the response names them.
+ */
+
+/** Top-level keys a tool's params schema declares, or null if not an object schema. */
+export function knownParamKeys(schema: unknown): Set<string> | null {
+  const shape = (schema as any)?._def?.shape;
+  if (!shape) return null;
+  try {
+    return new Set(Object.keys(typeof shape === "function" ? shape() : shape));
+  } catch {
+    return null;
+  }
+}
+
+/** Keep unknown keys through validation so they can be reported rather than vanish. */
+export function permissiveParamsSchema<T>(schema: T): T {
+  const anySchema = schema as any;
+  return typeof anySchema?.passthrough === "function" ? anySchema.passthrough() : schema;
+}
+
+/** Human-readable notice naming parameters the tool does not support. */
+export function unsupportedParamsWarning(
+  toolName: string,
+  known: Set<string> | null,
+  params: unknown
+): string | null {
+  if (!known || !params || typeof params !== "object" || Array.isArray(params)) return null;
+  const extras = Object.keys(params as Record<string, unknown>).filter((k) => !known.has(k));
+  if (extras.length === 0) return null;
+  return (
+    `WARNING: ${toolName} does not support ${extras.length === 1 ? "this parameter" : "these parameters"}: ` +
+    `${extras.join(", ")}. ${extras.length === 1 ? "It was" : "They were"} IGNORED - the value did not reach ` +
+    `QuickBooks. Supported parameters: ${[...known].sort().join(", ")}.`
+  );
+}
+
 export function RegisterTool<T extends z.ZodType<any, any>>(
   server: McpServer,
   toolDefinition: ToolDefinition<T>
 ) {
   if (isToolDisabled(toolDefinition.name)) return;
-  server.tool(
-    toolDefinition.name,
-    toolDefinition.description,
-    { params: toolDefinition.schema },
-    toolDefinition.handler
-  );
+
+  const known = knownParamKeys(toolDefinition.schema);
+  const paramsSchema = permissiveParamsSchema(toolDefinition.schema);
+  const baseHandler = toolDefinition.handler as unknown as (...a: any[]) => Promise<any>;
+
+  const handler = (async (...a: any[]) => {
+    let callArgs = a;
+    let warning: string | null = null;
+    try {
+      const params = (a[0] as any)?.params;
+      warning = unsupportedParamsWarning(toolDefinition.name, known, params);
+      if (warning && known && params && typeof params === "object" && !Array.isArray(params)) {
+        // Strip unknown keys before the handler runs. The permissive schema
+        // exists only so they can be SEEN; it must not change what reaches
+        // QuickBooks. Several search tools destructure their params with a rest
+        // element and pass the rest on as query criteria (search-bills,
+        // search-customers, search-estimates, search-vendors), so an unknown key
+        // left in place would become a real SQL filter - quietly changing which
+        // records the search returns while this warning claimed it was ignored.
+        const cleaned: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(params as Record<string, unknown>)) {
+          if (known.has(k)) cleaned[k] = v;
+        }
+        callArgs = [{ ...(a[0] as any), params: cleaned }, ...a.slice(1)];
+      }
+    } catch {
+      /* diagnostics must never break a working call */
+    }
+
+    const result = await baseHandler(...callArgs);
+
+    try {
+      if (warning && result && Array.isArray(result.content)) {
+        // Prepended so it cannot be missed, and added even on error responses.
+        result.content.unshift({ type: "text" as const, text: warning });
+      }
+    } catch {
+      /* diagnostics must never break a working call */
+    }
+    return result;
+  }) as typeof toolDefinition.handler;
+
+  server.tool(toolDefinition.name, toolDefinition.description, { params: paramsSchema }, handler);
 }

--- a/tests/unit/helpers/register-tool.test.ts
+++ b/tests/unit/helpers/register-tool.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, afterEach, jest } from "@jest/globals";
 import {
   getCrudCategory,
   isToolDisabled,
+  knownParamKeys,
+  permissiveParamsSchema,
   RegisterTool,
+  unsupportedParamsWarning,
 } from "../../../src/helpers/register-tool";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -95,7 +98,14 @@ describe("RegisterTool", () => {
     const d = def("get_invoice");
     RegisterTool(server, d);
     expect(server.tool).toHaveBeenCalledTimes(1);
-    expect(server.tool).toHaveBeenCalledWith(d.name, d.description, { params: d.schema }, d.handler);
+    const [name, description, shape, handler] = (server.tool as jest.Mock).mock.calls[0] as any[];
+    expect(name).toBe(d.name);
+    expect(description).toBe(d.description);
+    expect(typeof handler).toBe("function");
+    // The registered schema is the definition's schema made permissive, so an
+    // unsupported parameter survives validation and can be reported instead of
+    // silently vanishing. It is therefore not the same object identity.
+    expect((shape.params as any).parse({ id: "1", unexpected_key: 1 }).unexpected_key).toBe(1);
   });
 
   // One test per mutable category to confirm the early-return path is reached.
@@ -136,5 +146,79 @@ describe("RegisterTool", () => {
     const server = { tool: jest.fn() } as unknown as McpServer;
     RegisterTool(server, def("create-bill"));
     expect(server.tool).not.toHaveBeenCalled();
+  });
+});
+
+
+// ── unsupported parameters ───────────────────────────────────────────────────
+// A tool schema is a strict zod object, so an undeclared parameter is dropped
+// during validation and the caller is never told. These cover both halves of
+// the fix: naming the parameter, and still not forwarding it to QuickBooks.
+describe("unsupported parameter reporting", () => {
+  const runRegistered = async (toolName: string, schema: any, params: any) => {
+    const seen: any[] = [];
+    const handler = jest.fn(async (args: any) => {
+      seen.push(args);
+      return { content: [{ type: "text", text: "ok" }] };
+    });
+    const server = { tool: jest.fn() } as unknown as McpServer;
+    RegisterTool(server, { name: toolName, description: "d", schema, handler } as any);
+    const registered = (server.tool as jest.Mock).mock.calls[0][3] as any;
+    const result = await registered({ params });
+    return { result, seenByHandler: seen[0]?.params };
+  };
+
+  it("names an unsupported parameter in the response", async () => {
+    const { result } = await runRegistered(
+      "create_invoice",
+      z.object({ customer_ref: z.string() }),
+      { customer_ref: "1", ship_date: "2026-09-01" }
+    );
+    expect(result.content[0].text).toContain("create_invoice does not support");
+    expect(result.content[0].text).toContain("ship_date");
+    expect(result.content[0].text).toContain("customer_ref"); // lists what IS supported
+    expect(result.content[1].text).toBe("ok"); // original response preserved
+  });
+
+  it("strips unknown keys so they cannot reach QuickBooks", async () => {
+    // search-bills/customers/estimates/vendors spread leftover params into query
+    // criteria; a key left in place would become a real SQL filter.
+    const { seenByHandler } = await runRegistered(
+      "search_bills",
+      z.object({ criteria: z.any().optional() }),
+      { criteria: [], DocNumber: "1042" }
+    );
+    expect(seenByHandler).toEqual({ criteria: [] });
+    expect(seenByHandler).not.toHaveProperty("DocNumber");
+  });
+
+  it("leaves a fully supported call untouched", async () => {
+    const { result, seenByHandler } = await runRegistered(
+      "read_invoice",
+      z.object({ invoice_id: z.string() }),
+      { invoice_id: "42" }
+    );
+    expect(seenByHandler).toEqual({ invoice_id: "42" });
+    expect(result.content[0].text).toBe("ok");
+  });
+
+  it("pluralises, and stays silent on input it cannot analyse", () => {
+    const known = knownParamKeys(z.object({ a: z.string() }));
+    expect(unsupportedParamsWarning("t", known, { b: 1, c: 2 })).toContain("these parameters");
+    expect(unsupportedParamsWarning("t", known, { a: "x" })).toBeNull();
+    expect(unsupportedParamsWarning("t", known, undefined)).toBeNull();
+    expect(unsupportedParamsWarning("t", null, { b: 1 })).toBeNull();
+  });
+
+  it("knownParamKeys returns null for schemas without an object shape", () => {
+    expect(knownParamKeys(z.string())).toBeNull();
+    expect(knownParamKeys(undefined)).toBeNull();
+  });
+
+  it("permissiveParamsSchema keeps unknown keys and passes non-object schemas through", () => {
+    const permissive: any = permissiveParamsSchema(z.object({ a: z.string() }));
+    expect(permissive.parse({ a: "x", extra: 1 }).extra).toBe(1);
+    const plain = z.string();
+    expect(permissiveParamsSchema(plain)).toBe(plain);
   });
 });


### PR DESCRIPTION
## Problem

Tool schemas are strict `zod` objects, so a parameter a tool does not declare is **silently discarded during validation**: the call succeeds, the value never reaches QuickBooks, and the caller has no way to find out.

This is not theoretical. It surfaced as an invoice that went to a customer with a **blank Ship Date** — the caller passed `ship_date`, `create_invoice` did not declare it, the key was dropped in validation, and the tool reported success. The field being missing was one bug; the fact that nobody was told is the more general one, and it applies to every tool and every undeclared field.

## Approach

Rejecting unknown keys outright would turn a harmless stray parameter into a failed transaction, which seems worse than the problem. So `RegisterTool` now:

1. registers the params schema **permissively**, so unknown keys survive validation and can be seen at all;
2. **strips** them before the handler runs, so what reaches QuickBooks is unchanged;
3. **prepends a warning** to the response naming them, and listing the parameters the tool does support.

```
WARNING: create_invoice does not support this parameter: ship_date. It was
IGNORED - the value did not reach QuickBooks. Supported parameters: ...
```

### Why the strip is load-bearing

Making schemas permissive without stripping would be worse than the original bug. `search-bills`, `search-customers`, `search-estimates` and `search-vendors` destructure their params with a rest element and pass the rest on as query criteria:

```ts
const { criteria = [], fields, summary, ...options } = args.params;
```

An unknown key left in place therefore becomes a real SQL `WHERE` filter, quietly changing which records a search returns — while the new warning claimed the key was ignored. Stripping preserves today's behaviour exactly and keeps the message truthful.

## Compatibility

Additive and non-breaking:

- a fully supported call behaves exactly as before — no warning, identical params, identical response;
- the warning is advisory; tools still succeed;
- what is sent to QuickBooks is unchanged in every case;
- schemas that are not object schemas (`z.record`, free-form patches) are passed through untouched and never produce a warning.

## Tests

Six cases in `tests/unit/helpers/register-tool.test.ts` covering: the warning naming an unsupported parameter and listing supported ones; unknown keys being stripped before the handler (the search-criteria regression); a fully supported call left untouched; pluralisation and non-analysable input; `knownParamKeys` on non-object schemas; and `permissiveParamsSchema` retaining unknown keys while passing non-object schemas through.

Full suite: 633 passing. The two failures on my machine are the pre-existing `save-tokens-to-env` / `invoice-pdf.tool` symlink tests, which need Windows developer-mode privileges and fail on a clean checkout of `main` too.
